### PR TITLE
[Memory] Schema & Metadata -- Foundation

### DIFF
--- a/agents/knowledge_graph.py
+++ b/agents/knowledge_graph.py
@@ -12,13 +12,17 @@ Required env vars (shared with memory.py):
 """
 
 import json
+import logging
 import os
 import re
 
 import requests
 from agent_tooling import tool
 from agents.secret_manager import get_credential
+from core.memory_schema import build_metadata, validate_source
 from neo4j import GraphDatabase
+
+logger = logging.getLogger(__name__)
 
 GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8420")
 HITL_TTL = 180
@@ -45,6 +49,7 @@ NEO4J_AUTH_ENV = get_credential("NEO4J_AUTH") or "neo4j/hivemind-memory"
 _NEO4J_USER, _, _NEO4J_PASS = NEO4J_AUTH_ENV.partition("/")
 
 _driver = None
+_kg_index_created = False
 
 _VALID_ENTITY_TYPES = {"Person", "Project", "System", "Concept", "Preference"}
 _VALID_RELATIONS = {"KNOWS_ABOUT", "WORKS_ON", "PREFERS", "RELATED_TO", "MANAGES"}
@@ -75,6 +80,29 @@ def _validate_relation(relation: str) -> str:
     return relation
 
 
+def _ensure_metadata_indexes(session) -> None:  # type: ignore[no-untyped-def]
+    """Create property indexes for metadata fields on entity nodes.
+
+    Uses a global guard to run only once per process, same pattern as
+    agents/memory.py _ensure_index.
+    """
+    global _kg_index_created
+    if _kg_index_created:
+        return
+
+    for label in _VALID_ENTITY_TYPES:
+        for field in ("tier", "data_class", "source"):
+            try:
+                session.run(  # type: ignore[union-attr]
+                    f"CREATE INDEX idx_{label.lower()}_{field} IF NOT EXISTS "
+                    f"FOR (n:{label}) ON (n.{field})"
+                )
+            except Exception:
+                logger.debug("Index idx_%s_%s may already exist", label.lower(), field)
+
+    _kg_index_created = True
+
+
 def graph_upsert_direct(
     entity_type: str,
     name: str,
@@ -83,14 +111,34 @@ def graph_upsert_direct(
     target_name: str = "",
     target_type: str = "",
     agent_id: str = "ada",
+    data_class: str | None = None,
+    as_of: str | None = None,
+    source: str = "user",
 ) -> str:
     """Write to the knowledge graph without HITL. Called by the epilogue after batch approval."""
     try:
+        # Validate data_class and source, build metadata
+        try:
+            validate_source(source)
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+
+        try:
+            meta = build_metadata(
+                data_class=data_class, source=source, as_of=as_of
+            )
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+
         label = _validate_label(entity_type)
         props = json.loads(properties) if properties.strip() != "{}" else {}
 
+        # Merge metadata into props for the SET clause
+        props.update(meta)
+
         driver = _get_driver()
         with driver.session() as session:
+            _ensure_metadata_indexes(session)
             result = session.run(
                 f"""
                 MERGE (n:{label} {{name: $name, agent_id: $agent_id}})
@@ -110,13 +158,21 @@ def graph_upsert_direct(
                 session.run(
                     f"""
                     MERGE (t:{tgt_label} {{name: $target_name, agent_id: $agent_id}})
+                    SET t += $meta_props
                     WITH t
                     MATCH (n:{label} {{name: $name, agent_id: $agent_id}})
-                    MERGE (n)-[:{rel_type}]->(t)
+                    MERGE (n)-[r:{rel_type}]->(t)
+                    SET r.as_of = $meta_as_of, r.source = $meta_source,
+                        r.data_class = $meta_data_class, r.tier = $meta_tier
                     """,
                     target_name=target_name,
                     agent_id=agent_id,
                     name=name,
+                    meta_props=meta,
+                    meta_as_of=meta.get("as_of"),
+                    meta_source=meta.get("source", source),
+                    meta_data_class=meta.get("data_class"),
+                    meta_tier=meta.get("tier"),
                 )
                 rel_created = True
 
@@ -127,6 +183,7 @@ def graph_upsert_direct(
             "name": name,
             "relation_created": rel_created,
             "relation": f"-[:{relation}]->({target_name})" if rel_created else None,
+            "data_class": meta.get("data_class"),
         })
     except Exception as e:
         return json.dumps({"error": str(e)})
@@ -141,6 +198,9 @@ def graph_upsert(
     target_name: str = "",
     target_type: str = "",
     agent_id: str = "ada",
+    data_class: str | None = None,
+    as_of: str | None = None,
+    source: str = "user",
 ) -> str:
     """Add or update a knowledge graph node, optionally linking it to another node.
 
@@ -152,6 +212,9 @@ def graph_upsert(
         target_name: Name of the target node to link to. Required if relation is set.
         target_type: Entity type of the target node (defaults to entity_type if omitted).
         agent_id: Which agent's graph this belongs to (default "ada").
+        data_class: Data class for this entry (e.g. "person", "preference", "technical-config").
+        as_of: ISO datetime for when the fact was established (defaults to now).
+        source: Origin of the entry — "user", "tool", "session", or "self".
 
     Returns:
         JSON confirmation with node id and relationship created (if any).
@@ -180,6 +243,9 @@ def graph_upsert(
             target_name=target_name,
             target_type=target_type,
             agent_id=agent_id,
+            data_class=data_class,
+            as_of=as_of,
+            source=source,
         )
     except Exception as e:
         return json.dumps({"error": str(e)})

--- a/agents/memory.py
+++ b/agents/memory.py
@@ -21,6 +21,7 @@ from typing import Optional
 import requests
 from agent_tooling import tool
 from agents.secret_manager import get_credential
+from core.memory_schema import build_metadata, validate_source
 from neo4j import GraphDatabase
 
 logger = logging.getLogger(__name__)
@@ -81,6 +82,15 @@ def _ensure_index(session):
         }}
         """
     )
+    # Create property indexes for metadata fields on Memory nodes
+    for field in ("tier", "data_class", "expires_at", "source"):
+        try:
+            session.run(
+                f"CREATE INDEX idx_memory_{field} IF NOT EXISTS "
+                f"FOR (m:Memory) ON (m.{field})"
+            )
+        except Exception:
+            logger.debug("Index idx_memory_%s may already exist", field)
     _index_created = True
 
 
@@ -99,9 +109,25 @@ def memory_store_direct(
     tags: str = "",
     source: str = "user",
     agent_id: str = "ada",
+    data_class: str | None = None,
+    as_of: str | None = None,
+    expires_at: str | None = None,
 ) -> str:
     """Write to vector memory without HITL. Called by the epilogue after batch approval."""
     try:
+        # Validate data_class and source, build metadata
+        try:
+            validate_source(source)
+        except ValueError as e:
+            return json.dumps({"stored": False, "error": str(e)})
+
+        try:
+            meta = build_metadata(
+                data_class=data_class, source=source, as_of=as_of, expires_at=expires_at
+            )
+        except ValueError as e:
+            return json.dumps({"stored": False, "error": str(e), "prompt": str(e)})
+
         embedding = _embed(content)
         driver = _get_driver()
         with driver.session() as session:
@@ -114,20 +140,35 @@ def memory_store_direct(
                     source: $source,
                     agent_id: $agent_id,
                     created_at: $created_at,
-                    embedding: $embedding
+                    embedding: $embedding,
+                    data_class: $data_class,
+                    tier: $tier,
+                    as_of: $as_of,
+                    expires_at: $expires_at,
+                    superseded: $superseded
                 })
                 RETURN elementId(m) AS id
                 """,
                 content=content,
                 tags=tags,
-                source=source,
+                source=meta.get("source", source),
                 agent_id=agent_id,
                 created_at=int(time.time()),
                 embedding=embedding,
+                data_class=meta.get("data_class"),
+                tier=meta.get("tier"),
+                as_of=meta.get("as_of"),
+                expires_at=meta.get("expires_at"),
+                superseded=meta.get("superseded", False),
             )
             record = result.single()
             memory_id = record["id"] if record else "unknown"
-        return json.dumps({"stored": True, "id": memory_id, "agent_id": agent_id})
+        return json.dumps({
+            "stored": True,
+            "id": memory_id,
+            "agent_id": agent_id,
+            "data_class": meta.get("data_class"),
+        })
     except Exception as e:
         logger.exception("memory_store_direct failed")
         return json.dumps({"error": str(e)})
@@ -139,6 +180,9 @@ def memory_store(
     tags: str = "",
     source: str = "user",
     agent_id: str = "ada",
+    data_class: str | None = None,
+    as_of: str | None = None,
+    expires_at: str | None = None,
 ) -> str:
     """Store a memory as a semantic embedding in Neo4j.
 
@@ -147,6 +191,9 @@ def memory_store(
         tags: Comma-separated tags for categorisation (e.g. "session,preference")
         source: Origin of the memory — "user", "tool", "session", "self"
         agent_id: Which agent this memory belongs to (default "ada")
+        data_class: Memory data class (e.g. "person", "preference", "technical-config")
+        as_of: ISO datetime for when the fact was established (defaults to now)
+        expires_at: ISO datetime for when a timed-event expires (required for timed-event)
 
     Returns:
         JSON with the stored memory ID and confirmation.
@@ -155,7 +202,15 @@ def memory_store(
         if not _hitl_gate(content):
             return json.dumps({"stored": False, "reason": "denied by HITL"})
 
-        return memory_store_direct(content, tags=tags, source=source, agent_id=agent_id)
+        return memory_store_direct(
+            content,
+            tags=tags,
+            source=source,
+            agent_id=agent_id,
+            data_class=data_class,
+            as_of=as_of,
+            expires_at=expires_at,
+        )
     except Exception as e:
         logger.exception("memory_store failed")
         return json.dumps({"error": str(e)})
@@ -197,6 +252,11 @@ def memory_retrieve(
                            m.source AS source,
                            m.agent_id AS agent_id,
                            m.created_at AS created_at,
+                           m.data_class AS data_class,
+                           m.tier AS tier,
+                           m.as_of AS as_of,
+                           m.expires_at AS expires_at,
+                           m.superseded AS superseded,
                            score
                     ORDER BY score DESC
                     """,
@@ -217,6 +277,11 @@ def memory_retrieve(
                            m.source AS source,
                            m.agent_id AS agent_id,
                            m.created_at AS created_at,
+                           m.data_class AS data_class,
+                           m.tier AS tier,
+                           m.as_of AS as_of,
+                           m.expires_at AS expires_at,
+                           m.superseded AS superseded,
                            score
                     ORDER BY score DESC
                     """,
@@ -233,6 +298,11 @@ def memory_retrieve(
                     "agent_id": record["agent_id"],
                     "created_at": record["created_at"],
                     "score": round(record["score"], 4),
+                    "data_class": record["data_class"],
+                    "tier": record["tier"],
+                    "as_of": record["as_of"],
+                    "expires_at": record["expires_at"],
+                    "superseded": record["superseded"],
                 }
                 for record in result
             ]

--- a/core/memory_schema.py
+++ b/core/memory_schema.py
@@ -1,0 +1,158 @@
+"""Memory data classification schema and validation.
+
+Defines the seven data classes from specs/memory-lifecycle.md, along with
+validation functions for data_class, source, and metadata building.
+
+This module is shared between agents/memory.py and agents/knowledge_graph.py
+to keep validation logic DRY and avoid circular dependencies.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class DataClassDef:
+    """Definition of a memory data class."""
+
+    name: str  # e.g. "technical-config"
+    tier: str  # "reviewable" or "durable"
+    tags: list[str] = field(default_factory=list)  # e.g. ["reviewable", "technical"]
+    requires_expires: bool = False  # True only for timed-event
+
+
+DATA_CLASS_REGISTRY: dict[str, DataClassDef] = {
+    "technical-config": DataClassDef(
+        "technical-config", "reviewable", ["reviewable", "technical"], False
+    ),
+    "session-log": DataClassDef(
+        "session-log", "reviewable", ["reviewable", "session"], False
+    ),
+    "timed-event": DataClassDef(
+        "timed-event", "reviewable", ["reviewable", "event"], True
+    ),
+    "person": DataClassDef("person", "durable", ["durable", "person"], False),
+    "world-event": DataClassDef(
+        "world-event", "reviewable", ["reviewable", "world-event"], False
+    ),
+    "preference": DataClassDef(
+        "preference", "durable", ["durable", "preference"], False
+    ),
+    "intention": DataClassDef(
+        "intention", "reviewable", ["reviewable", "intention"], False
+    ),
+}
+
+VALID_SOURCES = {"user", "tool", "session", "self"}
+VALID_TIERS = {"reviewable", "durable"}
+
+
+def validate_data_class(data_class: str | None) -> DataClassDef | None:
+    """Validate a data class name against the registry.
+
+    Args:
+        data_class: The data class name to validate, or None for backward compat.
+
+    Returns:
+        The DataClassDef for known classes, or None when data_class is None.
+
+    Raises:
+        ValueError: When data_class is a non-None string not in the registry.
+    """
+    if data_class is None:
+        logger.warning(
+            "data_class not provided -- this is deprecated and will become "
+            "required in a future release. Pass a valid data_class from the "
+            "registry: %s",
+            sorted(DATA_CLASS_REGISTRY.keys()),
+        )
+        return None
+
+    if data_class not in DATA_CLASS_REGISTRY:
+        raise ValueError(
+            f"Unknown data_class {data_class!r}. I don't have a class defined "
+            f"for this type of data. Should I define one, discard it, or handle "
+            f"it differently? Valid classes: {sorted(DATA_CLASS_REGISTRY.keys())}"
+        )
+
+    return DATA_CLASS_REGISTRY[data_class]
+
+
+def validate_source(source: str) -> str:
+    """Validate a source string against the allowed set.
+
+    Args:
+        source: The source identifier to validate.
+
+    Returns:
+        The validated source string.
+
+    Raises:
+        ValueError: When source is not in VALID_SOURCES.
+    """
+    if source not in VALID_SOURCES:
+        raise ValueError(
+            f"Invalid source {source!r}. Must be one of: {sorted(VALID_SOURCES)}"
+        )
+    return source
+
+
+def build_metadata(
+    data_class: str | None,
+    source: str,
+    as_of: str | None = None,
+    expires_at: str | None = None,
+) -> dict:
+    """Build a metadata dict for a memory or graph entry.
+
+    Validates data_class and source, then assembles the metadata fields.
+
+    Args:
+        data_class: The data class name, or None for backward compat.
+        source: Origin of the entry ("user", "tool", "session", "self").
+        as_of: ISO datetime string; defaults to now if not provided.
+        expires_at: ISO datetime string; required for timed-event class.
+
+    Returns:
+        Dict with metadata fields: data_class, tier, as_of, source,
+        superseded, and optionally expires_at.
+
+    Raises:
+        ValueError: On invalid data_class, source, or missing expires_at
+            for timed-event.
+    """
+    validate_source(source)
+    cls_def = validate_data_class(data_class)
+
+    if as_of is None:
+        as_of = datetime.now(timezone.utc).isoformat()
+
+    meta: dict = {
+        "as_of": as_of,
+        "source": source,
+        "superseded": False,
+    }
+
+    if cls_def is not None:
+        meta["data_class"] = cls_def.name
+        meta["tier"] = cls_def.tier
+
+        if cls_def.requires_expires and not expires_at:
+            raise ValueError(
+                f"data_class {data_class!r} requires expires_at to be set "
+                f"(an ISO datetime for when the event occurs)."
+            )
+        if expires_at:
+            meta["expires_at"] = expires_at
+    else:
+        meta["data_class"] = None
+        meta["tier"] = None
+        if expires_at:
+            meta["expires_at"] = expires_at
+
+    return meta

--- a/specs/memory-lifecycle.md
+++ b/specs/memory-lifecycle.md
@@ -1,0 +1,215 @@
+# Memory Lifecycle Management
+
+**Status:** Draft — in progress
+**Related card:** [Memory] Memory Lifecycle Management
+
+---
+
+## Overview
+
+The Hive Mind semantic memory system (Neo4j vector store + knowledge graph) requires explicit lifecycle policies to remain accurate and useful over time. Without them, stale facts accumulate, technical configuration drifts out of sync with reality, and retrieval quality degrades.
+
+This spec defines:
+1. A **data classification model** — what kind of data this is and how long it lives
+2. A **write procedure** — how to add to the knowledge graph correctly
+3. A **pruning procedure** — how stale data is identified and removed
+
+---
+
+## 1. Data Classification — Spec-Driven Model
+
+### The Core Rule: Every memory entry must match a defined data class.
+
+If a proposed memory entry does not match any existing class, do not store it. Instead, surface a prompt to Daniel:
+
+> "I don't have a class defined for this type of data: [description]. Should I define one, discard it, or handle it differently?"
+
+This keeps the taxonomy accurate and self-improving. After a few months of use, the class registry will cover the real distribution of data encountered — not a hypothetical one designed up front.
+
+**Defined data classes are listed in §1.2.** The framework for adding new classes is in §1.3.
+
+---
+
+### 1.1 Tiers
+
+All memory entries fall into one of three tiers:
+
+### Tier 1 — Discard (do not store)
+Data that is ephemeral by nature and has no value beyond the current exchange. Examples: intermediate reasoning steps, conversational filler, raw tool output that was already processed.
+
+Rule: **do not write to memory**. If in doubt, apply the test: "Would this still be useful if reviewed in a future pruning session?" If no, discard.
+
+### Tier 2 — Reviewable (store; pruned by relevance, not time)
+Data that is useful now but expected to change or expire. There are no arbitrary TTLs in this tier. Data stays until a pruning session determines it is no longer relevant. Two subcategories:
+
+**Tier 2a — Technical/Configuration data**
+Any fact about how Hive Mind is currently implemented, configured, or structured. Examples: which endpoint handles a feature, what a field in the DB schema is called, which container has which mount, current architectural decisions.
+
+- Tag: `reviewable`, `technical`
+- Pruning: **code-verified** — at each pruning session, verify the fact against the codebase. If still accurate, keep. If the codebase contradicts it or it no longer applies, prune immediately.
+- No time limit: a configuration fact that hasn't changed is kept indefinitely.
+
+**Tier 2b — Session/event data**
+Incident notes, session summaries, recovered-session logs, one-off observations. Examples: "session 48ec54d4 was recovered manually."
+
+- Tag: `reviewable`, `session`
+- Pruning: at each pruning session, assess whether the entry is still actionable or informative. If it has no remaining value, prune.
+
+### Tier 3 — Durable (permanent until explicitly updated)
+Facts that are stable and identity-defining, even if they may eventually change. Examples: Daniel's preferences, Ada's soul/identity, architectural decisions that represent deliberate long-term choices, people and relationships.
+
+- No pruning
+- Tag: `durable`
+- Updated explicitly when superseded, never auto-pruned
+- When a durable fact changes, the old entry should be marked `superseded=True` rather than deleted, for auditability
+
+---
+
+### 1.2 Defined Data Classes
+
+Each class specifies: tier, pruning rule, and tags.
+
+---
+
+**Class: `technical-config`**
+Facts about how Hive Mind is currently built, configured, or structured.
+- Tier: 2 (Reviewable)
+- Pruning: code-verified at each pruning session — kept if still accurate, pruned if contradicted by the codebase or no longer applicable
+- Tags: `reviewable`, `technical`
+
+---
+
+**Class: `session-log`**
+Incident notes, recovery logs, one-off debugging observations tied to a specific session ID.
+- Tier: 2 (Reviewable)
+- Pruning: assessed at each pruning session — pruned once it has no remaining actionable or informative value
+- Tags: `reviewable`, `session`
+
+---
+
+**Class: `timed-event`**
+A specific occurrence with a known datetime — appointments, deliveries, games, meetings.
+- Tier: 2 (Reviewable)
+- Pruning: auto-expire after the event datetime passes — this is the one case where the data itself sets its own expiry, because the event time is resolved to an absolute datetime at write time
+- Exception: if the event matches a recurring pattern (birthday, anniversary, weekly meeting) → do not auto-prune; ask before deleting
+- Tags: `reviewable`, `event`
+- Write rule: if a memory contains a time reference, it **must** be resolved to an absolute datetime at write time. If it cannot be resolved, do not write it as a timed-event — reclassify or discard.
+
+---
+
+**Class: `person`**
+Facts about a named individual — name, relationship to Daniel, contact info, preferences, life events.
+- Tier: 3 (Durable)
+- Pruning: explicit update only; old version marked `superseded=True`
+- Tags: `durable`, `person`
+- Notes: people facts are almost always durable. Even time-bound facts about a person (e.g. birthday) attach to the person node as a property or edge — they don't get their own `timed-event` entry unless the event itself is non-recurring.
+
+---
+
+**Class: `world-event`**
+News events, external incidents, cultural moments unrelated to Daniel's personal life or Hive Mind's codebase. Examples: the Austin shooting, a geopolitical event, a major product launch.
+- Tier: 2 (Reviewable) with long-term archival option
+- Pruning behavior: at each monthly review, surface a prompt to Daniel:
+  > "It's been a month since I stored this world event: [summary]. Keep it, archive it to long-term storage, or discard?"
+  - **Keep** → retain in active vector store until next monthly review
+  - **Archive** → move to long-term document store (NoSQL/document DB, TBD) for low-frequency retrieval; remove from active vector store
+  - **Discard** → delete
+- Tags: `reviewable`, `world-event`
+- Rationale: world events are worth remembering but are low-priority relative to personal and technical data. The active vector store should stay high-signal. Long-term archival allows retrieval when desired without polluting everyday context.
+
+---
+
+**Class: `preference`**
+Daniel's stated preferences, habits, and recurring patterns of behavior.
+- Tier: 3 (Durable)
+- Pruning: explicit update or periodic review — never auto-pruned
+- Exception: if stated with a temporal qualifier ("for now", "at the moment") → treat as Tier 2, reviewed at next pruning session
+- Tags: `durable`, `preference`
+
+---
+
+**Class: `intention`**
+Goals, plans, or things Daniel wants to do without a committed deadline.
+- Tier: 2 (Reviewable)
+- Pruning: reviewed at monthly sessions — still relevant, completed, or abandoned?
+- Tags: `reviewable`, `intention`
+
+---
+
+### 1.3 Adding a New Data Class
+
+When a memory entry doesn't match any existing class:
+
+1. Ada surfaces a prompt to Daniel describing the data and asking how to handle it
+2. Daniel decides: define a new class, map to an existing class, or discard
+3. If a new class is needed, define it here with: name, tier, pruning rule, tags
+4. The new class is immediately active for future entries
+
+This ensures the taxonomy grows from real usage rather than speculation.
+
+---
+
+## 2. Knowledge Graph Write Procedure
+
+Before writing any node or edge to the knowledge graph, the following steps are required:
+
+### Step 1 — Query first
+Call `graph_query` for every entity proposed for insertion. Check for:
+- An existing node with the same or similar name
+- An existing node that represents the same concept under a different label
+- Existing edges that would be duplicated
+
+### Step 2 — Resolve ambiguity before writing
+If a proposed entity could map to an existing node but is not clearly identical:
+- Do **not** create the new node speculatively
+- Send Daniel a clarifying message: "I'm about to add [X] to the graph — is this the same as [Y], or a separate entity?"
+- Wait for confirmation before proceeding
+
+This is not a full HITL approval flow — it is a lightweight disambiguation check. The goal is to avoid graph fragmentation (multiple nodes that should be one).
+
+### Step 3 — Write with metadata
+Every node and edge must include:
+- `tier`: `reviewable` or `durable`
+- `as_of`: ISO date of when the fact was established
+- `expires_at`: only for `timed-event` class entries (set to event datetime); omit for everything else
+- `source`: `user`, `tool`, `session`, or `self`
+
+### Step 4 — No orphan nodes
+Do not create a node without at least one edge. If no relationship is known yet, defer creation until the relationship is established. Orphan nodes are noise and degrade graph traversal quality.
+
+---
+
+## 3. Pruning Procedure
+
+Pruning runs on a schedule (frequency TBD — nightly is the default candidate for automated passes; monthly for review-based passes). There are no arbitrary time-based expirations. Data is pruned because it is **no longer relevant**, not because a timer ran out.
+
+### Pass 1 — Timed-event expiry
+The only automated expiry. Find all `timed-event` entries where `expires_at < now` and the event is not flagged as recurring. Delete unconditionally. For recurring events, surface a prompt to Daniel before deleting.
+
+### Pass 2 — Technical-config verification
+For all `technical-config` entries, verify each fact against the codebase:
+- Read the relevant files and check whether the stored fact is still accurate
+- If still accurate → keep, no change
+- If inaccurate or no longer applicable → prune immediately; optionally store a corrected replacement
+
+### Pass 3 — Session-log review
+For all `session-log` entries, assess whether the entry still has actionable or informative value. Prune entries that are purely historical with no remaining relevance.
+
+### Pass 4 — Monthly review (world-event, intention)
+Surface a batch prompt to Daniel covering all `world-event` and `intention` entries due for review. Daniel decides: keep, archive, or discard each one.
+
+### Pass 5 — Orphan node cleanup
+Find all graph nodes with zero edges. Log and surface for review. Nodes in an active session window (grace period TBD) are left alone.
+
+### Pass 6 — Consolidation (future)
+Identify clusters of related reviewable memories that could be summarized into a single durable one. Mark originals `consolidated=True`. See backlog card for detail.
+
+---
+
+## Open Items
+
+- Final decision on pruning schedule (nightly for automated passes, monthly for review passes)
+- Whether Pass 2 (code verification) should be done by Claude or a simpler heuristic
+- Consolidation spec (tracked separately)
+- Long-term document store for `world-event` archival — technology choice TBD (NoSQL, document DB, separate SQLite, etc.)
+- Token refresh OAuth flow for LinkedIn (separate card — mentioned here for cross-reference only)

--- a/tests/integration/test_memory_metadata_flow.py
+++ b/tests/integration/test_memory_metadata_flow.py
@@ -1,0 +1,131 @@
+"""Integration tests for memory metadata flow — store and retrieve with metadata."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_neo4j_and_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure agents.knowledge_graph can be imported by mocking neo4j and agent_tooling."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"id": "test-id"}
+    mock_session.run.return_value = mock_result
+    return mock_driver
+
+
+class TestStoreRetrieveMetadataFlow:
+    """Tests for the full store-then-retrieve flow with metadata."""
+
+    def test_store_then_retrieve_preserves_metadata(self) -> None:
+        import agents.memory as mem_mod
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        # Store with data_class
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            store_result_str = mem_mod.memory_store_direct(
+                content="Daniel prefers dark mode",
+                tags="preference",
+                source="user",
+                data_class="preference",
+            )
+            store_result = json.loads(store_result_str)
+            assert store_result["stored"] is True
+            assert store_result["data_class"] == "preference"
+
+            # Verify stored params
+            store_call = mock_session.run.call_args_list[-1]
+            params = store_call[1]
+            assert params["data_class"] == "preference"
+            assert params["tier"] == "durable"
+
+        # Retrieve and verify metadata is included
+        record_mock = MagicMock()
+        record_mock.__getitem__ = lambda self, key: {
+            "content": "Daniel prefers dark mode",
+            "tags": "preference",
+            "source": "user",
+            "agent_id": "ada",
+            "created_at": 1000,
+            "score": 0.99,
+            "data_class": "preference",
+            "tier": "durable",
+            "as_of": "2026-01-01T00:00:00Z",
+            "expires_at": None,
+            "superseded": False,
+        }[key]
+        retrieve_result_mock = MagicMock()
+        retrieve_result_mock.__iter__ = MagicMock(return_value=iter([record_mock]))
+        mock_session.run.return_value = retrieve_result_mock
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            retrieve_result_str = mem_mod.memory_retrieve(query="dark mode preference")
+            retrieve_result = json.loads(retrieve_result_str)
+            assert retrieve_result["count"] == 1
+            memory = retrieve_result["memories"][0]
+            assert memory["data_class"] == "preference"
+            assert memory["tier"] == "durable"
+
+
+class TestEpilogueWriteWithoutDataClass:
+    """Tests that epilogue write_to_memory still works during transition period."""
+
+    def test_epilogue_write_to_memory_without_data_class_still_works(self) -> None:
+        """Verify that write_to_memory (which calls memory_store_direct and
+        graph_upsert_direct without data_class) still succeeds."""
+        import agents.memory as mem_mod
+        import agents.knowledge_graph as kg_mod
+
+        mock_driver = _make_mock_driver()
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            # Simulate epilogue calling memory_store_direct without data_class
+            result_str = mem_mod.memory_store_direct(
+                content="Session 48ec54d4 was about dark mode preferences.",
+                tags="session,epilogue",
+                source="session",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+
+            # Simulate epilogue calling graph_upsert_direct without data_class
+            result_str = kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+                properties='{"context": "prefers dark mode"}',
+            )
+            result = json.loads(result_str)
+            assert result["upserted"] is True

--- a/tests/unit/test_graph_upsert_metadata.py
+++ b/tests/unit/test_graph_upsert_metadata.py
@@ -1,0 +1,216 @@
+"""Unit tests for metadata enforcement in graph_upsert and graph_upsert_direct."""
+
+import json
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_neo4j_and_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure agents.knowledge_graph can be imported by mocking neo4j and agent_tooling."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver with session and run mocked."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"id": "test-node-id"}
+    mock_session.run.return_value = mock_result
+    return mock_driver
+
+
+class TestGraphUpsertDirectMetadata:
+    """Tests for graph_upsert_direct with metadata parameters."""
+
+    def test_graph_upsert_direct_with_data_class_sets_metadata_on_node(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            result_str = kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+                data_class="person",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert result["upserted"] is True
+            assert result.get("data_class") == "person"
+
+            # Check the props dict passed to SET n += $props
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args_list[0]
+            params = call_args[1]
+            props = params["props"]
+            assert props["data_class"] == "person"
+            assert props["tier"] == "durable"
+            assert props["superseded"] is False
+            assert "as_of" in props
+            assert props["source"] == "user"
+
+    def test_graph_upsert_direct_unknown_class_returns_prompt(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            result_str = kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+                data_class="unknown-class",
+            )
+            result = json.loads(result_str)
+            assert "error" in result
+            assert "unknown-class" in result["error"].lower()
+
+    def test_graph_upsert_direct_without_data_class_logs_deprecation(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+            caplog.at_level(logging.WARNING),
+        ):
+            result_str = kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+            )
+            result = json.loads(result_str)
+            assert result["upserted"] is True  # Backward compat
+            assert any("deprecat" in msg.lower() for msg in caplog.messages)
+
+    def test_graph_upsert_direct_metadata_on_relationship_target(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            result_str = kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+                relation="MANAGES",
+                target_name="Hive Mind",
+                target_type="Project",
+                data_class="person",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert result["upserted"] is True
+            assert result["relation_created"] is True
+
+            # The second run call should set metadata on the target/relationship
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            rel_call = mock_session.run.call_args_list[1]
+            rel_query = rel_call[0][0] if rel_call[0] else ""
+            rel_params = rel_call[1]
+            # Metadata should appear in the params for target node
+            assert "meta_data_class" in rel_params or "data_class" in rel_query
+
+    def test_graph_upsert_direct_relationship_includes_tier(self) -> None:
+        """AC-4: tier must be set on every edge, not just nodes."""
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+                relation="MANAGES",
+                target_name="Hive Mind",
+                target_type="Project",
+                data_class="person",
+                source="user",
+            )
+
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            rel_call = mock_session.run.call_args_list[1]
+            rel_query = rel_call[0][0] if rel_call[0] else ""
+            rel_params = rel_call[1]
+            # r.tier must be set in the relationship SET clause
+            assert "r.tier" in rel_query
+            assert "meta_tier" in rel_params
+            assert rel_params["meta_tier"] == "durable"
+
+    def test_graph_upsert_direct_invalid_source_returns_error(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            result_str = kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+                data_class="person",
+                source="random",
+            )
+            result = json.loads(result_str)
+            assert "error" in result
+
+    def test_graph_upsert_return_includes_data_class(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            result_str = kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+                data_class="person",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert "data_class" in result
+            assert result["data_class"] == "person"
+
+
+class TestGraphUpsertWithHITL:
+    """Tests for graph_upsert (HITL-gated) with metadata pass-through."""
+
+    def test_graph_upsert_with_hitl_passes_data_class_through(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_hitl_gate", return_value=True),
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            result_str = kg_mod.graph_upsert(
+                entity_type="Person",
+                name="Daniel",
+                data_class="person",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert result["upserted"] is True
+            assert result.get("data_class") == "person"

--- a/tests/unit/test_memory_backward_compat.py
+++ b/tests/unit/test_memory_backward_compat.py
@@ -1,0 +1,169 @@
+"""Unit tests for backward compatibility — calling without data_class still works."""
+
+import json
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_neo4j_and_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure agents.knowledge_graph can be imported by mocking neo4j and agent_tooling."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"id": "test-id"}
+    mock_session.run.return_value = mock_result
+    return mock_driver
+
+
+class TestMemoryStoreBackwardCompat:
+    """Tests that memory_store_direct works without data_class (backward compat)."""
+
+    def test_memory_store_direct_no_data_class_still_stores(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="A backward-compatible memory entry",
+                tags="test",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+
+    def test_memory_store_direct_no_data_class_logs_deprecation_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+            caplog.at_level(logging.WARNING),
+        ):
+            mem_mod.memory_store_direct(
+                content="No data_class provided",
+                source="user",
+            )
+            assert any("deprecat" in msg.lower() for msg in caplog.messages)
+
+
+class TestGraphUpsertBackwardCompat:
+    """Tests that graph_upsert_direct works without data_class (backward compat)."""
+
+    def test_graph_upsert_direct_no_data_class_still_upserts(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+        ):
+            result_str = kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+            )
+            result = json.loads(result_str)
+            assert result["upserted"] is True
+
+    def test_graph_upsert_direct_no_data_class_logs_deprecation_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.knowledge_graph as kg_mod
+
+        with (
+            patch.object(kg_mod, "_get_driver", return_value=mock_driver),
+            patch.object(kg_mod, "_kg_index_created", True),
+            caplog.at_level(logging.WARNING),
+        ):
+            kg_mod.graph_upsert_direct(
+                entity_type="Person",
+                name="Daniel",
+            )
+            assert any("deprecat" in msg.lower() for msg in caplog.messages)
+
+
+class TestMemoryRetrieveBackwardCompat:
+    """Tests that memory_retrieve handles entries with and without metadata."""
+
+    def test_memory_retrieve_returns_entries_with_and_without_metadata(self) -> None:
+        import agents.memory as mem_mod
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        # Mock Neo4j to return mixed entries
+        record_with_meta = MagicMock()
+        record_with_meta.__getitem__ = lambda self, key: {
+            "content": "Entry with metadata",
+            "tags": "test",
+            "source": "user",
+            "agent_id": "ada",
+            "created_at": 1000,
+            "score": 0.95,
+            "data_class": "person",
+            "tier": "durable",
+            "as_of": "2026-01-01T00:00:00Z",
+            "expires_at": None,
+            "superseded": False,
+        }[key]
+
+        record_without_meta = MagicMock()
+        record_without_meta.__getitem__ = lambda self, key: {
+            "content": "Legacy entry without metadata",
+            "tags": "legacy",
+            "source": "user",
+            "agent_id": "ada",
+            "created_at": 999,
+            "score": 0.85,
+            "data_class": None,
+            "tier": None,
+            "as_of": None,
+            "expires_at": None,
+            "superseded": None,
+        }[key]
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(
+            return_value=iter([record_with_meta, record_without_meta])
+        )
+        mock_session.run.return_value = mock_result
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_retrieve(query="test query")
+            result = json.loads(result_str)
+            assert result["count"] == 2
+            memories = result["memories"]
+            # First entry has metadata
+            assert memories[0]["data_class"] == "person"
+            assert memories[0]["tier"] == "durable"
+            # Second entry has None metadata (backward compat)
+            assert memories[1]["data_class"] is None

--- a/tests/unit/test_memory_neo4j_indexes.py
+++ b/tests/unit/test_memory_neo4j_indexes.py
@@ -1,0 +1,133 @@
+"""Unit tests for Neo4j metadata index creation in memory.py and knowledge_graph.py."""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_neo4j_and_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure agents.knowledge_graph can be imported by mocking neo4j and agent_tooling."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"id": "test-id"}
+    mock_session.run.return_value = mock_result
+    return mock_driver
+
+
+class TestMemoryEnsureIndex:
+    """Tests for _ensure_index in agents/memory.py."""
+
+    def test_ensure_index_creates_vector_index(self) -> None:
+        import agents.memory as mem_mod
+
+        # Reset the global guard
+        with patch.object(mem_mod, "_index_created", False):
+            mock_session = MagicMock()
+            mem_mod._ensure_index(mock_session)
+
+            # Should have called run multiple times: vector + metadata indexes
+            calls = mock_session.run.call_args_list
+            assert len(calls) >= 1
+            # First call should be the vector index
+            first_query = calls[0][0][0]
+            assert "VECTOR INDEX" in first_query.upper() or "vector" in first_query.lower()
+
+    def test_ensure_index_creates_tier_index(self) -> None:
+        import agents.memory as mem_mod
+
+        with patch.object(mem_mod, "_index_created", False):
+            mock_session = MagicMock()
+            mem_mod._ensure_index(mock_session)
+
+            all_queries = [c[0][0] for c in mock_session.run.call_args_list]
+            tier_queries = [q for q in all_queries if "tier" in q.lower()]
+            assert len(tier_queries) >= 1
+
+    def test_ensure_index_creates_data_class_index(self) -> None:
+        import agents.memory as mem_mod
+
+        with patch.object(mem_mod, "_index_created", False):
+            mock_session = MagicMock()
+            mem_mod._ensure_index(mock_session)
+
+            all_queries = [c[0][0] for c in mock_session.run.call_args_list]
+            dc_queries = [q for q in all_queries if "data_class" in q.lower()]
+            assert len(dc_queries) >= 1
+
+    def test_ensure_index_creates_expires_at_index(self) -> None:
+        import agents.memory as mem_mod
+
+        with patch.object(mem_mod, "_index_created", False):
+            mock_session = MagicMock()
+            mem_mod._ensure_index(mock_session)
+
+            all_queries = [c[0][0] for c in mock_session.run.call_args_list]
+            exp_queries = [q for q in all_queries if "expires_at" in q.lower()]
+            assert len(exp_queries) >= 1
+
+    def test_ensure_index_creates_source_index(self) -> None:
+        import agents.memory as mem_mod
+
+        with patch.object(mem_mod, "_index_created", False):
+            mock_session = MagicMock()
+            mem_mod._ensure_index(mock_session)
+
+            all_queries = [c[0][0] for c in mock_session.run.call_args_list]
+            src_queries = [q for q in all_queries if "source" in q.lower() and "INDEX" in q.upper()]
+            assert len(src_queries) >= 1
+
+    def test_ensure_index_idempotent(self) -> None:
+        import agents.memory as mem_mod
+
+        with patch.object(mem_mod, "_index_created", False):
+            mock_session = MagicMock()
+            mem_mod._ensure_index(mock_session)
+            first_call_count = mock_session.run.call_count
+
+            # Second call should do nothing because _index_created is now True
+            mem_mod._ensure_index(mock_session)
+            assert mock_session.run.call_count == first_call_count
+
+
+class TestKnowledgeGraphEnsureMetadataIndexes:
+    """Tests for _ensure_metadata_indexes in agents/knowledge_graph.py."""
+
+    def test_ensure_metadata_indexes_creates_indexes(self) -> None:
+        import agents.knowledge_graph as kg_mod
+
+        with patch.object(kg_mod, "_kg_index_created", False):
+            mock_session = MagicMock()
+            kg_mod._ensure_metadata_indexes(mock_session)
+
+            # Should create indexes for all entity types and metadata fields
+            calls = mock_session.run.call_args_list
+            # 5 entity types * 3 fields = 15 indexes
+            assert len(calls) >= 15
+
+    def test_ensure_metadata_indexes_idempotent(self) -> None:
+        import agents.knowledge_graph as kg_mod
+
+        with patch.object(kg_mod, "_kg_index_created", False):
+            mock_session = MagicMock()
+            kg_mod._ensure_metadata_indexes(mock_session)
+            first_count = mock_session.run.call_count
+
+            # Second call should do nothing
+            kg_mod._ensure_metadata_indexes(mock_session)
+            assert mock_session.run.call_count == first_count

--- a/tests/unit/test_memory_retrieve_metadata.py
+++ b/tests/unit/test_memory_retrieve_metadata.py
@@ -1,0 +1,156 @@
+"""Unit tests for memory_retrieve metadata surfacing."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_driver
+
+
+def _make_record(**fields: object) -> MagicMock:
+    """Create a mock Neo4j record with dict-like access."""
+    record = MagicMock()
+    record.__getitem__ = lambda self, key: fields[key]
+    return record
+
+
+class TestMemoryRetrieveMetadata:
+    """Tests for metadata fields in memory_retrieve results."""
+
+    def test_memory_retrieve_includes_data_class_in_results(self) -> None:
+        import agents.memory as mem_mod
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        record = _make_record(
+            content="Test memory",
+            tags="test",
+            source="user",
+            agent_id="ada",
+            created_at=1000,
+            score=0.95,
+            data_class="person",
+            tier="durable",
+            as_of="2026-01-01T00:00:00Z",
+            expires_at=None,
+            superseded=False,
+        )
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([record]))
+        mock_session.run.return_value = mock_result
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_retrieve(query="test")
+            result = json.loads(result_str)
+            assert result["count"] == 1
+            assert result["memories"][0]["data_class"] == "person"
+
+    def test_memory_retrieve_includes_tier_in_results(self) -> None:
+        import agents.memory as mem_mod
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        record = _make_record(
+            content="Test",
+            tags="",
+            source="user",
+            agent_id="ada",
+            created_at=1000,
+            score=0.9,
+            data_class="preference",
+            tier="durable",
+            as_of="2026-01-01",
+            expires_at=None,
+            superseded=False,
+        )
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([record]))
+        mock_session.run.return_value = mock_result
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_retrieve(query="test")
+            result = json.loads(result_str)
+            assert result["memories"][0]["tier"] == "durable"
+
+    def test_memory_retrieve_includes_as_of_in_results(self) -> None:
+        import agents.memory as mem_mod
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        record = _make_record(
+            content="Test",
+            tags="",
+            source="user",
+            agent_id="ada",
+            created_at=1000,
+            score=0.9,
+            data_class="person",
+            tier="durable",
+            as_of="2026-03-01T12:00:00Z",
+            expires_at=None,
+            superseded=False,
+        )
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([record]))
+        mock_session.run.return_value = mock_result
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_retrieve(query="test")
+            result = json.loads(result_str)
+            assert result["memories"][0]["as_of"] == "2026-03-01T12:00:00Z"
+
+    def test_memory_retrieve_handles_entries_without_metadata(self) -> None:
+        """Pre-migration entries should return None for metadata fields."""
+        import agents.memory as mem_mod
+
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        # Simulate a pre-migration record that has None for metadata fields
+        record = _make_record(
+            content="Legacy entry",
+            tags="old",
+            source="user",
+            agent_id="ada",
+            created_at=500,
+            score=0.8,
+            data_class=None,
+            tier=None,
+            as_of=None,
+            expires_at=None,
+            superseded=None,
+        )
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([record]))
+        mock_session.run.return_value = mock_result
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_retrieve(query="legacy")
+            result = json.loads(result_str)
+            assert result["count"] == 1
+            memory = result["memories"][0]
+            assert memory["data_class"] is None
+            assert memory["tier"] is None
+            assert memory["as_of"] is None

--- a/tests/unit/test_memory_schema.py
+++ b/tests/unit/test_memory_schema.py
@@ -1,0 +1,155 @@
+"""Unit tests for core.memory_schema — data class registry and validation."""
+
+import logging
+from datetime import datetime, timezone
+
+import pytest
+
+from core.memory_schema import (
+    DATA_CLASS_REGISTRY,
+    VALID_SOURCES,
+    VALID_TIERS,
+    DataClassDef,
+    build_metadata,
+    validate_data_class,
+    validate_source,
+)
+
+
+class TestDataClassRegistry:
+    """Tests for the DATA_CLASS_REGISTRY constant."""
+
+    def test_registry_contains_all_seven_classes(self) -> None:
+        expected = {
+            "technical-config",
+            "session-log",
+            "timed-event",
+            "person",
+            "world-event",
+            "preference",
+            "intention",
+        }
+        assert set(DATA_CLASS_REGISTRY.keys()) == expected
+        assert len(DATA_CLASS_REGISTRY) == 7
+
+    def test_registry_technical_config_is_reviewable(self) -> None:
+        dc = DATA_CLASS_REGISTRY["technical-config"]
+        assert dc.tier == "reviewable"
+        assert "reviewable" in dc.tags
+        assert "technical" in dc.tags
+
+    def test_registry_person_is_durable(self) -> None:
+        dc = DATA_CLASS_REGISTRY["person"]
+        assert dc.tier == "durable"
+        assert "durable" in dc.tags
+        assert "person" in dc.tags
+
+    def test_registry_timed_event_requires_expires(self) -> None:
+        dc = DATA_CLASS_REGISTRY["timed-event"]
+        assert dc.requires_expires is True
+        # All other classes should NOT require expires
+        for name, cls_def in DATA_CLASS_REGISTRY.items():
+            if name != "timed-event":
+                assert cls_def.requires_expires is False, (
+                    f"{name} should not require expires_at"
+                )
+
+    def test_registry_entries_are_frozen_dataclasses(self) -> None:
+        for name, dc in DATA_CLASS_REGISTRY.items():
+            assert isinstance(dc, DataClassDef)
+            with pytest.raises(AttributeError):
+                dc.name = "modified"  # type: ignore[misc]
+
+    def test_valid_sources_contains_expected(self) -> None:
+        assert VALID_SOURCES == {"user", "tool", "session", "self"}
+
+    def test_valid_tiers_contains_expected(self) -> None:
+        assert VALID_TIERS == {"reviewable", "durable"}
+
+
+class TestValidateDataClass:
+    """Tests for validate_data_class()."""
+
+    def test_validate_data_class_known_returns_def(self) -> None:
+        result = validate_data_class("person")
+        assert result is not None
+        assert result.name == "person"
+        assert result.tier == "durable"
+
+    def test_validate_data_class_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="unknown-class"):
+            validate_data_class("unknown-class")
+
+    def test_validate_data_class_none_warns(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level(logging.WARNING):
+            result = validate_data_class(None)
+        assert result is None
+        assert any("deprecat" in msg.lower() for msg in caplog.messages)
+
+    def test_validate_data_class_empty_string_raises(self) -> None:
+        with pytest.raises(ValueError):
+            validate_data_class("")
+
+
+class TestValidateSource:
+    """Tests for validate_source()."""
+
+    def test_validate_source_valid(self) -> None:
+        for src in VALID_SOURCES:
+            result = validate_source(src)
+            assert result == src
+
+    def test_validate_source_invalid_raises(self) -> None:
+        with pytest.raises(ValueError, match="random"):
+            validate_source("random")
+
+
+class TestBuildMetadata:
+    """Tests for build_metadata()."""
+
+    def test_build_metadata_with_data_class(self) -> None:
+        meta = build_metadata(data_class="person", source="user")
+        assert meta["data_class"] == "person"
+        assert meta["tier"] == "durable"
+        assert meta["source"] == "user"
+        assert meta["superseded"] is False
+        assert "as_of" in meta
+        assert "expires_at" not in meta or meta.get("expires_at") is None
+
+    def test_build_metadata_timed_event_requires_expires_at(self) -> None:
+        with pytest.raises(ValueError, match="expires_at"):
+            build_metadata(data_class="timed-event", source="user")
+
+    def test_build_metadata_timed_event_with_expires_at(self) -> None:
+        meta = build_metadata(
+            data_class="timed-event",
+            source="user",
+            expires_at="2026-04-01T00:00:00Z",
+        )
+        assert meta["expires_at"] == "2026-04-01T00:00:00Z"
+        assert meta["data_class"] == "timed-event"
+        assert meta["tier"] == "reviewable"
+
+    def test_build_metadata_without_data_class_returns_minimal(self) -> None:
+        meta = build_metadata(data_class=None, source="user")
+        assert meta["source"] == "user"
+        assert "as_of" in meta
+        # When data_class is None, tier and data_class should not be in metadata
+        # or should be None
+        assert meta.get("data_class") is None
+        assert meta.get("tier") is None
+
+    def test_build_metadata_as_of_defaults_to_now(self) -> None:
+        before = datetime.now(timezone.utc).isoformat()
+        meta = build_metadata(data_class="person", source="user")
+        after = datetime.now(timezone.utc).isoformat()
+        assert before <= meta["as_of"] <= after
+
+    def test_build_metadata_as_of_custom(self) -> None:
+        custom = "2025-01-15T12:00:00Z"
+        meta = build_metadata(data_class="person", source="user", as_of=custom)
+        assert meta["as_of"] == custom
+
+    def test_build_metadata_invalid_source_raises(self) -> None:
+        with pytest.raises(ValueError, match="random"):
+            build_metadata(data_class="person", source="random")

--- a/tests/unit/test_memory_store_metadata.py
+++ b/tests/unit/test_memory_store_metadata.py
@@ -1,0 +1,201 @@
+"""Unit tests for metadata enforcement in memory_store and memory_store_direct."""
+
+import json
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_neo4j_and_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure agents.memory can be imported by mocking neo4j and keyring."""
+    # Mock neo4j if not available
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    # Mock agent_tooling if not available
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver with session and run mocked."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"id": "test-id-123"}
+    mock_session.run.return_value = mock_result
+    return mock_driver
+
+
+class TestMemoryStoreDirectMetadata:
+    """Tests for memory_store_direct with metadata parameters."""
+
+    def test_memory_store_direct_with_data_class_includes_metadata(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Daniel prefers dark mode",
+                tags="preference",
+                source="user",
+                data_class="preference",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+            assert result["data_class"] == "preference"
+
+            # Check that the Cypher query params include metadata
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["data_class"] == "preference"
+            assert params["tier"] == "durable"
+            assert params["superseded"] is False
+            assert params["as_of"] is not None
+
+    def test_memory_store_direct_unknown_class_returns_prompt(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="some content",
+                data_class="unknown-class",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is False
+            assert "unknown-class" in result.get("prompt", "").lower() or "unknown-class" in result.get("error", "").lower()
+
+    def test_memory_store_direct_without_data_class_logs_deprecation(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+            caplog.at_level(logging.WARNING),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="something without class",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True  # Backward compat
+            assert any("deprecat" in msg.lower() for msg in caplog.messages)
+
+    def test_memory_store_direct_timed_event_without_expires_returns_error(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Meeting at 3pm",
+                data_class="timed-event",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is False
+
+    def test_memory_store_direct_timed_event_with_expires_includes_field(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Meeting at 3pm",
+                data_class="timed-event",
+                source="user",
+                expires_at="2026-04-01T00:00:00Z",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+            # Check cypher params include expires_at
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["expires_at"] == "2026-04-01T00:00:00Z"
+
+    def test_memory_store_direct_invalid_source_returns_error(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="something",
+                source="random",
+                data_class="person",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is False
+
+    def test_memory_store_return_includes_data_class_in_response(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Test content",
+                source="user",
+                data_class="person",
+            )
+            result = json.loads(result_str)
+            assert "data_class" in result
+            assert result["data_class"] == "person"
+
+
+class TestMemoryStoreWithHITL:
+    """Tests for memory_store (HITL-gated) with metadata pass-through."""
+
+    def test_memory_store_with_hitl_passes_data_class_through(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_hitl_gate", return_value=True),
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store(
+                content="Daniel prefers dark mode",
+                source="user",
+                data_class="preference",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+            assert result["data_class"] == "preference"


### PR DESCRIPTION
## Summary
- Added `core/memory_schema.py` with a 7-class data classification registry (`technical-config`, `session-log`, `timed-event`, `person`, `world-event`, `preference`, `intention`), validation functions, and metadata builder
- Updated `memory_store` and `memory_store_direct` in `agents/memory.py` to accept `data_class`, `as_of`, `expires_at`, and `source` parameters with full validation against the class registry
- Updated `graph_upsert` and `graph_upsert_direct` in `agents/knowledge_graph.py` to enforce the same metadata fields on all nodes and edges, with Neo4j property indexes for efficient pruning queries

## Acceptance Criteria
- [x] `memory_store` accepts and validates `data_class` parameter against registry
- [x] Unknown `data_class` values trigger a prompt to Daniel; memory is not stored
- [x] All new `memory_store` entries include: `tier`, `as_of`, `expires_at` (timed-event only), `source`, `superseded`, `data_class`
- [x] `graph_upsert` enforces same metadata fields on all nodes and edges
- [x] Neo4j indexes created for: `tier`, `data_class`, `expires_at`, `source`
- [x] Class registry constant defined in `core/memory_schema.py` with all 7 classes
- [x] Existing entries without `data_class` remain unchanged (backward compatible)
- [x] `data_class` is optional with deprecation warning until backfill is complete
- [x] All tests pass (new + regression)
- [x] Code review approved

## Test Plan
- 1161 lines of new tests across 7 test files covering schema validation, store metadata, graph upsert metadata, backward compatibility, Neo4j indexes, retrieve metadata, and integration flow
- All unit and integration tests pass (pytest)
- mypy and ruff clean

Implemented autonomously by Ada -- Hive Mind