### PR TITLE
[Memory] Timed-Event Auto-Expiry — Nightly Pass

### DIFF
--- a/agents/memory.py
+++ b/agents/memory.py
@@ -83,7 +83,7 @@ def _ensure_index(session):
         """
     )
     # Create property indexes for metadata fields on Memory nodes
-    for field in ("tier", "data_class", "expires_at", "source"):
+    for field in ("tier", "data_class", "expires_at", "source", "recurring"):
         try:
             session.run(
                 f"CREATE INDEX idx_memory_{field} IF NOT EXISTS "
@@ -113,6 +113,7 @@ def memory_store_direct(
     agent_id: str = "ada",
     as_of: str | None = None,
     expires_at: str | None = None,
+    recurring: bool | None = None,
 ) -> str:
     """Write to vector memory without HITL. Called by the epilogue after batch approval."""
     try:
@@ -124,7 +125,12 @@ def memory_store_direct(
 
         try:
             meta = build_metadata(
-                data_class=data_class, source=source, as_of=as_of, expires_at=expires_at
+                data_class=data_class,
+                source=source,
+                as_of=as_of,
+                expires_at=expires_at,
+                recurring=recurring,
+                content=content,
             )
         except ValueError as e:
             return json.dumps({"stored": False, "error": str(e), "prompt": str(e)})
@@ -146,7 +152,8 @@ def memory_store_direct(
                     tier: $tier,
                     as_of: $as_of,
                     expires_at: $expires_at,
-                    superseded: $superseded
+                    superseded: $superseded,
+                    recurring: $recurring
                 })
                 RETURN elementId(m) AS id
                 """,
@@ -161,6 +168,7 @@ def memory_store_direct(
                 as_of=meta.get("as_of"),
                 expires_at=meta.get("expires_at"),
                 superseded=meta.get("superseded", False),
+                recurring=meta.get("recurring"),
             )
             record = result.single()
             memory_id = record["id"] if record else "unknown"
@@ -185,6 +193,7 @@ def memory_store(
     agent_id: str = "ada",
     as_of: str | None = None,
     expires_at: str | None = None,
+    recurring: bool | None = None,
 ) -> str:
     """Store a memory as a semantic embedding in Neo4j.
 
@@ -196,6 +205,7 @@ def memory_store(
         agent_id: Which agent this memory belongs to (default "ada")
         as_of: ISO datetime for when the fact was established (defaults to now)
         expires_at: ISO datetime for when a timed-event expires (required for timed-event)
+        recurring: Explicit recurring flag for timed-events (overrides heuristic detection)
 
     Returns:
         JSON with the stored memory ID and confirmation.
@@ -212,6 +222,7 @@ def memory_store(
             data_class=data_class,
             as_of=as_of,
             expires_at=expires_at,
+            recurring=recurring,
         )
     except Exception as e:
         logger.exception("memory_store failed")

--- a/clients/scheduler.py
+++ b/clients/scheduler.py
@@ -147,6 +147,25 @@ async def run_task(task_index: int) -> None:
     await _send_text(bot_token, chat_id, response)
 
 
+async def _memory_expiry_sweep() -> None:
+    """Call the gateway's memory expiry sweep endpoint to process expired timed-events."""
+    log.info("Running memory expiry sweep")
+    try:
+        timeout = aiohttp.ClientTimeout(total=120)
+        headers = {"X-HITL-Internal": config.hitl_internal_token or ""}
+        async with aiohttp.ClientSession(timeout=timeout) as http:
+            async with http.post(f"{SERVER_URL}/memory/expiry-sweep", headers=headers) as resp:
+                data = await resp.json()
+                log.info(
+                    "Memory expiry sweep: deleted=%d, prompted=%d, errors=%d",
+                    data.get("deleted", 0),
+                    data.get("prompted", 0),
+                    data.get("errors", 0),
+                )
+    except Exception:
+        log.exception("Memory expiry sweep failed")
+
+
 async def _epilogue_sweep() -> None:
     """Call the gateway's epilogue sweep endpoint to process unprocessed dead sessions."""
     log.info("Running epilogue sweep")
@@ -194,8 +213,13 @@ async def main() -> None:
     scheduler.add_job(_epilogue_sweep, epilogue_trigger, id="epilogue-sweep")
     log.info("Scheduled epilogue sweep @ */30 * * * *")
 
+    # Add memory expiry sweep job (nightly at 3:30 AM CT)
+    memory_expiry_trigger = CronTrigger(hour="3", minute="30", timezone="America/Chicago")
+    scheduler.add_job(_memory_expiry_sweep, memory_expiry_trigger, id="memory-expiry-sweep")
+    log.info("Scheduled memory expiry sweep @ 30 3 * * *")
+
     scheduler.start()
-    log.info("Scheduler running — %d job(s) active + epilogue sweep", len(config.scheduled_tasks))
+    log.info("Scheduler running — %d job(s) active + epilogue sweep + memory expiry sweep", len(config.scheduled_tasks))
 
     await asyncio.Event().wait()  # run forever
 

--- a/core/memory_expiry.py
+++ b/core/memory_expiry.py
@@ -1,0 +1,118 @@
+"""Memory expiry sweep -- deletes expired timed-event entries from Neo4j.
+
+Non-recurring expired events are deleted unconditionally.
+Recurring expired events trigger a Telegram prompt to Daniel.
+
+Called by the scheduler via the /memory/expiry-sweep gateway endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+def _get_driver():
+    """Lazy import to avoid circular dependency and allow mocking."""
+    from agents.memory import _get_driver as _mem_get_driver
+    return _mem_get_driver()
+
+
+def _telegram_direct(message: str) -> tuple[bool, str]:
+    """Lazy import of the Telegram direct send function."""
+    from agents.notify import _telegram_direct as _notify_telegram
+    return _notify_telegram(message)
+
+
+def sweep_expired_events() -> dict:
+    """Query Neo4j for expired timed-event entries and process them.
+
+    - Non-recurring entries: deleted unconditionally.
+    - Recurring entries: Telegram prompt sent to Daniel; entry NOT deleted.
+
+    Returns:
+        Summary dict with keys: deleted, prompted, errors.
+    """
+    deleted = 0
+    prompted = 0
+    errors = 0
+    now = datetime.now(timezone.utc).isoformat()
+
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (m:Memory)
+                WHERE m.data_class = 'timed-event'
+                  AND m.expires_at IS NOT NULL
+                  AND m.expires_at < $now
+                RETURN m.content AS content,
+                       m.expires_at AS expires_at,
+                       m.recurring AS recurring,
+                       elementId(m) AS id
+                """,
+                now=now,
+            )
+
+            for record in result:
+                content = record["content"]
+                expires_at = record["expires_at"]
+                is_recurring = record["recurring"]
+                element_id = record["id"]
+
+                if is_recurring:
+                    # Send Telegram prompt for recurring events
+                    try:
+                        msg = (
+                            f"Recurring event expired:\n\n"
+                            f"{content}\n\n"
+                            f"Expired at: {expires_at}\n\n"
+                            f"Should I keep this for the next occurrence or delete it?"
+                        )
+                        _telegram_direct(msg)
+                        prompted += 1
+                        logger.info(
+                            "Prompted for recurring expired event: %s (expires_at=%s)",
+                            content,
+                            expires_at,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to send Telegram prompt for recurring event: %s",
+                            content,
+                        )
+                        errors += 1
+                else:
+                    # Delete non-recurring expired events
+                    try:
+                        session.run(
+                            "MATCH (m) WHERE elementId(m) = $id DETACH DELETE m",
+                            id=element_id,
+                        )
+                        deleted += 1
+                        logger.info(
+                            "Deleted expired non-recurring event: %s (expires_at=%s)",
+                            content,
+                            expires_at,
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to delete expired event: %s",
+                            content,
+                        )
+                        errors += 1
+
+    except Exception:
+        logger.exception("Memory expiry sweep failed")
+        errors += 1
+
+    logger.info(
+        "Memory expiry sweep complete: deleted=%d, prompted=%d, errors=%d",
+        deleted,
+        prompted,
+        errors,
+    )
+    return {"deleted": deleted, "prompted": prompted, "errors": errors}

--- a/core/memory_schema.py
+++ b/core/memory_schema.py
@@ -10,6 +10,7 @@ to keep validation logic DRY and avoid circular dependencies.
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
@@ -50,6 +51,74 @@ DATA_CLASS_REGISTRY: dict[str, DataClassDef] = {
 
 VALID_SOURCES = {"user", "tool", "session", "self"}
 VALID_TIERS = {"reviewable", "durable"}
+
+RECURRING_KEYWORDS: frozenset[str] = frozenset({
+    "birthday", "anniversary", "weekly", "monthly", "annual", "every", "recurring",
+})
+
+_RECURRING_PATTERN = re.compile(
+    r"\b(?:" + "|".join(RECURRING_KEYWORDS) + r")\b",
+    re.IGNORECASE,
+)
+
+
+def detect_recurring(content: str) -> bool:
+    """Detect whether content describes a recurring event via keyword heuristics.
+
+    Scans the content string for word-boundary matches against RECURRING_KEYWORDS.
+    Case-insensitive.
+
+    Args:
+        content: The text content to scan.
+
+    Returns:
+        True if any recurring keyword is found, False otherwise.
+    """
+    if not content:
+        return False
+    return bool(_RECURRING_PATTERN.search(content))
+
+
+def validate_expires_at(expires_at: str) -> str:
+    """Validate that expires_at is a resolved absolute ISO 8601 datetime.
+
+    Args:
+        expires_at: The datetime string to validate.
+
+    Returns:
+        The validated expires_at string.
+
+    Raises:
+        ValueError: When expires_at is not a valid ISO datetime or is date-only.
+    """
+    if not expires_at:
+        raise ValueError(
+            "expires_at must be a resolved absolute ISO datetime "
+            "(e.g. '2026-04-01T15:00:00Z'). Relative or unresolved time "
+            f"references like '{expires_at}' are not valid. Please resolve to "
+            "an absolute datetime, reclassify the entry, or discard."
+        )
+    # Reject date-only strings (no 'T' separator)
+    if "T" not in expires_at:
+        raise ValueError(
+            "expires_at must be a resolved absolute ISO datetime "
+            "(e.g. '2026-04-01T15:00:00Z'). Relative or unresolved time "
+            f"references like '{expires_at}' are not valid. Please resolve to "
+            "an absolute datetime, reclassify the entry, or discard."
+        )
+    try:
+        # Handle 'Z' suffix which Python < 3.11 may not parse directly
+        parse_value = expires_at.replace("Z", "+00:00") if expires_at.endswith("Z") else expires_at
+        datetime.fromisoformat(parse_value)
+    except (ValueError, TypeError):
+        raise ValueError(
+            "expires_at must be a resolved absolute ISO datetime "
+            "(e.g. '2026-04-01T15:00:00Z'). Relative or unresolved time "
+            f"references like '{expires_at}' are not valid. Please resolve to "
+            "an absolute datetime, reclassify the entry, or discard."
+        )
+    return expires_at
+
 
 def register_new_class(
     class_name: str,
@@ -129,6 +198,8 @@ def build_metadata(
     source: str,
     as_of: str | None = None,
     expires_at: str | None = None,
+    recurring: bool | None = None,
+    content: str | None = None,
 ) -> dict:
     """Build a metadata dict for a memory or graph entry.
 
@@ -139,14 +210,18 @@ def build_metadata(
         source: Origin of the entry ("user", "tool", "session", "self").
         as_of: ISO datetime string; defaults to now if not provided.
         expires_at: ISO datetime string; required for timed-event class.
+        recurring: Explicit recurring flag (overrides heuristic detection).
+            Only used for timed-event class.
+        content: Content text for recurring keyword detection.
+            Only used for timed-event class.
 
     Returns:
         Dict with metadata fields: data_class, tier, as_of, source,
-        superseded, and optionally expires_at.
+        superseded, and optionally expires_at and recurring.
 
     Raises:
-        ValueError: On invalid/missing data_class, source, or missing expires_at
-            for timed-event.
+        ValueError: On invalid/missing data_class, source, or missing/invalid
+            expires_at for timed-event.
     """
     validate_source(source)
     cls_def = validate_data_class(data_class)
@@ -168,6 +243,16 @@ def build_metadata(
             f"(an ISO datetime for when the event occurs)."
         )
     if expires_at:
+        # Validate the format for timed-event entries
+        if cls_def.requires_expires:
+            validate_expires_at(expires_at)
         meta["expires_at"] = expires_at
+
+    # Add recurring flag for timed-event class
+    if cls_def.requires_expires:
+        if recurring is not None:
+            meta["recurring"] = recurring
+        else:
+            meta["recurring"] = detect_recurring(content or "")
 
     return meta

--- a/server.py
+++ b/server.py
@@ -204,6 +204,21 @@ async def list_models():
 
 
 # ---------------------------------------------------------------------------
+# Memory Expiry
+# ---------------------------------------------------------------------------
+@app.post("/memory/expiry-sweep")
+async def memory_expiry_sweep(x_hitl_internal: str = Header(None)):
+    """Trigger memory expiry sweep for expired timed-event entries."""
+    if not config.hitl_internal_token:
+        return JSONResponse({"error": "HITL not configured"}, status_code=500)
+    if x_hitl_internal != config.hitl_internal_token:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    from core.memory_expiry import sweep_expired_events
+    results = await asyncio.to_thread(sweep_expired_events)
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Epilogue sweep endpoint
 # ---------------------------------------------------------------------------
 @app.post("/epilogue/sweep")

--- a/tests/api/test_memory_expiry_sweep.py
+++ b/tests/api/test_memory_expiry_sweep.py
@@ -1,0 +1,84 @@
+"""API tests for the /memory/expiry-sweep endpoint."""
+
+from unittest.mock import AsyncMock, patch, MagicMock
+import asyncio
+
+import pytest
+from fastapi.testclient import TestClient
+
+_AUTH_HEADER = {"X-HITL-Internal": "test-token"}
+
+
+class TestMemoryExpirySweepEndpoint:
+    """Tests for POST /memory/expiry-sweep."""
+
+    def test_expiry_sweep_endpoint_returns_200(self) -> None:
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg, \
+             patch("core.memory_expiry.sweep_expired_events", return_value={"deleted": 1, "prompted": 0, "errors": 0}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/expiry-sweep", headers=_AUTH_HEADER)
+            assert response.status_code == 200
+
+    def test_expiry_sweep_rejects_missing_token(self) -> None:
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/expiry-sweep")
+            assert response.status_code == 401
+
+    def test_expiry_sweep_rejects_wrong_token(self) -> None:
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/expiry-sweep",
+                headers={"X-HITL-Internal": "wrong-token"},
+            )
+            assert response.status_code == 401
+
+    def test_expiry_sweep_returns_counts(self) -> None:
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg, \
+             patch("core.memory_expiry.sweep_expired_events", return_value={"deleted": 3, "prompted": 1, "errors": 0}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/expiry-sweep", headers=_AUTH_HEADER)
+            data = response.json()
+            assert "deleted" in data
+            assert "prompted" in data
+            assert "errors" in data
+            assert data["deleted"] == 3
+            assert data["prompted"] == 1
+            assert data["errors"] == 0
+
+    def test_expiry_sweep_uses_to_thread(self) -> None:
+        """Assert that the endpoint runs sweep_expired_events via asyncio.to_thread to avoid blocking."""
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg, \
+             patch("core.memory_expiry.sweep_expired_events", return_value={"deleted": 0, "prompted": 0, "errors": 0}) as mock_sweep, \
+             patch("server.asyncio") as mock_asyncio:
+            mock_cfg.hitl_internal_token = "test-token"
+
+            # Make to_thread return a coroutine that returns the sweep result
+            async def fake_to_thread(fn):
+                return fn()
+            mock_asyncio.to_thread = AsyncMock(side_effect=fake_to_thread)
+
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/expiry-sweep", headers=_AUTH_HEADER)
+            assert response.status_code == 200
+            mock_asyncio.to_thread.assert_called_once_with(mock_sweep)

--- a/tests/integration/test_memory_expiry_flow.py
+++ b/tests/integration/test_memory_expiry_flow.py
@@ -1,0 +1,174 @@
+"""Integration tests for the memory expiry flow.
+
+Tests the full flow from expired entries to deletion/Telegram prompt,
+and from memory_store with validation of expires_at and recurring.
+"""
+
+import json
+import sys
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock neo4j and agent_tooling for importing agents.memory / core.memory_expiry."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"id": "test-id-123"}
+    mock_session.run.return_value = mock_result
+    return mock_driver
+
+
+def _make_mock_driver_with_expired_records(records: list[dict]) -> MagicMock:
+    """Create a mock Neo4j driver that returns expired records from the sweep query."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_query_result = MagicMock()
+    mock_query_result.__iter__ = MagicMock(return_value=iter(records))
+    mock_delete_result = MagicMock()
+
+    mock_session.run.side_effect = [mock_query_result] + [mock_delete_result] * len(records)
+    return mock_driver
+
+
+class TestExpiredNonRecurringDeletion:
+    """Integration test: expired non-recurring entries are deleted."""
+
+    def test_expired_non_recurring_entry_is_deleted(self) -> None:
+        past = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        records = [
+            {
+                "content": "Doctor appointment at 2pm",
+                "expires_at": past,
+                "recurring": False,
+                "id": "element-id-1",
+            },
+        ]
+        mock_driver = _make_mock_driver_with_expired_records(records)
+
+        from core import memory_expiry
+
+        with (
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(memory_expiry, "_telegram_direct"),
+        ):
+            result = memory_expiry.sweep_expired_events()
+
+        assert result["deleted"] == 1
+        assert result["prompted"] == 0
+        assert result["errors"] == 0
+
+        # Verify the delete Cypher was called with the correct element ID
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        # Second call should be the delete
+        delete_call = mock_session.run.call_args_list[1]
+        assert "DETACH DELETE" in delete_call[0][0]
+        assert delete_call[1]["id"] == "element-id-1"
+
+
+class TestExpiredRecurringTelegramPrompt:
+    """Integration test: expired recurring entries trigger Telegram prompt."""
+
+    def test_expired_recurring_entry_triggers_telegram(self) -> None:
+        past = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        records = [
+            {
+                "content": "Mom's birthday dinner",
+                "expires_at": past,
+                "recurring": True,
+                "id": "element-id-2",
+            },
+        ]
+        mock_driver = _make_mock_driver_with_expired_records(records)
+
+        from core import memory_expiry
+
+        with (
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(memory_expiry, "_telegram_direct", return_value=(True, "sent")) as mock_tg,
+        ):
+            result = memory_expiry.sweep_expired_events()
+
+        assert result["prompted"] == 1
+        assert result["deleted"] == 0
+
+        # Verify Telegram message contains event content
+        mock_tg.assert_called_once()
+        msg = mock_tg.call_args[0][0]
+        assert "Mom's birthday dinner" in msg
+
+        # Verify the node was NOT deleted (no delete Cypher after the query)
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        # Only one call: the query. No second call for delete.
+        assert len(mock_session.run.call_args_list) == 1
+
+
+class TestMemoryStoreExpiresAtValidation:
+    """Integration test: memory_store rejects unresolved expires_at."""
+
+    def test_memory_store_rejects_unresolved_expires_at(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Meet at coffee shop",
+                data_class="timed-event",
+                source="user",
+                expires_at="next Friday",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is False
+            assert "resolved absolute ISO datetime" in result.get("error", "")
+
+
+class TestMemoryStoreRecurringFromContent:
+    """Integration test: memory_store sets recurring=True from content keywords."""
+
+    def test_memory_store_sets_recurring_from_content(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Mom's birthday dinner at Olive Garden",
+                data_class="timed-event",
+                source="user",
+                expires_at="2026-04-01T18:00:00Z",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+
+            # Check that recurring=True was passed to Neo4j
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["recurring"] is True

--- a/tests/unit/test_memory_expiry.py
+++ b/tests/unit/test_memory_expiry.py
@@ -1,0 +1,358 @@
+"""Unit tests for memory expiry: recurring detection, expires_at validation, and build_metadata integration."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_neo4j_and_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure agents.memory can be imported by mocking neo4j and keyring."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+# ---------------------------------------------------------------------------
+# Step 1: detect_recurring tests
+# ---------------------------------------------------------------------------
+class TestDetectRecurring:
+    """Tests for the detect_recurring function in core.memory_schema."""
+
+    def test_detect_recurring_birthday_returns_true(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("Mom's birthday party") is True
+
+    def test_detect_recurring_anniversary_returns_true(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("Wedding anniversary dinner") is True
+
+    def test_detect_recurring_weekly_returns_true(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("Weekly standup meeting") is True
+
+    def test_detect_recurring_monthly_returns_true(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("Monthly review") is True
+
+    def test_detect_recurring_annual_returns_true(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("Annual performance review") is True
+
+    def test_detect_recurring_every_returns_true(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("Every Tuesday yoga class") is True
+
+    def test_detect_recurring_keyword_recurring_returns_true(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("Recurring team sync") is True
+
+    def test_detect_recurring_no_keywords_returns_false(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("Doctor appointment tomorrow") is False
+
+    def test_detect_recurring_case_insensitive(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("BIRTHDAY celebration") is True
+
+    def test_detect_recurring_partial_word_annually_no_match(self) -> None:
+        from core.memory_schema import detect_recurring
+        # "annually" should NOT match "annual" with trailing word boundary
+        assert detect_recurring("I am annually reviewing") is False
+
+    def test_detect_recurring_word_annual_matches(self) -> None:
+        from core.memory_schema import detect_recurring
+        # "annual" as a standalone word should still match
+        assert detect_recurring("annual review meeting") is True
+
+    def test_detect_recurring_everyday_no_match(self) -> None:
+        from core.memory_schema import detect_recurring
+        # "everyday" should NOT match "every" -- trailing \b prevents it
+        assert detect_recurring("This is an everyday task") is False
+
+    def test_detect_recurring_everything_no_match(self) -> None:
+        from core.memory_schema import detect_recurring
+        # "everything" should NOT match "every" -- trailing \b prevents it
+        assert detect_recurring("everything is fine") is False
+
+    def test_detect_recurring_every_standalone_matches(self) -> None:
+        from core.memory_schema import detect_recurring
+        # "every" as standalone word should still match
+        assert detect_recurring("every morning jog") is True
+
+    def test_detect_recurring_empty_string(self) -> None:
+        from core.memory_schema import detect_recurring
+        assert detect_recurring("") is False
+
+
+# ---------------------------------------------------------------------------
+# Step 2: validate_expires_at tests
+# ---------------------------------------------------------------------------
+class TestValidateExpiresAt:
+    """Tests for the validate_expires_at function in core.memory_schema."""
+
+    def test_validate_expires_at_valid_iso_returns_string(self) -> None:
+        from core.memory_schema import validate_expires_at
+        result = validate_expires_at("2026-04-01T15:00:00Z")
+        assert isinstance(result, str)
+
+    def test_validate_expires_at_with_timezone_offset(self) -> None:
+        from core.memory_schema import validate_expires_at
+        result = validate_expires_at("2026-04-01T15:00:00-05:00")
+        assert isinstance(result, str)
+
+    def test_validate_expires_at_no_timezone_returns_string(self) -> None:
+        from core.memory_schema import validate_expires_at
+        result = validate_expires_at("2026-04-01T15:00:00")
+        assert isinstance(result, str)
+
+    def test_validate_expires_at_invalid_format_raises(self) -> None:
+        from core.memory_schema import validate_expires_at
+        with pytest.raises(ValueError, match="resolved absolute ISO datetime"):
+            validate_expires_at("next Tuesday at 3pm")
+
+    def test_validate_expires_at_relative_time_raises(self) -> None:
+        from core.memory_schema import validate_expires_at
+        with pytest.raises(ValueError):
+            validate_expires_at("tomorrow")
+
+    def test_validate_expires_at_empty_string_raises(self) -> None:
+        from core.memory_schema import validate_expires_at
+        with pytest.raises(ValueError):
+            validate_expires_at("")
+
+    def test_validate_expires_at_date_only_raises(self) -> None:
+        from core.memory_schema import validate_expires_at
+        with pytest.raises(ValueError):
+            validate_expires_at("2026-04-01")
+
+
+# ---------------------------------------------------------------------------
+# Step 3: build_metadata integration with recurring and expires_at validation
+# ---------------------------------------------------------------------------
+class TestBuildMetadataTimedEventExpiry:
+    """Tests for build_metadata with timed-event recurring/expires_at integration."""
+
+    def test_build_metadata_timed_event_validates_expires_format(self) -> None:
+        from core.memory_schema import build_metadata
+        with pytest.raises(ValueError):
+            build_metadata(
+                data_class="timed-event",
+                source="user",
+                expires_at="next Tuesday",
+            )
+
+    def test_build_metadata_timed_event_valid_expires_passes(self) -> None:
+        from core.memory_schema import build_metadata
+        result = build_metadata(
+            data_class="timed-event",
+            source="user",
+            expires_at="2026-04-01T15:00:00Z",
+        )
+        assert "expires_at" in result
+        assert "recurring" in result
+
+    def test_build_metadata_timed_event_recurring_from_content(self) -> None:
+        from core.memory_schema import build_metadata
+        result = build_metadata(
+            data_class="timed-event",
+            source="user",
+            expires_at="2026-04-01T15:00:00Z",
+            content="Mom's birthday dinner",
+        )
+        assert result["recurring"] is True
+
+    def test_build_metadata_timed_event_not_recurring_by_default(self) -> None:
+        from core.memory_schema import build_metadata
+        result = build_metadata(
+            data_class="timed-event",
+            source="user",
+            expires_at="2026-04-01T15:00:00Z",
+            content="Doctor appointment",
+        )
+        assert result["recurring"] is False
+
+    def test_build_metadata_timed_event_explicit_recurring_override(self) -> None:
+        from core.memory_schema import build_metadata
+        result = build_metadata(
+            data_class="timed-event",
+            source="user",
+            expires_at="2026-04-01T15:00:00Z",
+            content="Doctor appointment",
+            recurring=True,
+        )
+        assert result["recurring"] is True
+
+    def test_build_metadata_non_timed_event_ignores_recurring(self) -> None:
+        from core.memory_schema import build_metadata
+        result = build_metadata(data_class="person", source="user")
+        assert "recurring" not in result
+
+    def test_build_metadata_timed_event_no_content_defaults_recurring_false(self) -> None:
+        from core.memory_schema import build_metadata
+        result = build_metadata(
+            data_class="timed-event",
+            source="user",
+            expires_at="2026-04-01T15:00:00Z",
+        )
+        assert result["recurring"] is False
+
+    def test_build_metadata_timed_event_no_content_explicit_recurring_true(self) -> None:
+        from core.memory_schema import build_metadata
+        result = build_metadata(
+            data_class="timed-event",
+            source="user",
+            expires_at="2026-04-01T15:00:00Z",
+            recurring=True,
+        )
+        assert result["recurring"] is True
+
+
+# ---------------------------------------------------------------------------
+# Step 4: memory_store / memory_store_direct with recurring parameter
+# ---------------------------------------------------------------------------
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver with session and run mocked."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"id": "test-id-123"}
+    mock_session.run.return_value = mock_result
+    return mock_driver
+
+
+class TestMemoryStoreDirectRecurring:
+    """Tests for memory_store_direct with recurring parameter."""
+
+    def test_memory_store_direct_timed_event_with_recurring_stores_property(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Mom's birthday dinner",
+                data_class="timed-event",
+                source="user",
+                expires_at="2026-04-01T15:00:00Z",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["recurring"] is True
+
+    def test_memory_store_direct_timed_event_explicit_recurring_false(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Mom's birthday dinner",
+                data_class="timed-event",
+                source="user",
+                expires_at="2026-04-01T15:00:00Z",
+                recurring=False,
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["recurring"] is False
+
+    def test_memory_store_direct_timed_event_without_expires_returns_error(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Meeting at 3pm",
+                data_class="timed-event",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is False
+
+    def test_memory_store_direct_timed_event_invalid_expires_returns_error(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Meeting next Friday",
+                data_class="timed-event",
+                source="user",
+                expires_at="next Friday",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is False
+
+    def test_memory_store_direct_non_timed_event_no_recurring_property(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="Daniel is a person",
+                data_class="person",
+                source="user",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            # For non-timed-event, recurring should not be present or should be None
+            assert params.get("recurring") is None
+
+    def test_memory_store_timed_event_hitl_approved_stores_recurring(self) -> None:
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_hitl_gate", return_value=True),
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store(
+                content="Mom's birthday dinner",
+                data_class="timed-event",
+                source="user",
+                expires_at="2026-04-01T15:00:00Z",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["recurring"] is True

--- a/tests/unit/test_memory_expiry_scheduler.py
+++ b/tests/unit/test_memory_expiry_scheduler.py
@@ -1,0 +1,115 @@
+"""Unit tests for the memory expiry sweep scheduler integration."""
+
+import logging
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock third-party dependencies for importing clients.scheduler."""
+    # Remove cached scheduler module so it gets reimported with our mocks
+    for mod_name in list(sys.modules.keys()):
+        if mod_name.startswith("clients.scheduler"):
+            del sys.modules[mod_name]
+
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+    # Mock apscheduler modules
+    apscheduler_mock = MagicMock()
+    apscheduler_schedulers_mock = MagicMock()
+    apscheduler_schedulers_asyncio_mock = MagicMock()
+    apscheduler_triggers_mock = MagicMock()
+    apscheduler_triggers_cron_mock = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "apscheduler", apscheduler_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.schedulers", apscheduler_schedulers_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.schedulers.asyncio", apscheduler_schedulers_asyncio_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers", apscheduler_triggers_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers.cron", apscheduler_triggers_cron_mock)
+
+
+class TestMemoryExpirySweepScheduler:
+    """Tests for _memory_expiry_sweep in clients.scheduler."""
+
+    @pytest.mark.asyncio
+    async def test_memory_expiry_sweep_calls_endpoint(self) -> None:
+        """Assert that _memory_expiry_sweep POSTs to /memory/expiry-sweep with auth."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"deleted": 1, "prompted": 0, "errors": 0})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _memory_expiry_sweep
+            await _memory_expiry_sweep()
+
+            mock_session.post.assert_called_once()
+            call_args = mock_session.post.call_args
+            assert "/memory/expiry-sweep" in call_args[0][0]
+            assert call_args[1]["headers"]["X-HITL-Internal"] == "test-token"
+
+    @pytest.mark.asyncio
+    async def test_memory_expiry_sweep_logs_results(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Assert that sweep results are logged."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"deleted": 2, "prompted": 1, "errors": 0})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg, \
+             caplog.at_level(logging.INFO, logger="hive-mind-scheduler"):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _memory_expiry_sweep
+            await _memory_expiry_sweep()
+
+        assert any("deleted=2" in record.message for record in caplog.records)
+        assert any("prompted=1" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_memory_expiry_sweep_handles_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Assert that sweep failure is handled gracefully."""
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(side_effect=Exception("Connection refused"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg, \
+             caplog.at_level(logging.ERROR, logger="hive-mind-scheduler"):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _memory_expiry_sweep
+            # Should not raise
+            await _memory_expiry_sweep()
+
+        assert any("failed" in record.message.lower() for record in caplog.records)

--- a/tests/unit/test_memory_expiry_sweep.py
+++ b/tests/unit/test_memory_expiry_sweep.py
@@ -1,0 +1,198 @@
+"""Unit tests for the memory expiry sweep module (core.memory_expiry)."""
+
+import logging
+import sys
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock neo4j, agent_tooling, and keyring for importing agents.memory / core.memory_expiry."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_expired_record(
+    content: str,
+    expires_at: str,
+    recurring: bool,
+    element_id: str = "test-id-1",
+) -> dict:
+    """Create a mock record matching the sweep query result shape."""
+    return {
+        "content": content,
+        "expires_at": expires_at,
+        "recurring": recurring,
+        "id": element_id,
+    }
+
+
+def _make_mock_driver_with_results(records: list[dict]) -> MagicMock:
+    """Create a mock Neo4j driver that returns given records from the query."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+    # The first run call is the query; subsequent calls are deletes
+    mock_query_result = MagicMock()
+    mock_query_result.__iter__ = MagicMock(return_value=iter(records))
+
+    mock_delete_result = MagicMock()
+
+    # First call returns query results, all subsequent calls return delete results
+    mock_session.run.side_effect = [mock_query_result] + [mock_delete_result] * len(records)
+
+    return mock_driver
+
+
+class TestSweepExpiredEvents:
+    """Tests for sweep_expired_events in core.memory_expiry."""
+
+    def test_sweep_deletes_expired_non_recurring_events(self) -> None:
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        records = [
+            _make_expired_record("Meeting at 3pm", past, False, "id-1"),
+            _make_expired_record("Dentist appointment", past, False, "id-2"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import memory_expiry
+
+        with (
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(memory_expiry, "_telegram_direct") as mock_telegram,
+        ):
+            result = memory_expiry.sweep_expired_events()
+
+        assert result["deleted"] == 2
+        assert result["prompted"] == 0
+        assert result["errors"] == 0
+        mock_telegram.assert_not_called()
+
+    def test_sweep_prompts_for_expired_recurring_events(self) -> None:
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        records = [
+            _make_expired_record("Mom's birthday dinner", past, True, "id-1"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import memory_expiry
+
+        with (
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(memory_expiry, "_telegram_direct", return_value=(True, "sent")) as mock_telegram,
+        ):
+            result = memory_expiry.sweep_expired_events()
+
+        assert result["deleted"] == 0
+        assert result["prompted"] == 1
+        assert result["errors"] == 0
+        mock_telegram.assert_called_once()
+        # Check the message contains the event content
+        call_msg = mock_telegram.call_args[0][0]
+        assert "Mom's birthday dinner" in call_msg
+
+    def test_sweep_mixed_expired_events(self) -> None:
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        records = [
+            _make_expired_record("Meeting at 3pm", past, False, "id-1"),
+            _make_expired_record("Dentist appointment", past, False, "id-2"),
+            _make_expired_record("Mom's birthday dinner", past, True, "id-3"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import memory_expiry
+
+        with (
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(memory_expiry, "_telegram_direct", return_value=(True, "sent")),
+        ):
+            result = memory_expiry.sweep_expired_events()
+
+        assert result["deleted"] == 2
+        assert result["prompted"] == 1
+        assert result["errors"] == 0
+
+    def test_sweep_no_expired_events(self) -> None:
+        mock_driver = _make_mock_driver_with_results([])
+
+        from core import memory_expiry
+
+        with (
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(memory_expiry, "_telegram_direct"),
+        ):
+            result = memory_expiry.sweep_expired_events()
+
+        assert result["deleted"] == 0
+        assert result["prompted"] == 0
+        assert result["errors"] == 0
+
+    def test_sweep_logs_deletions(self, caplog: pytest.LogCaptureFixture) -> None:
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        records = [
+            _make_expired_record("Meeting at 3pm", past, False, "id-1"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import memory_expiry
+
+        with (
+            caplog.at_level(logging.INFO, logger="core.memory_expiry"),
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(memory_expiry, "_telegram_direct"),
+        ):
+            memory_expiry.sweep_expired_events()
+
+        assert any("Meeting at 3pm" in record.message for record in caplog.records)
+
+    def test_sweep_handles_neo4j_error_gracefully(self) -> None:
+        mock_driver = MagicMock()
+        mock_session = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.run.side_effect = Exception("Neo4j connection lost")
+
+        from core import memory_expiry
+
+        with (
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(memory_expiry, "_telegram_direct"),
+        ):
+            result = memory_expiry.sweep_expired_events()
+
+        assert result["deleted"] == 0
+        assert result["prompted"] == 0
+        assert result["errors"] == 1
+
+    def test_sweep_telegram_failure_does_not_block(self) -> None:
+        past = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        records = [
+            _make_expired_record("Mom's birthday dinner", past, True, "id-1"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import memory_expiry
+
+        with (
+            patch.object(memory_expiry, "_get_driver", return_value=mock_driver),
+            patch.object(
+                memory_expiry, "_telegram_direct",
+                side_effect=Exception("Telegram API down"),
+            ),
+        ):
+            result = memory_expiry.sweep_expired_events()
+
+        # Sweep completes despite Telegram failure; recurring entry NOT deleted
+        assert result["deleted"] == 0
+        assert result["prompted"] == 0
+        assert result["errors"] == 1


### PR DESCRIPTION
## Summary

- Adds write-time validation for `timed-event` entries: requires a resolved absolute ISO datetime for `expires_at`, rejects relative/unresolved time references with an actionable error
- Implements recurring event detection via keyword heuristics (birthday, anniversary, weekly, monthly, annual, every, recurring) with explicit `recurring=True/False` override support
- Adds nightly expiry sweep (`/memory/expiry-sweep` endpoint + scheduler job at 3:30 AM CT) that deletes expired non-recurring entries and sends Telegram prompts to Daniel for expired recurring entries

## Acceptance Criteria

- [x] `memory_store` rejects `timed-event` entries without a resolved absolute `expires_at` datetime
- [x] Invalid time references in content trigger an error prompting reclassification or discard
- [x] `recurring` boolean flag is set on timed-event entries (default `False`)
- [x] Nightly scheduler job queries all `timed-event` entries where `expires_at < now`
- [x] Non-recurring entries are deleted unconditionally
- [x] Recurring entries trigger a Telegram prompt to Daniel asking to delete or keep for next occurrence
- [x] All deletions are logged
- [x] Recurring events detected via keyword heuristics (birthday, anniversary, weekly, monthly, annual, every, recurring)
- [x] Manual override via explicit `recurring=True` at write time is supported
- [x] Unit tests cover nightly job deletion of expired non-recurring events
- [x] Unit tests cover nightly job Telegram prompt for expired recurring events
- [x] Unit tests verify `memory_store` rejection of entries with unresolved time references

## Test Plan

- Unit tests for recurring keyword detection (15 cases including boundary/partial-word)
- Unit tests for `validate_expires_at` (valid ISO, timezone offsets, invalid/relative/empty/date-only)
- Unit tests for `build_metadata` integration with recurring flag and expires_at validation
- Unit tests for `memory_store_direct` and `memory_store` with recurring parameter
- Unit tests for sweep module: deletion, Telegram prompts, mixed events, error handling
- Unit tests for scheduler integration: endpoint call, logging, failure handling
- Integration tests: end-to-end expired non-recurring deletion, recurring Telegram prompt, store validation
- API tests: endpoint auth, response codes, counts, asyncio.to_thread usage

Implemented autonomously by Ada -- Hive Mind