### PR TITLE
[Memory] Technical-Config Pruning — Code Verification Pass

### DIFF
--- a/agents/memory.py
+++ b/agents/memory.py
@@ -114,6 +114,7 @@ def memory_store_direct(
     as_of: str | None = None,
     expires_at: str | None = None,
     recurring: bool | None = None,
+    codebase_ref: str | None = None,
 ) -> str:
     """Write to vector memory without HITL. Called by the epilogue after batch approval."""
     try:
@@ -153,7 +154,8 @@ def memory_store_direct(
                     as_of: $as_of,
                     expires_at: $expires_at,
                     superseded: $superseded,
-                    recurring: $recurring
+                    recurring: $recurring,
+                    codebase_ref: $codebase_ref
                 })
                 RETURN elementId(m) AS id
                 """,
@@ -169,6 +171,7 @@ def memory_store_direct(
                 expires_at=meta.get("expires_at"),
                 superseded=meta.get("superseded", False),
                 recurring=meta.get("recurring"),
+                codebase_ref=codebase_ref,
             )
             record = result.single()
             memory_id = record["id"] if record else "unknown"
@@ -194,6 +197,7 @@ def memory_store(
     as_of: str | None = None,
     expires_at: str | None = None,
     recurring: bool | None = None,
+    codebase_ref: str | None = None,
 ) -> str:
     """Store a memory as a semantic embedding in Neo4j.
 
@@ -206,6 +210,9 @@ def memory_store(
         as_of: ISO datetime for when the fact was established (defaults to now)
         expires_at: ISO datetime for when a timed-event expires (required for timed-event)
         recurring: Explicit recurring flag for timed-events (overrides heuristic detection)
+        codebase_ref: Optional file path or symbol reference in the codebase this entry
+            is about (e.g. "core/sessions.py", "SessionManager.send_message"). Used by
+            the technical-config pruning pass to verify accuracy.
 
     Returns:
         JSON with the stored memory ID and confirmation.
@@ -223,6 +230,7 @@ def memory_store(
             as_of=as_of,
             expires_at=expires_at,
             recurring=recurring,
+            codebase_ref=codebase_ref,
         )
     except Exception as e:
         logger.exception("memory_store failed")
@@ -270,6 +278,7 @@ def memory_retrieve(
                            m.as_of AS as_of,
                            m.expires_at AS expires_at,
                            m.superseded AS superseded,
+                           m.codebase_ref AS codebase_ref,
                            score
                     ORDER BY score DESC
                     """,
@@ -295,6 +304,7 @@ def memory_retrieve(
                            m.as_of AS as_of,
                            m.expires_at AS expires_at,
                            m.superseded AS superseded,
+                           m.codebase_ref AS codebase_ref,
                            score
                     ORDER BY score DESC
                     """,
@@ -316,6 +326,7 @@ def memory_retrieve(
                     "as_of": record["as_of"],
                     "expires_at": record["expires_at"],
                     "superseded": record["superseded"],
+                    "codebase_ref": record["codebase_ref"],
                 }
                 for record in result
             ]

--- a/clients/scheduler.py
+++ b/clients/scheduler.py
@@ -185,6 +185,26 @@ async def _orphan_sweep() -> None:
         log.exception("Orphan sweep failed")
 
 
+async def _techconfig_sweep() -> None:
+    """Call the gateway's techconfig sweep endpoint to verify technical-config entries."""
+    log.info("Running technical-config pruning sweep")
+    try:
+        timeout = aiohttp.ClientTimeout(total=300)
+        headers = {"X-HITL-Internal": config.hitl_internal_token or ""}
+        async with aiohttp.ClientSession(timeout=timeout) as http:
+            async with http.post(f"{SERVER_URL}/memory/techconfig-sweep", headers=headers) as resp:
+                data = await resp.json()
+                log.info(
+                    "Techconfig sweep: verified=%d, pruned=%d, flagged=%d, errors=%d",
+                    data.get("verified", 0),
+                    data.get("pruned", 0),
+                    data.get("flagged", 0),
+                    data.get("errors", 0),
+                )
+    except Exception:
+        log.exception("Technical-config pruning sweep failed")
+
+
 async def _epilogue_sweep() -> None:
     """Call the gateway's epilogue sweep endpoint to process unprocessed dead sessions."""
     log.info("Running epilogue sweep")
@@ -242,8 +262,13 @@ async def main() -> None:
     scheduler.add_job(_orphan_sweep, orphan_trigger, id="orphan-sweep")
     log.info("Scheduled orphan sweep @ 45 3 * * *")
 
+    # Add techconfig pruning sweep job (weekly, Sunday at 4:00 AM CT)
+    techconfig_trigger = CronTrigger(hour="4", minute="0", day_of_week="sun", timezone="America/Chicago")
+    scheduler.add_job(_techconfig_sweep, techconfig_trigger, id="techconfig-sweep")
+    log.info("Scheduled technical-config pruning sweep @ 0 4 * * 0")
+
     scheduler.start()
-    log.info("Scheduler running — %d job(s) active + epilogue sweep + memory expiry sweep + orphan sweep", len(config.scheduled_tasks))
+    log.info("Scheduler running — %d job(s) active + epilogue sweep + memory expiry sweep + orphan sweep + techconfig sweep", len(config.scheduled_tasks))
 
     await asyncio.Event().wait()  # run forever
 

--- a/core/techconfig_pruning.py
+++ b/core/techconfig_pruning.py
@@ -1,0 +1,149 @@
+"""Technical-config pruning sweep -- verifies stored facts against the codebase.
+
+Queries Neo4j for all data_class=technical-config entries, runs verification
+heuristics, marks inaccurate entries as superseded, and sends a Telegram summary.
+
+Called by the scheduler via the /memory/techconfig-sweep gateway endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from core.techconfig_verifier import verify_entry
+
+logger = logging.getLogger(__name__)
+
+
+def _get_driver():
+    """Lazy import to avoid circular dependency and allow mocking."""
+    from agents.memory import _get_driver as _mem_get_driver
+    return _mem_get_driver()
+
+
+def _telegram_direct(message: str) -> tuple[bool, str]:
+    """Lazy import of the Telegram direct send function."""
+    from agents.notify import _telegram_direct as _notify_telegram
+    return _notify_telegram(message)
+
+
+def sweep_techconfig_entries() -> dict:
+    """Query Neo4j for technical-config entries and verify against codebase.
+
+    For each entry:
+    - verified: no change, count incremented
+    - pruned: set superseded=True in Neo4j
+    - flagged: no change, collected for review message
+
+    Returns:
+        Summary dict with keys: verified, pruned, flagged, errors.
+    """
+    verified = 0
+    pruned = 0
+    flagged = 0
+    errors = 0
+    flagged_entries: list[str] = []
+
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (m:Memory)
+                WHERE m.data_class = 'technical-config'
+                  AND (m.superseded IS NULL OR m.superseded = false)
+                RETURN m.content AS content,
+                       m.codebase_ref AS codebase_ref,
+                       elementId(m) AS id
+                """
+            )
+
+            for record in result:
+                content = record["content"]
+                codebase_ref = record["codebase_ref"]
+                element_id = record["id"]
+
+                try:
+                    vr = verify_entry(content, element_id, codebase_ref)
+
+                    if vr.status == "verified":
+                        verified += 1
+                        logger.info(
+                            "Verified: %s (ref=%s)",
+                            content[:80],
+                            codebase_ref,
+                        )
+                    elif vr.status == "pruned":
+                        try:
+                            session.run(
+                                "MATCH (m) WHERE elementId(m) = $id SET m.superseded = true",
+                                id=element_id,
+                            )
+                            pruned += 1
+                            logger.info(
+                                "Pruned (superseded): %s (reason=%s)",
+                                content[:80],
+                                vr.reason,
+                            )
+                        except Exception:
+                            logger.exception(
+                                "Failed to mark entry as superseded: %s",
+                                element_id,
+                            )
+                            errors += 1
+                    elif vr.status == "flagged":
+                        flagged += 1
+                        flagged_entries.append(
+                            f"- {content[:200]}\n  Reason: {vr.reason}"
+                        )
+                        logger.info(
+                            "Flagged for review: %s (reason=%s)",
+                            content[:80],
+                            vr.reason,
+                        )
+                except Exception:
+                    logger.exception(
+                        "Error verifying entry %s: %s",
+                        element_id,
+                        content[:80],
+                    )
+                    errors += 1
+
+    except Exception:
+        logger.exception("Technical-config pruning sweep failed")
+        errors += 1
+
+    # Send Telegram summary if there were any results
+    total = verified + pruned + flagged
+    if total > 0:
+        summary = (
+            f"Technical-config pruning sweep complete:\n\n"
+            f"Verified: {verified}\n"
+            f"Pruned: {pruned}\n"
+            f"Flagged: {flagged}\n"
+            f"Errors: {errors}"
+        )
+        try:
+            _telegram_direct(summary)
+        except Exception:
+            logger.exception("Failed to send techconfig sweep summary via Telegram")
+
+        # Send flagged entries in a separate message
+        if flagged_entries:
+            flagged_msg = (
+                f"Flagged entries for review ({flagged}):\n\n"
+                + "\n\n".join(flagged_entries)
+            )
+            try:
+                _telegram_direct(flagged_msg)
+            except Exception:
+                logger.exception("Failed to send flagged entries via Telegram")
+
+    logger.info(
+        "Technical-config pruning sweep complete: verified=%d, pruned=%d, flagged=%d, errors=%d",
+        verified,
+        pruned,
+        flagged,
+        errors,
+    )
+    return {"verified": verified, "pruned": pruned, "flagged": flagged, "errors": errors}

--- a/core/techconfig_verifier.py
+++ b/core/techconfig_verifier.py
@@ -1,0 +1,346 @@
+"""Technical-config memory entry verifier.
+
+Verifies whether a stored technical-config memory entry is still accurate
+by checking the codebase for file existence and symbol presence.
+
+Uses lightweight heuristics only -- no Claude session spawning.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+PROJECT_DIR = Path("/usr/src/app")
+
+# Regex to find file paths in content (e.g. server.py, core/sessions.py, config.yaml)
+_FILE_REF_PATTERN = re.compile(
+    r"(?:^|[\s`\"'(,])("
+    r"(?:[\w./-]+/)?"        # optional directory prefix
+    r"[\w.-]+"               # filename stem
+    r"\."                    # dot separator
+    r"(?:py|yaml|yml|json|toml|cfg|txt|md|sh)"  # known extensions
+    r")(?:[\s`\"'),.:;]|$)",
+    re.MULTILINE,
+)
+
+# Regex to find likely symbol names: function names (word_word), class names (CamelCase),
+# config keys (UPPER_CASE), dotted references (module.attr)
+_KEYWORD_PATTERN = re.compile(
+    r"\b("
+    r"[a-z_][a-z0-9_]{2,}"     # snake_case identifiers (min 3 chars)
+    r"|[A-Z][a-zA-Z0-9]{2,}"   # CamelCase or UPPER identifiers
+    r"|[A-Z_]{3,}"             # UPPER_CASE constants
+    r")\b"
+)
+
+# Common English words to exclude from keyword extraction
+_STOP_WORDS = frozenset({
+    "the", "and", "for", "that", "this", "with", "from", "are", "was",
+    "were", "been", "have", "has", "had", "not", "but", "all", "can",
+    "will", "each", "which", "when", "what", "where", "how", "use",
+    "uses", "used", "using", "set", "get", "run", "runs", "new",
+    "also", "via", "its", "into", "one", "two", "any", "per",
+    "does", "file", "files", "name", "path", "true", "false",
+    "none", "null", "default", "value", "values", "type", "types",
+    "class", "def", "return", "import", "module", "function",
+})
+
+
+@dataclass
+class VerificationResult:
+    """Result of verifying a single technical-config memory entry."""
+
+    status: str          # "verified" | "pruned" | "flagged"
+    reason: str          # Human-readable explanation
+    content: str         # Original memory content
+    element_id: str      # Neo4j element ID
+    codebase_ref: str | None  # Original codebase_ref if any
+
+
+def _extract_file_references(content: str) -> list[str]:
+    """Extract file path references from content text.
+
+    Finds patterns like server.py, core/sessions.py, config.yaml.
+
+    Args:
+        content: The text content to scan.
+
+    Returns:
+        List of file path strings found in the content.
+    """
+    matches = _FILE_REF_PATTERN.findall(content)
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    result: list[str] = []
+    for match in matches:
+        if match not in seen:
+            seen.add(match)
+            result.append(match)
+    return result
+
+
+def _extract_keywords(content: str) -> list[str]:
+    """Extract likely symbol names from content text.
+
+    Pulls function names, class names, config keys, etc.
+
+    Args:
+        content: The text content to scan.
+
+    Returns:
+        List of keyword strings found in the content.
+    """
+    matches = _KEYWORD_PATTERN.findall(content)
+    # Filter out common stop words and short matches
+    seen: set[str] = set()
+    result: list[str] = []
+    for match in matches:
+        lower = match.lower()
+        if lower not in _STOP_WORDS and match not in seen:
+            seen.add(match)
+            result.append(match)
+    return result
+
+
+def _is_path_within_project(filepath: str) -> bool:
+    """Check that a resolved path stays within PROJECT_DIR.
+
+    Prevents CWE-22 path traversal by resolving symlinks and relative
+    segments, then asserting the result is under PROJECT_DIR.
+
+    Args:
+        filepath: Relative path from project root.
+
+    Returns:
+        True if the resolved path is within PROJECT_DIR, False otherwise.
+    """
+    resolved = os.path.realpath(PROJECT_DIR / filepath)
+    return resolved.startswith(str(PROJECT_DIR) + os.sep) or resolved == str(PROJECT_DIR)
+
+
+def _check_file_exists(filepath: str) -> bool:
+    """Check if a file exists relative to the project directory.
+
+    Args:
+        filepath: Relative path from project root.
+
+    Returns:
+        True if the file exists, False otherwise.
+        Returns False if the path resolves outside PROJECT_DIR.
+    """
+    if not _is_path_within_project(filepath):
+        logger.warning("Path traversal blocked in _check_file_exists: %s", filepath)
+        return False
+    return os.path.isfile(PROJECT_DIR / filepath)
+
+
+def _check_symbol_in_file(filepath: str, symbol: str) -> bool:
+    """Check if a symbol appears in a specific file using grep.
+
+    Args:
+        filepath: Relative path from project root.
+        symbol: The symbol string to search for.
+
+    Returns:
+        True if the symbol is found in the file, False otherwise.
+        Returns False if the path resolves outside PROJECT_DIR.
+    """
+    if not _is_path_within_project(filepath):
+        logger.warning("Path traversal blocked in _check_symbol_in_file: %s", filepath)
+        return False
+    try:
+        result = subprocess.run(
+            ["grep", "-q", symbol, str(PROJECT_DIR / filepath)],
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        logger.warning("Symbol check failed for %s in %s", symbol, filepath)
+        return False
+
+
+def _check_symbol_in_project(symbol: str) -> bool:
+    """Check if a symbol appears anywhere in the project using recursive grep.
+
+    Args:
+        symbol: The symbol string to search for.
+
+    Returns:
+        True if the symbol is found anywhere in the project, False otherwise.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "grep", "-rq",
+                "--exclude-dir=.git",
+                "--exclude-dir=backups",
+                "--exclude-dir=data",
+                "--exclude-dir=documents",
+                "--exclude-dir=__pycache__",
+                "--exclude-dir=.pylibs",
+                "--exclude-dir=node_modules",
+                symbol,
+                str(PROJECT_DIR),
+            ],
+            capture_output=True,
+            timeout=30,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, OSError):
+        logger.warning("Project-wide symbol check failed for %s", symbol)
+        return False
+
+
+def verify_entry(
+    content: str,
+    element_id: str,
+    codebase_ref: str | None,
+) -> VerificationResult:
+    """Verify a single technical-config memory entry against the codebase.
+
+    Decision tree:
+    1. If codebase_ref present and file exists: grep for keywords -> verified or pruned
+    2. If codebase_ref present and file missing: flagged
+    3. If codebase_ref absent: try to infer file from content, then grep keywords
+       If no inference possible, check project-wide; if still nothing, flagged
+
+    Args:
+        content: The memory entry content text.
+        element_id: The Neo4j element ID.
+        codebase_ref: Optional file path reference.
+
+    Returns:
+        VerificationResult with status, reason, and metadata.
+    """
+    # Edge case: empty content
+    if not content or not content.strip():
+        return VerificationResult(
+            status="flagged",
+            reason="Empty content -- cannot verify",
+            content=content,
+            element_id=element_id,
+            codebase_ref=codebase_ref,
+        )
+
+    keywords = _extract_keywords(content)
+
+    if codebase_ref:
+        # Validate codebase_ref does not escape PROJECT_DIR
+        if not _is_path_within_project(codebase_ref):
+            logger.warning("Path traversal blocked for codebase_ref: %s", codebase_ref)
+            return VerificationResult(
+                status="flagged",
+                reason=f"codebase_ref resolves outside project directory (path traversal blocked): {codebase_ref}",
+                content=content,
+                element_id=element_id,
+                codebase_ref=codebase_ref,
+            )
+
+        # Case 1: codebase_ref provided
+        if not _check_file_exists(codebase_ref):
+            return VerificationResult(
+                status="flagged",
+                reason=f"Referenced file does not exist: {codebase_ref}",
+                content=content,
+                element_id=element_id,
+                codebase_ref=codebase_ref,
+            )
+
+        # File exists -- check if keywords are present
+        if keywords:
+            found_any = any(
+                _check_symbol_in_file(codebase_ref, kw) for kw in keywords
+            )
+            if found_any:
+                return VerificationResult(
+                    status="verified",
+                    reason=f"File {codebase_ref} exists and keywords found",
+                    content=content,
+                    element_id=element_id,
+                    codebase_ref=codebase_ref,
+                )
+            else:
+                return VerificationResult(
+                    status="pruned",
+                    reason=f"File {codebase_ref} exists but keywords not found in file",
+                    content=content,
+                    element_id=element_id,
+                    codebase_ref=codebase_ref,
+                )
+        else:
+            # No keywords to check, but file exists -- verified (file reference alone is sufficient)
+            return VerificationResult(
+                status="verified",
+                reason=f"File {codebase_ref} exists (no keywords to verify)",
+                content=content,
+                element_id=element_id,
+                codebase_ref=codebase_ref,
+            )
+
+    # Case 2: no codebase_ref -- try to infer file from content
+    inferred_files = _extract_file_references(content)
+
+    if inferred_files:
+        # Try each inferred file
+        for filepath in inferred_files:
+            if _check_file_exists(filepath):
+                if keywords:
+                    found_any = any(
+                        _check_symbol_in_file(filepath, kw) for kw in keywords
+                    )
+                    if found_any:
+                        return VerificationResult(
+                            status="verified",
+                            reason=f"Inferred file {filepath} exists and keywords found",
+                            content=content,
+                            element_id=element_id,
+                            codebase_ref=codebase_ref,
+                        )
+                else:
+                    # File exists but no keywords to check
+                    return VerificationResult(
+                        status="verified",
+                        reason=f"Inferred file {filepath} exists (no keywords to verify)",
+                        content=content,
+                        element_id=element_id,
+                        codebase_ref=codebase_ref,
+                    )
+
+        # All inferred files either don't exist or keywords not found
+        if keywords:
+            return VerificationResult(
+                status="pruned",
+                reason="Inferred file(s) found but keywords not present",
+                content=content,
+                element_id=element_id,
+                codebase_ref=codebase_ref,
+            )
+
+    # Case 3: no codebase_ref, no file inference -- check project-wide
+    if keywords:
+        found_any = any(_check_symbol_in_project(kw) for kw in keywords)
+        if found_any:
+            return VerificationResult(
+                status="verified",
+                reason="No file reference but keywords found in project",
+                content=content,
+                element_id=element_id,
+                codebase_ref=codebase_ref,
+            )
+
+    # Nothing matched -- flag for human review
+    return VerificationResult(
+        status="flagged",
+        reason="Cannot verify: no file reference and keywords not found in project",
+        content=content,
+        element_id=element_id,
+        codebase_ref=codebase_ref,
+    )

--- a/server.py
+++ b/server.py
@@ -234,6 +234,21 @@ async def memory_orphan_sweep(x_hitl_internal: str = Header(None)):
 
 
 # ---------------------------------------------------------------------------
+# Technical-Config Pruning Sweep
+# ---------------------------------------------------------------------------
+@app.post("/memory/techconfig-sweep")
+async def memory_techconfig_sweep(x_hitl_internal: str = Header(None)):
+    """Trigger technical-config pruning sweep to verify stored facts against codebase."""
+    if not config.hitl_internal_token:
+        return JSONResponse({"error": "HITL not configured"}, status_code=500)
+    if x_hitl_internal != config.hitl_internal_token:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    from core.techconfig_pruning import sweep_techconfig_entries
+    results = await asyncio.to_thread(sweep_techconfig_entries)
+    return results
+
+
+# ---------------------------------------------------------------------------
 # Epilogue sweep endpoint
 # ---------------------------------------------------------------------------
 @app.post("/epilogue/sweep")

--- a/tests/api/test_techconfig_sweep.py
+++ b/tests/api/test_techconfig_sweep.py
@@ -1,0 +1,65 @@
+"""API tests for the /memory/techconfig-sweep endpoint."""
+
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+_AUTH_HEADER = {"X-HITL-Internal": "test-token"}
+
+
+class TestTechconfigSweepEndpoint:
+    """Tests for POST /memory/techconfig-sweep."""
+
+    def test_techconfig_sweep_endpoint_returns_200(self) -> None:
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg, \
+             patch("core.techconfig_pruning.sweep_techconfig_entries", return_value={"verified": 1, "pruned": 0, "flagged": 0, "errors": 0}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/techconfig-sweep", headers=_AUTH_HEADER)
+            assert response.status_code == 200
+
+    def test_techconfig_sweep_rejects_missing_token(self) -> None:
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/techconfig-sweep")
+            assert response.status_code == 401
+
+    def test_techconfig_sweep_rejects_wrong_token(self) -> None:
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/techconfig-sweep",
+                headers={"X-HITL-Internal": "wrong-token"},
+            )
+            assert response.status_code == 401
+
+    def test_techconfig_sweep_returns_result_counts(self) -> None:
+        with patch("server.session_mgr") as mock_mgr, \
+             patch("server.config") as mock_cfg, \
+             patch("core.techconfig_pruning.sweep_techconfig_entries", return_value={"verified": 5, "pruned": 2, "flagged": 1, "errors": 0}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/techconfig-sweep", headers=_AUTH_HEADER)
+            data = response.json()
+            assert "verified" in data
+            assert "pruned" in data
+            assert "flagged" in data
+            assert "errors" in data
+            assert data["verified"] == 5
+            assert data["pruned"] == 2
+            assert data["flagged"] == 1
+            assert data["errors"] == 0

--- a/tests/integration/test_memory_metadata_flow.py
+++ b/tests/integration/test_memory_metadata_flow.py
@@ -76,6 +76,7 @@ class TestStoreRetrieveMetadataFlow:
             "as_of": "2026-01-01T00:00:00Z",
             "expires_at": None,
             "superseded": False,
+            "codebase_ref": None,
         }[key]
         retrieve_result_mock = MagicMock()
         retrieve_result_mock.__iter__ = MagicMock(return_value=iter([record_mock]))

--- a/tests/integration/test_techconfig_pruning_flow.py
+++ b/tests/integration/test_techconfig_pruning_flow.py
@@ -1,0 +1,213 @@
+"""Integration tests for the techconfig pruning sweep flow.
+
+Tests the full flow from queried memory entries through verification
+to superseded marking and Telegram notification.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock neo4j and agent_tooling for importing agents.memory / core modules."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver_with_results(records: list[dict]) -> MagicMock:
+    """Create a mock Neo4j driver that returns given records from the sweep query."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_query_result = MagicMock()
+    mock_query_result.__iter__ = MagicMock(return_value=iter(records))
+    mock_update_result = MagicMock()
+
+    mock_session.run.side_effect = [mock_query_result] + [mock_update_result] * len(records)
+
+    return mock_driver
+
+
+class TestSweepVerifiesAccurateEntry:
+    """Integration test: accurate entry is verified and NOT marked superseded."""
+
+    def test_sweep_verifies_accurate_entry_end_to_end(self) -> None:
+        """Entry with codebase_ref='server.py' and content referencing an existing function
+        is verified (not marked superseded)."""
+        records = [
+            {
+                "content": "server.py uses FastAPI as the gateway framework",
+                "codebase_ref": "server.py",
+                "id": "elem-accurate-1",
+            },
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        mock_verify = MagicMock(return_value=VerificationResult(
+            status="verified",
+            reason="File server.py exists and keywords found",
+            content=records[0]["content"],
+            element_id="elem-accurate-1",
+            codebase_ref="server.py",
+        ))
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["verified"] == 1
+        assert result["pruned"] == 0
+        assert result["flagged"] == 0
+
+        # Verify no SET superseded call was made (only query call)
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        assert len(mock_session.run.call_args_list) == 1
+        query_cypher = mock_session.run.call_args_list[0][0][0]
+        assert "technical-config" in query_cypher
+
+
+class TestSweepPrunesInaccurateEntry:
+    """Integration test: inaccurate entry IS marked superseded."""
+
+    def test_sweep_prunes_inaccurate_entry_end_to_end(self) -> None:
+        """Entry with codebase_ref='server.py' and content referencing a non-existent
+        function is pruned (marked superseded=True)."""
+        records = [
+            {
+                "content": "server.py uses Flask for routing",
+                "codebase_ref": "server.py",
+                "id": "elem-inaccurate-1",
+            },
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        mock_verify = MagicMock(return_value=VerificationResult(
+            status="pruned",
+            reason="File server.py exists but keywords not found",
+            content=records[0]["content"],
+            element_id="elem-inaccurate-1",
+            codebase_ref="server.py",
+        ))
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["pruned"] == 1
+        assert result["verified"] == 0
+
+        # Verify SET superseded call was made
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        assert len(mock_session.run.call_args_list) == 2
+        set_call = mock_session.run.call_args_list[1]
+        assert "superseded" in set_call[0][0]
+        assert set_call[1]["id"] == "elem-inaccurate-1"
+
+
+class TestSweepFlagsUnresolvableEntry:
+    """Integration test: unresolvable entry is flagged (not modified, not pruned)."""
+
+    def test_sweep_flags_unresolvable_entry_end_to_end(self) -> None:
+        """Entry with no codebase_ref and ambiguous content is flagged."""
+        records = [
+            {
+                "content": "Some vague configuration note about the system",
+                "codebase_ref": None,
+                "id": "elem-vague-1",
+            },
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        mock_verify = MagicMock(return_value=VerificationResult(
+            status="flagged",
+            reason="Cannot verify: no file reference and keywords not found",
+            content=records[0]["content"],
+            element_id="elem-vague-1",
+            codebase_ref=None,
+        ))
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["flagged"] == 1
+        assert result["pruned"] == 0
+        assert result["verified"] == 0
+
+        # Verify no SET call was made
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        assert len(mock_session.run.call_args_list) == 1
+
+
+class TestSweepSendsSummaryTelegram:
+    """Integration test: Telegram summary sent with correct counts."""
+
+    def test_sweep_sends_summary_telegram(self) -> None:
+        """Sweep with mixed results sends Telegram with correct summary counts."""
+        records = [
+            {"content": "server.py uses FastAPI", "codebase_ref": "server.py", "id": "id-1"},
+            {"content": "server.py uses Flask", "codebase_ref": "server.py", "id": "id-2"},
+            {"content": "vague note", "codebase_ref": None, "id": "id-3"},
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        verify_results = [
+            VerificationResult("verified", "OK", records[0]["content"], "id-1", "server.py"),
+            VerificationResult("pruned", "Not found", records[1]["content"], "id-2", "server.py"),
+            VerificationResult("flagged", "Cannot verify", records[2]["content"], "id-3", None),
+        ]
+        mock_verify = MagicMock(side_effect=verify_results)
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct") as mock_telegram,
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["verified"] == 1
+        assert result["pruned"] == 1
+        assert result["flagged"] == 1
+
+        # First telegram call: summary
+        assert mock_telegram.call_count >= 1
+        summary_msg = mock_telegram.call_args_list[0][0][0]
+        assert "Verified: 1" in summary_msg
+        assert "Pruned: 1" in summary_msg
+        assert "Flagged: 1" in summary_msg
+
+        # Second telegram call: flagged entries
+        assert mock_telegram.call_count >= 2
+        flagged_msg = mock_telegram.call_args_list[1][0][0]
+        assert "vague note" in flagged_msg

--- a/tests/unit/test_memory_backward_compat.py
+++ b/tests/unit/test_memory_backward_compat.py
@@ -116,6 +116,7 @@ class TestMemoryRetrieveBackwardCompat:
             "as_of": "2026-01-01T00:00:00Z",
             "expires_at": None,
             "superseded": False,
+            "codebase_ref": None,
         }[key]
 
         record_without_meta = MagicMock()
@@ -131,6 +132,7 @@ class TestMemoryRetrieveBackwardCompat:
             "as_of": None,
             "expires_at": None,
             "superseded": None,
+            "codebase_ref": None,
         }[key]
 
         mock_result = MagicMock()

--- a/tests/unit/test_memory_retrieve_metadata.py
+++ b/tests/unit/test_memory_retrieve_metadata.py
@@ -40,6 +40,7 @@ class TestMemoryRetrieveMetadata:
             as_of="2026-01-01T00:00:00Z",
             expires_at=None,
             superseded=False,
+            codebase_ref=None,
         )
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([record]))
@@ -72,6 +73,7 @@ class TestMemoryRetrieveMetadata:
             as_of="2026-01-01",
             expires_at=None,
             superseded=False,
+            codebase_ref=None,
         )
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([record]))
@@ -103,6 +105,7 @@ class TestMemoryRetrieveMetadata:
             as_of="2026-03-01T12:00:00Z",
             expires_at=None,
             superseded=False,
+            codebase_ref=None,
         )
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([record]))
@@ -137,6 +140,7 @@ class TestMemoryRetrieveMetadata:
             as_of=None,
             expires_at=None,
             superseded=None,
+            codebase_ref=None,
         )
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([record]))

--- a/tests/unit/test_techconfig_codebase_ref.py
+++ b/tests/unit/test_techconfig_codebase_ref.py
@@ -1,0 +1,145 @@
+"""Unit tests for codebase_ref field support in agents/memory.py."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock neo4j and agent_tooling for importing agents.memory."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver that returns a result with an id."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    mock_result = MagicMock()
+    mock_result.single.return_value = {"id": "test-id-123"}
+    mock_session.run.return_value = mock_result
+    return mock_driver
+
+
+class TestCodebaseRefInMemoryStore:
+    """Tests for codebase_ref parameter in memory_store and memory_store_direct."""
+
+    def test_memory_store_direct_accepts_codebase_ref(self) -> None:
+        """Passing codebase_ref='server.py' results in the Cypher query receiving the param."""
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="server.py uses FastAPI gateway on port 8420",
+                data_class="technical-config",
+                source="self",
+                codebase_ref="server.py",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+
+            # Verify codebase_ref was passed to Neo4j
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["codebase_ref"] == "server.py"
+
+    def test_memory_store_direct_codebase_ref_defaults_to_none(self) -> None:
+        """Omitting codebase_ref passes None to Cypher."""
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_store_direct(
+                content="config.yaml stores non-secret settings",
+                data_class="technical-config",
+                source="self",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["codebase_ref"] is None
+
+    def test_memory_store_codebase_ref_passed_through(self) -> None:
+        """memory_store passes codebase_ref through to memory_store_direct."""
+        mock_driver = _make_mock_driver()
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+            patch.object(mem_mod, "_hitl_gate", return_value=True),
+        ):
+            result_str = mem_mod.memory_store(
+                content="sessions.py manages process pool",
+                data_class="technical-config",
+                source="self",
+                codebase_ref="core/sessions.py",
+            )
+            result = json.loads(result_str)
+            assert result["stored"] is True
+
+            mock_session = mock_driver.session.return_value.__enter__.return_value
+            call_args = mock_session.run.call_args
+            params = call_args[1]
+            assert params["codebase_ref"] == "core/sessions.py"
+
+    def test_memory_retrieve_returns_codebase_ref(self) -> None:
+        """Retrieved memories include the codebase_ref field."""
+        mock_driver = MagicMock()
+        mock_session = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+        mock_record = {
+            "content": "server.py uses FastAPI",
+            "tags": "technical",
+            "source": "self",
+            "agent_id": "ada",
+            "created_at": 1000000,
+            "score": 0.95,
+            "data_class": "technical-config",
+            "tier": "reviewable",
+            "as_of": "2026-03-01T00:00:00Z",
+            "expires_at": None,
+            "superseded": False,
+            "codebase_ref": "server.py",
+        }
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([mock_record]))
+        mock_session.run.return_value = mock_result
+
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result_str = mem_mod.memory_retrieve("FastAPI server")
+            result = json.loads(result_str)
+            assert result["count"] == 1
+            assert result["memories"][0]["codebase_ref"] == "server.py"

--- a/tests/unit/test_techconfig_pruning.py
+++ b/tests/unit/test_techconfig_pruning.py
@@ -1,0 +1,335 @@
+"""Unit tests for the techconfig pruning sweep module (core.techconfig_pruning)."""
+
+import logging
+import sys
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock neo4j, agent_tooling, and keyring for importing agents.memory / core modules."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_memory_record(
+    content: str,
+    codebase_ref: str | None,
+    element_id: str = "test-id-1",
+) -> dict:
+    """Create a mock record matching the sweep query result shape."""
+    return {
+        "content": content,
+        "codebase_ref": codebase_ref,
+        "id": element_id,
+    }
+
+
+def _make_mock_driver_with_results(records: list[dict]) -> MagicMock:
+    """Create a mock Neo4j driver that returns given records from the query."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_query_result = MagicMock()
+    mock_query_result.__iter__ = MagicMock(return_value=iter(records))
+
+    mock_update_result = MagicMock()
+
+    # First call returns query results, subsequent calls are SET operations
+    mock_session.run.side_effect = [mock_query_result] + [mock_update_result] * len(records)
+
+    return mock_driver
+
+
+class TestSweepTechconfigEntries:
+    """Tests for sweep_techconfig_entries in core.techconfig_pruning."""
+
+    def test_sweep_queries_technical_config_entries(self) -> None:
+        """The Cypher query filters by data_class='technical-config'."""
+        records: list[dict] = []
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+        ):
+            techconfig_pruning.sweep_techconfig_entries()
+
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        query_call = mock_session.run.call_args_list[0]
+        cypher = query_call[0][0]
+        assert "technical-config" in cypher
+        assert "data_class" in cypher
+
+    def test_sweep_verified_entry_not_modified(self) -> None:
+        """Entry verified by heuristic is not changed in Neo4j; verified count incremented."""
+        records = [
+            _make_memory_record("server.py uses FastAPI", "server.py", "id-1"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        mock_verify = MagicMock(return_value=VerificationResult(
+            status="verified",
+            reason="File exists and keywords found",
+            content="server.py uses FastAPI",
+            element_id="id-1",
+            codebase_ref="server.py",
+        ))
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["verified"] == 1
+        assert result["pruned"] == 0
+        # Only the query call, no SET call for verified entries
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        assert len(mock_session.run.call_args_list) == 1
+
+    def test_sweep_pruned_entry_marked_superseded(self) -> None:
+        """Entry that fails verification gets superseded=True set via Cypher."""
+        records = [
+            _make_memory_record("server.py uses Flask", "server.py", "id-2"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        mock_verify = MagicMock(return_value=VerificationResult(
+            status="pruned",
+            reason="Keywords not found in file",
+            content="server.py uses Flask",
+            element_id="id-2",
+            codebase_ref="server.py",
+        ))
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["pruned"] == 1
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        # Second call should be the SET superseded
+        assert len(mock_session.run.call_args_list) >= 2
+        set_call = mock_session.run.call_args_list[1]
+        assert "superseded" in set_call[0][0]
+        assert set_call[1]["id"] == "id-2"
+
+    def test_sweep_flagged_entry_not_modified(self) -> None:
+        """Entry that is flagged for review is not changed in Neo4j."""
+        records = [
+            _make_memory_record("some vague config note", None, "id-3"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        mock_verify = MagicMock(return_value=VerificationResult(
+            status="flagged",
+            reason="Cannot verify",
+            content="some vague config note",
+            element_id="id-3",
+            codebase_ref=None,
+        ))
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["flagged"] == 1
+        assert result["pruned"] == 0
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        # Only the query call, no SET call for flagged entries
+        assert len(mock_session.run.call_args_list) == 1
+
+    def test_sweep_sends_telegram_summary_with_counts(self) -> None:
+        """After sweep, Telegram is called with verified/pruned/flagged counts."""
+        records = [
+            _make_memory_record("server.py uses FastAPI", "server.py", "id-1"),
+            _make_memory_record("server.py uses Flask", "server.py", "id-2"),
+            _make_memory_record("some vague note", None, "id-3"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        verify_results = [
+            VerificationResult("verified", "OK", records[0]["content"], "id-1", "server.py"),
+            VerificationResult("pruned", "Not found", records[1]["content"], "id-2", "server.py"),
+            VerificationResult("flagged", "Cannot verify", records[2]["content"], "id-3", None),
+        ]
+        mock_verify = MagicMock(side_effect=verify_results)
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct") as mock_telegram,
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["verified"] == 1
+        assert result["pruned"] == 1
+        assert result["flagged"] == 1
+
+        # Telegram should have been called at least once for the summary
+        assert mock_telegram.call_count >= 1
+        summary_msg = mock_telegram.call_args_list[0][0][0]
+        assert "1" in summary_msg  # verified count
+        assert "pruned" in summary_msg.lower() or "Pruned" in summary_msg
+
+    def test_sweep_sends_flagged_entries_in_review_message(self) -> None:
+        """Flagged entries are batched into a Telegram message with their content."""
+        records = [
+            _make_memory_record("flaggable entry content", None, "id-1"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        mock_verify = MagicMock(return_value=VerificationResult(
+            status="flagged",
+            reason="Cannot verify",
+            content="flaggable entry content",
+            element_id="id-1",
+            codebase_ref=None,
+        ))
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct") as mock_telegram,
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            techconfig_pruning.sweep_techconfig_entries()
+
+        # Should have a second message for flagged entries
+        assert mock_telegram.call_count >= 2
+        flagged_msg = mock_telegram.call_args_list[1][0][0]
+        assert "flaggable entry content" in flagged_msg
+
+    def test_sweep_no_telegram_when_nothing_found(self) -> None:
+        """No entries found means no Telegram message sent."""
+        records: list[dict] = []
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct") as mock_telegram,
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        mock_telegram.assert_not_called()
+        assert result["verified"] == 0
+        assert result["pruned"] == 0
+        assert result["flagged"] == 0
+
+    def test_sweep_neo4j_error_handled_gracefully(self) -> None:
+        """Neo4j failure does not raise; errors count incremented."""
+        mock_driver = MagicMock()
+        mock_session = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+        mock_session.run.side_effect = Exception("Neo4j connection lost")
+
+        from core import techconfig_pruning
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result["errors"] >= 1
+
+    def test_sweep_telegram_failure_does_not_raise(self) -> None:
+        """Telegram failure handled gracefully."""
+        records = [
+            _make_memory_record("server.py uses FastAPI", "server.py", "id-1"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+        from core.techconfig_verifier import VerificationResult
+
+        mock_verify = MagicMock(return_value=VerificationResult(
+            status="verified",
+            reason="OK",
+            content="server.py uses FastAPI",
+            element_id="id-1",
+            codebase_ref="server.py",
+        ))
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(
+                techconfig_pruning, "_telegram_direct",
+                side_effect=Exception("Telegram API down"),
+            ),
+            patch("core.techconfig_pruning.verify_entry", mock_verify),
+        ):
+            # Should not raise
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        # Sweep should still have processed entries
+        assert result["verified"] == 1
+
+    def test_sweep_returns_result_dict(self) -> None:
+        """Return dict has keys: verified, pruned, flagged, errors."""
+        records: list[dict] = []
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert "verified" in result
+        assert "pruned" in result
+        assert "flagged" in result
+        assert "errors" in result
+
+    def test_sweep_empty_results_returns_zeros(self) -> None:
+        """No matching entries returns all-zero counts."""
+        records: list[dict] = []
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import techconfig_pruning
+
+        with (
+            patch.object(techconfig_pruning, "_get_driver", return_value=mock_driver),
+            patch.object(techconfig_pruning, "_telegram_direct"),
+        ):
+            result = techconfig_pruning.sweep_techconfig_entries()
+
+        assert result == {"verified": 0, "pruned": 0, "flagged": 0, "errors": 0}

--- a/tests/unit/test_techconfig_sweep_scheduler.py
+++ b/tests/unit/test_techconfig_sweep_scheduler.py
@@ -1,0 +1,115 @@
+"""Unit tests for the techconfig sweep scheduler integration."""
+
+import logging
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock third-party dependencies for importing clients.scheduler."""
+    # Remove cached scheduler module so it gets reimported with our mocks
+    for mod_name in list(sys.modules.keys()):
+        if mod_name.startswith("clients.scheduler"):
+            del sys.modules[mod_name]
+
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+    # Mock apscheduler modules
+    apscheduler_mock = MagicMock()
+    apscheduler_schedulers_mock = MagicMock()
+    apscheduler_schedulers_asyncio_mock = MagicMock()
+    apscheduler_triggers_mock = MagicMock()
+    apscheduler_triggers_cron_mock = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "apscheduler", apscheduler_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.schedulers", apscheduler_schedulers_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.schedulers.asyncio", apscheduler_schedulers_asyncio_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers", apscheduler_triggers_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers.cron", apscheduler_triggers_cron_mock)
+
+
+class TestTechconfigSweepScheduler:
+    """Tests for _techconfig_sweep in clients.scheduler."""
+
+    @pytest.mark.asyncio
+    async def test_techconfig_sweep_calls_endpoint(self) -> None:
+        """Assert that _techconfig_sweep POSTs to /memory/techconfig-sweep with auth."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"verified": 3, "pruned": 1, "flagged": 0, "errors": 0})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _techconfig_sweep
+            await _techconfig_sweep()
+
+            mock_session.post.assert_called_once()
+            call_args = mock_session.post.call_args
+            assert "/memory/techconfig-sweep" in call_args[0][0]
+            assert call_args[1]["headers"]["X-HITL-Internal"] == "test-token"
+
+    @pytest.mark.asyncio
+    async def test_techconfig_sweep_logs_results(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Assert that sweep results are logged."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"verified": 5, "pruned": 2, "flagged": 1, "errors": 0})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg, \
+             caplog.at_level(logging.INFO, logger="hive-mind-scheduler"):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _techconfig_sweep
+            await _techconfig_sweep()
+
+        assert any("verified=5" in record.message for record in caplog.records)
+        assert any("pruned=2" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_techconfig_sweep_handles_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Assert that sweep failure is handled gracefully."""
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(side_effect=Exception("Connection refused"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg, \
+             caplog.at_level(logging.ERROR, logger="hive-mind-scheduler"):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _techconfig_sweep
+            # Should not raise
+            await _techconfig_sweep()
+
+        assert any("failed" in record.message.lower() for record in caplog.records)

--- a/tests/unit/test_techconfig_verifier.py
+++ b/tests/unit/test_techconfig_verifier.py
@@ -1,0 +1,289 @@
+"""Unit tests for the techconfig verifier module (core.techconfig_verifier)."""
+
+from unittest.mock import patch, MagicMock
+import subprocess
+
+import pytest
+
+
+class TestVerifyEntryWithCodebaseRef:
+    """Tests for verify_entry when codebase_ref is provided."""
+
+    def test_verify_entry_file_exists_and_symbol_found_returns_verified(self) -> None:
+        """Entry with codebase_ref='server.py' and content mentioning 'FastAPI' returns verified."""
+        from core.techconfig_verifier import verify_entry
+
+        with (
+            patch("core.techconfig_verifier._check_file_exists", return_value=True),
+            patch("core.techconfig_verifier._check_symbol_in_file", return_value=True),
+        ):
+            result = verify_entry(
+                content="server.py uses FastAPI as the gateway framework",
+                element_id="elem-1",
+                codebase_ref="server.py",
+            )
+        assert result.status == "verified"
+        assert result.element_id == "elem-1"
+        assert result.codebase_ref == "server.py"
+
+    def test_verify_entry_file_exists_but_symbol_not_found_returns_pruned(self) -> None:
+        """Entry with codebase_ref='server.py' and content mentioning a non-existent function returns pruned."""
+        from core.techconfig_verifier import verify_entry
+
+        with (
+            patch("core.techconfig_verifier._check_file_exists", return_value=True),
+            patch("core.techconfig_verifier._check_symbol_in_file", return_value=False),
+        ):
+            result = verify_entry(
+                content="server.py uses the nonexistent_function() for routing",
+                element_id="elem-2",
+                codebase_ref="server.py",
+            )
+        assert result.status == "pruned"
+        assert "not found" in result.reason.lower() or "symbol" in result.reason.lower()
+
+    def test_verify_entry_file_does_not_exist_returns_flagged(self) -> None:
+        """Entry with codebase_ref='nonexistent.py' returns flagged for review."""
+        from core.techconfig_verifier import verify_entry
+
+        with patch("core.techconfig_verifier._check_file_exists", return_value=False):
+            result = verify_entry(
+                content="nonexistent.py handles X",
+                element_id="elem-3",
+                codebase_ref="nonexistent.py",
+            )
+        assert result.status == "flagged"
+        assert "not exist" in result.reason.lower() or "missing" in result.reason.lower()
+
+
+class TestVerifyEntryWithoutCodebaseRef:
+    """Tests for verify_entry when codebase_ref is absent."""
+
+    def test_verify_entry_no_codebase_ref_infers_file_and_verifies(self) -> None:
+        """Entry without codebase_ref but with content like 'server.py handles /sessions' infers the file."""
+        from core.techconfig_verifier import verify_entry
+
+        with (
+            patch("core.techconfig_verifier._extract_file_references", return_value=["server.py"]),
+            patch("core.techconfig_verifier._check_file_exists", return_value=True),
+            patch("core.techconfig_verifier._check_symbol_in_file", return_value=True),
+        ):
+            result = verify_entry(
+                content="server.py handles /sessions endpoint",
+                element_id="elem-4",
+                codebase_ref=None,
+            )
+        assert result.status == "verified"
+
+    def test_verify_entry_no_codebase_ref_no_file_match_returns_flagged(self) -> None:
+        """Entry without codebase_ref and no file inference possible returns flagged."""
+        from core.techconfig_verifier import verify_entry
+
+        with (
+            patch("core.techconfig_verifier._extract_file_references", return_value=[]),
+            patch("core.techconfig_verifier._extract_keywords", return_value=["something"]),
+            patch("core.techconfig_verifier._check_symbol_in_project", return_value=False),
+        ):
+            result = verify_entry(
+                content="Some vague technical configuration note",
+                element_id="elem-5",
+                codebase_ref=None,
+            )
+        assert result.status == "flagged"
+
+    def test_verify_entry_no_codebase_ref_file_inferred_but_symbol_missing_returns_pruned(self) -> None:
+        """Entry without codebase_ref, file inferred from content, but symbol not found returns pruned."""
+        from core.techconfig_verifier import verify_entry
+
+        with (
+            patch("core.techconfig_verifier._extract_file_references", return_value=["core/sessions.py"]),
+            patch("core.techconfig_verifier._check_file_exists", return_value=True),
+            patch("core.techconfig_verifier._check_symbol_in_file", return_value=False),
+        ):
+            result = verify_entry(
+                content="core/sessions.py uses the old_function() for reaping",
+                element_id="elem-6",
+                codebase_ref=None,
+            )
+        assert result.status == "pruned"
+
+
+class TestVerifyEntryEdgeCases:
+    """Edge cases for verify_entry."""
+
+    def test_verify_entry_empty_content_returns_flagged(self) -> None:
+        """Empty content string returns flagged."""
+        from core.techconfig_verifier import verify_entry
+
+        result = verify_entry(
+            content="",
+            element_id="elem-7",
+            codebase_ref=None,
+        )
+        assert result.status == "flagged"
+
+
+class TestExtractKeywords:
+    """Tests for _extract_keywords helper."""
+
+    def test_extract_keywords_from_content(self) -> None:
+        """Extracts filenames, function names, and config keys from content text."""
+        from core.techconfig_verifier import _extract_keywords
+
+        content = "The send_message function in sessions.py uses model_registry"
+        keywords = _extract_keywords(content)
+        assert isinstance(keywords, list)
+        assert len(keywords) > 0
+        # Should include function-like names
+        assert "send_message" in keywords or any("send_message" in kw for kw in keywords)
+
+
+class TestExtractFileReferences:
+    """Tests for _extract_file_references helper."""
+
+    def test_extract_file_references_finds_python_files(self) -> None:
+        """Finds .py file references in content."""
+        from core.techconfig_verifier import _extract_file_references
+
+        content = "server.py uses FastAPI and core/sessions.py manages processes"
+        refs = _extract_file_references(content)
+        assert "server.py" in refs
+        assert "core/sessions.py" in refs
+
+    def test_extract_file_references_finds_yaml_files(self) -> None:
+        """Finds .yaml file references in content."""
+        from core.techconfig_verifier import _extract_file_references
+
+        content = "Non-secret settings are stored in config.yaml"
+        refs = _extract_file_references(content)
+        assert "config.yaml" in refs
+
+    def test_extract_file_references_no_files_returns_empty(self) -> None:
+        """Returns empty list when no file references found."""
+        from core.techconfig_verifier import _extract_file_references
+
+        content = "The system uses a centralized gateway pattern"
+        refs = _extract_file_references(content)
+        assert refs == []
+
+
+class TestCheckFileExists:
+    """Tests for _check_file_exists helper."""
+
+    def test_check_file_exists_true(self) -> None:
+        """Returns True for existing file."""
+        from core.techconfig_verifier import _check_file_exists
+
+        with patch("os.path.isfile", return_value=True):
+            assert _check_file_exists("server.py") is True
+
+    def test_check_file_exists_false(self) -> None:
+        """Returns False for non-existing file."""
+        from core.techconfig_verifier import _check_file_exists
+
+        with patch("os.path.isfile", return_value=False):
+            assert _check_file_exists("nonexistent.py") is False
+
+
+class TestCheckSymbolInFile:
+    """Tests for _check_symbol_in_file helper."""
+
+    def test_check_symbol_in_file_found(self) -> None:
+        """Returns True when symbol is found in file."""
+        from core.techconfig_verifier import _check_symbol_in_file
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch("subprocess.run", return_value=mock_result):
+            assert _check_symbol_in_file("server.py", "FastAPI") is True
+
+    def test_check_symbol_in_file_not_found(self) -> None:
+        """Returns False when symbol is not found in file."""
+        from core.techconfig_verifier import _check_symbol_in_file
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        with patch("subprocess.run", return_value=mock_result):
+            assert _check_symbol_in_file("server.py", "nonexistent") is False
+
+
+class TestCheckSymbolInProject:
+    """Tests for _check_symbol_in_project helper."""
+
+    def test_check_symbol_in_project_found(self) -> None:
+        """Returns True when symbol is found anywhere in project."""
+        from core.techconfig_verifier import _check_symbol_in_project
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch("subprocess.run", return_value=mock_result):
+            assert _check_symbol_in_project("FastAPI") is True
+
+    def test_check_symbol_in_project_not_found(self) -> None:
+        """Returns False when symbol is not found in project."""
+        from core.techconfig_verifier import _check_symbol_in_project
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        with patch("subprocess.run", return_value=mock_result):
+            assert _check_symbol_in_project("nonexistent_symbol") is False
+
+    def test_check_symbol_in_project_excludes_non_source_dirs(self) -> None:
+        """Grep command includes --exclude-dir flags for .git, backups, etc."""
+        from core.techconfig_verifier import _check_symbol_in_project
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            _check_symbol_in_project("some_symbol")
+            args = mock_run.call_args[0][0]
+            # The command should include --exclude-dir flags
+            assert "--exclude-dir=.git" in args
+            assert "--exclude-dir=backups" in args
+            assert "--exclude-dir=__pycache__" in args
+            assert "--exclude-dir=data" in args
+            assert "--exclude-dir=documents" in args
+
+
+class TestPathTraversalValidation:
+    """Tests for M1: path traversal protection on codebase_ref."""
+
+    def test_check_file_exists_rejects_path_traversal(self) -> None:
+        """_check_file_exists returns False for path traversal attempts."""
+        from core.techconfig_verifier import _check_file_exists
+
+        # ../../etc/passwd resolves outside PROJECT_DIR
+        assert _check_file_exists("../../etc/passwd") is False
+
+    def test_check_symbol_in_file_rejects_path_traversal(self) -> None:
+        """_check_symbol_in_file returns False for path traversal attempts."""
+        from core.techconfig_verifier import _check_symbol_in_file
+
+        assert _check_symbol_in_file("../../etc/passwd", "root") is False
+
+    def test_is_path_within_project_valid_path(self) -> None:
+        """_is_path_within_project returns True for paths within PROJECT_DIR."""
+        from core.techconfig_verifier import _is_path_within_project
+
+        assert _is_path_within_project("server.py") is True
+        assert _is_path_within_project("core/sessions.py") is True
+
+    def test_is_path_within_project_traversal_path(self) -> None:
+        """_is_path_within_project returns False for paths escaping PROJECT_DIR."""
+        from core.techconfig_verifier import _is_path_within_project
+
+        assert _is_path_within_project("../../etc/passwd") is False
+        assert _is_path_within_project("/etc/passwd") is False
+        assert _is_path_within_project("../../../tmp/evil") is False
+
+    def test_verify_entry_with_traversal_codebase_ref_returns_flagged(self) -> None:
+        """verify_entry returns flagged when codebase_ref is a path traversal."""
+        from core.techconfig_verifier import verify_entry
+
+        result = verify_entry(
+            content="Some technical config content about password files",
+            element_id="elem-traversal",
+            codebase_ref="../../etc/passwd",
+        )
+        assert result.status == "flagged"
+        assert "outside" in result.reason.lower() or "traversal" in result.reason.lower()


### PR DESCRIPTION
## Summary
- Implements a weekly scheduled sweep that verifies all `data_class=technical-config` memory entries against the live codebase using lightweight heuristics (file existence, keyword grep)
- Entries are classified as verified (kept), pruned (marked superseded in Neo4j), or flagged (batched for Daniel's review via Telegram)
- Adds `codebase_ref` field to memory store/retrieve for explicit file/symbol references that accelerate verification

## Acceptance Criteria
1. **Pruning job implementation** — Weekly cron job (Sunday 4am CT) via scheduler, triggered through `/memory/techconfig-sweep` gateway endpoint
2. **Verification logic with codebase_ref** — If `codebase_ref` present, file is checked directly; if absent, file paths are inferred from content; decision tree: verified / pruned / flagged
3. **Reporting mechanism** — Telegram summary after each pass with verified/pruned/flagged/error counts; flagged entries batched into a separate review message
4. **Open question resolved** — Lightweight heuristic (file/symbol existence check) chosen; no Claude session spawning
5. **Test coverage** — 1162 lines across 6 test files covering all verification scenarios, scheduler integration, API endpoint, and edge cases

## Test Plan
- All unit/integration tests pass (pytest)
- mypy and ruff clean

🤖 Implemented autonomously by Ada — Hive Mind