### PR TITLE
[Memory] Monthly Review Pass -- World-Events, Intentions, Session-Logs

### DIFF
--- a/agents/memory.py
+++ b/agents/memory.py
@@ -243,6 +243,7 @@ def memory_retrieve(
     k: int = 10,
     agent_id: str = "ada",
     tag_filter: Optional[str] = None,
+    include_archived: bool = False,
 ) -> str:
     """Retrieve the most semantically relevant memories for a query.
 
@@ -251,12 +252,17 @@ def memory_retrieve(
         k: Number of results to return (default 10, max 50).
         agent_id: Which agent's memories to search (default "ada").
         tag_filter: Optional tag to filter results (e.g. "session").
+        include_archived: If True, include archived entries. Default False.
 
     Returns:
         JSON array of memories sorted by relevance (highest first), each with
         content, tags, source, agent_id, created_at, and similarity score.
     """
     k = min(k, 50)
+    archived_filter = (
+        "" if include_archived
+        else " AND (m.archived IS NULL OR m.archived = false)"
+    )
     try:
         embedding = _embed(query)
         driver = _get_driver()
@@ -264,10 +270,10 @@ def memory_retrieve(
             _ensure_index(session)
             if tag_filter:
                 result = session.run(
-                    """
+                    f"""
                     CALL db.index.vector.queryNodes($index, $k, $embedding)
                     YIELD node AS m, score
-                    WHERE m.agent_id = $agent_id AND m.tags CONTAINS $tag_filter
+                    WHERE m.agent_id = $agent_id AND m.tags CONTAINS $tag_filter{archived_filter}
                     RETURN m.content AS content,
                            m.tags AS tags,
                            m.source AS source,
@@ -279,6 +285,7 @@ def memory_retrieve(
                            m.expires_at AS expires_at,
                            m.superseded AS superseded,
                            m.codebase_ref AS codebase_ref,
+                           m.archived AS archived,
                            score
                     ORDER BY score DESC
                     """,
@@ -290,10 +297,10 @@ def memory_retrieve(
                 )
             else:
                 result = session.run(
-                    """
+                    f"""
                     CALL db.index.vector.queryNodes($index, $k, $embedding)
                     YIELD node AS m, score
-                    WHERE m.agent_id = $agent_id
+                    WHERE m.agent_id = $agent_id{archived_filter}
                     RETURN m.content AS content,
                            m.tags AS tags,
                            m.source AS source,
@@ -305,6 +312,7 @@ def memory_retrieve(
                            m.expires_at AS expires_at,
                            m.superseded AS superseded,
                            m.codebase_ref AS codebase_ref,
+                           m.archived AS archived,
                            score
                     ORDER BY score DESC
                     """,
@@ -327,6 +335,7 @@ def memory_retrieve(
                     "expires_at": record["expires_at"],
                     "superseded": record["superseded"],
                     "codebase_ref": record["codebase_ref"],
+                    "archived": record["archived"],
                 }
                 for record in result
             ]

--- a/clients/scheduler.py
+++ b/clients/scheduler.py
@@ -224,6 +224,25 @@ async def _epilogue_sweep() -> None:
         log.exception("Epilogue sweep failed")
 
 
+async def _monthly_review_sweep() -> None:
+    """Call the gateway's monthly review endpoint to surface entries for Daniel's review."""
+    log.info("Running monthly review sweep")
+    try:
+        timeout = aiohttp.ClientTimeout(total=120)
+        headers = {"X-HITL-Internal": config.hitl_internal_token or ""}
+        async with aiohttp.ClientSession(timeout=timeout) as http:
+            async with http.post(f"{SERVER_URL}/memory/monthly-review", headers=headers) as resp:
+                data = await resp.json()
+                log.info(
+                    "Monthly review sweep: entries_found=%d, messages_sent=%d, errors=%d",
+                    data.get("entries_found", 0),
+                    data.get("messages_sent", 0),
+                    data.get("errors", 0),
+                )
+    except Exception:
+        log.exception("Monthly review sweep failed")
+
+
 async def main() -> None:
     if not config.scheduled_tasks:
         log.warning("No scheduled_tasks configured in config.yaml — nothing to do")
@@ -267,8 +286,13 @@ async def main() -> None:
     scheduler.add_job(_techconfig_sweep, techconfig_trigger, id="techconfig-sweep")
     log.info("Scheduled technical-config pruning sweep @ 0 4 * * 0")
 
+    # Add monthly review sweep job (1st of every month at 9:00 AM CT)
+    monthly_review_trigger = CronTrigger(hour="9", minute="0", day="1", timezone="America/Chicago")
+    scheduler.add_job(_monthly_review_sweep, monthly_review_trigger, id="monthly-review-sweep")
+    log.info("Scheduled monthly review sweep @ 0 9 1 * *")
+
     scheduler.start()
-    log.info("Scheduler running — %d job(s) active + epilogue sweep + memory expiry sweep + orphan sweep + techconfig sweep", len(config.scheduled_tasks))
+    log.info("Scheduler running — %d job(s) active + epilogue sweep + memory expiry sweep + orphan sweep + techconfig sweep + monthly review sweep", len(config.scheduled_tasks))
 
     await asyncio.Event().wait()  # run forever
 

--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -524,6 +524,64 @@ async def cmd_classify(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 # ---------------------------------------------------------------------------
+# Monthly review response handlers (/keep_*, /archive_*, /discard_*)
+# ---------------------------------------------------------------------------
+async def _handle_review_response(update: Update, action: str) -> None:
+    """Extract element ID from /keep_<id>, /archive_<id>, or /discard_<id> and POST to gateway."""
+    if not _is_allowed_user(update.effective_user.id):
+        await update.message.reply_text("Not authorized.")
+        return
+
+    text = (update.message.text or "").strip()
+    # Extract ID: everything after /keep_, /archive_, or /discard_
+    prefix = f"/{action}_"
+    if not text.startswith(prefix):
+        await update.message.reply_text(f"Invalid command format. Usage: {prefix}<id>")
+        return
+
+    element_id = text[len(prefix):]
+    if not element_id:
+        await update.message.reply_text(f"Invalid command format. Usage: {prefix}<id>")
+        return
+
+    hitl_secret = config.hitl_internal_token
+    if not hitl_secret:
+        await update.message.reply_text("HITL not configured on server.")
+        return
+
+    try:
+        async with http.post(
+            f"{SERVER_URL}/memory/review-respond",
+            json={"element_id": element_id, "action": action},
+            headers={"X-HITL-Internal": hitl_secret},
+        ) as resp:
+            data = await resp.json()
+            if resp.status == 200 and data.get("ok"):
+                await update.message.reply_text(f"Done: {action} applied.")
+            else:
+                error_msg = data.get("error", "unknown error")
+                await update.message.reply_text(f"Failed: {error_msg}")
+    except Exception:
+        log.exception("Review respond failed for %s", action)
+        await update.message.reply_text("Failed to send response to server.")
+
+
+async def cmd_review_keep(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /keep_<id> commands from monthly review messages."""
+    await _handle_review_response(update, "keep")
+
+
+async def cmd_review_archive(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /archive_<id> commands from monthly review messages."""
+    await _handle_review_response(update, "archive")
+
+
+async def cmd_review_discard(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle /discard_<id> commands from monthly review messages."""
+    await _handle_review_response(update, "discard")
+
+
+# ---------------------------------------------------------------------------
 # HITL approve/deny handlers
 # ---------------------------------------------------------------------------
 async def cmd_hitl_approve(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -726,6 +784,9 @@ if __name__ == "__main__":
     app.add_handler(MessageHandler(filters.Regex(r"^/approve_\w+$"), cmd_hitl_approve))
     app.add_handler(MessageHandler(filters.Regex(r"^/deny_\w+$"), cmd_hitl_deny))
     app.add_handler(MessageHandler(filters.Regex(r"^/classify_"), cmd_classify))
+    app.add_handler(MessageHandler(filters.Regex(r"^/keep_[^\s]+$"), cmd_review_keep))
+    app.add_handler(MessageHandler(filters.Regex(r"^/archive_[^\s]+$"), cmd_review_archive))
+    app.add_handler(MessageHandler(filters.Regex(r"^/discard_[^\s]+$"), cmd_review_discard))
     app.add_handler(MessageHandler(filters.PHOTO, handle_photo))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text))
     app.add_handler(MessageHandler(filters.VOICE, handle_voice))

--- a/core/archive_store.py
+++ b/core/archive_store.py
@@ -1,0 +1,92 @@
+"""Archive store for world-event entries.
+
+JSON file-backed archive store. Entries are preserved here when
+archived from the active Neo4j graph. The abstraction uses a simple
+class interface so the backend can be swapped to SQLite or a separate
+Neo4j label later without changing call sites.
+
+Default path: /usr/src/app/data/world_events_archive.json
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ARCHIVE_PATH = Path("/usr/src/app/data/world_events_archive.json")
+
+
+@dataclass
+class ArchivedEntry:
+    """A single archived memory entry."""
+
+    original_id: str          # Neo4j elementId at time of archive
+    content: str
+    data_class: str
+    tags: str
+    source: str
+    agent_id: str
+    created_at: int           # original created_at timestamp
+    archived_at: str          # ISO 8601 datetime
+    original_metadata: dict   # full original node properties
+
+
+class ArchiveStore:
+    """JSON file-backed archive store.
+
+    Thread-safe via fcntl.flock on every read/write cycle.
+    """
+
+    def __init__(self, path: Path | None = None) -> None:
+        self._path = path or DEFAULT_ARCHIVE_PATH
+
+    def save(self, entry: ArchivedEntry) -> None:
+        """Append an entry to the archive file.
+
+        Creates the file if it does not exist. Uses file locking
+        to prevent corruption from concurrent writes.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+        with open(self._path, "a+") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            try:
+                f.seek(0)
+                raw = f.read()
+                entries: list[dict] = json.loads(raw) if raw.strip() else []
+                entries.append(asdict(entry))
+                f.seek(0)
+                f.truncate()
+                json.dump(entries, f, indent=2)
+            finally:
+                fcntl.flock(f, fcntl.LOCK_UN)
+
+    def list_all(self) -> list[ArchivedEntry]:
+        """Return all archived entries. Returns [] if file missing or empty."""
+        if not self._path.exists():
+            return []
+
+        try:
+            with open(self._path) as f:
+                fcntl.flock(f, fcntl.LOCK_SH)
+                try:
+                    raw = f.read()
+                    entries = json.loads(raw) if raw.strip() else []
+                finally:
+                    fcntl.flock(f, fcntl.LOCK_UN)
+            return [ArchivedEntry(**e) for e in entries]
+        except (json.JSONDecodeError, FileNotFoundError):
+            logger.warning("Failed to read archive at %s", self._path)
+            return []
+
+    def get(self, original_id: str) -> ArchivedEntry | None:
+        """Look up an archived entry by its original Neo4j element ID."""
+        for entry in self.list_all():
+            if entry.original_id == original_id:
+                return entry
+        return None

--- a/core/monthly_review.py
+++ b/core/monthly_review.py
@@ -1,0 +1,347 @@
+"""Monthly review sweep -- surfaces world-event, intention, and session-log
+entries for Daniel's review via Telegram.
+
+Daniel responds with keep/archive/discard per entry. This is the
+human-in-the-loop pass for data that cannot be auto-pruned (Pass 4
+in specs/memory-lifecycle.md).
+
+Called by the scheduler via the /memory/monthly-review gateway endpoint.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from core.archive_store import ArchiveStore, ArchivedEntry
+
+logger = logging.getLogger(__name__)
+
+# 30 days in seconds
+REVIEW_INTERVAL_SECONDS = 30 * 86400
+
+# Data classes eligible for monthly review
+REVIEW_DATA_CLASSES = ["world-event", "intention", "session-log"]
+
+# Max content length in review messages
+MAX_CONTENT_LENGTH = 200
+
+
+@dataclass
+class ReviewEntry:
+    """A single entry due for review."""
+
+    element_id: str
+    content: str
+    data_class: str
+    created_at: int
+    last_reviewed_at: int | None
+
+
+def _get_driver():
+    """Lazy import to avoid circular dependency and allow mocking."""
+    from agents.memory import _get_driver as _mem_get_driver
+    return _mem_get_driver()
+
+
+def _telegram_direct(message: str) -> tuple[bool, str]:
+    """Lazy import of the Telegram direct send function."""
+    from agents.notify import _telegram_direct as _notify_telegram
+    return _notify_telegram(message)
+
+
+def _get_archive_store() -> ArchiveStore:
+    """Return the default ArchiveStore instance. Separate function for mocking."""
+    return ArchiveStore()
+
+
+def query_entries_for_review() -> dict[str, list[ReviewEntry]]:
+    """Query Neo4j for entries due for monthly review.
+
+    Returns entries grouped by data_class where:
+    - data_class is world-event, intention, or session-log
+    - entry is not archived
+    - last_reviewed_at is null or older than 30 days
+
+    Returns:
+        Dict keyed by data_class, values are lists of ReviewEntry.
+    """
+    cutoff = int(time.time()) - REVIEW_INTERVAL_SECONDS
+    grouped: dict[str, list[ReviewEntry]] = {}
+
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (m:Memory)
+                WHERE m.data_class IN $data_classes
+                  AND (m.archived IS NULL OR m.archived = false)
+                  AND (m.last_reviewed_at IS NULL OR m.last_reviewed_at < $cutoff)
+                RETURN m.content AS content,
+                       m.data_class AS data_class,
+                       m.created_at AS created_at,
+                       m.last_reviewed_at AS last_reviewed_at,
+                       elementId(m) AS id
+                """,
+                data_classes=REVIEW_DATA_CLASSES,
+                cutoff=cutoff,
+            )
+
+            for record in result:
+                entry = ReviewEntry(
+                    element_id=record["id"],
+                    content=record["content"],
+                    data_class=record["data_class"],
+                    created_at=record["created_at"],
+                    last_reviewed_at=record["last_reviewed_at"],
+                )
+                grouped.setdefault(entry.data_class, []).append(entry)
+
+    except Exception:
+        logger.exception("Monthly review query failed")
+
+    return grouped
+
+
+def _short_id(element_id: str) -> str:
+    """Return the full element ID for use in Telegram commands.
+
+    Previously truncated to 12 chars, but Neo4j element IDs (e.g. '4:abc:123')
+    must be passed in full for lookups via elementId(). Truncation caused
+    keep/archive/discard to always fail with 'Entry not found'.
+    """
+    return element_id
+
+
+def _format_date(timestamp: int) -> str:
+    """Format a Unix timestamp as a human-readable date."""
+    try:
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).strftime("%Y-%m-%d")
+    except (OSError, ValueError):
+        return "unknown"
+
+
+def build_review_messages(grouped: dict[str, list[ReviewEntry]]) -> dict[str, str]:
+    """Build one Telegram message per data class group.
+
+    Args:
+        grouped: Dict of data_class -> list of ReviewEntry.
+
+    Returns:
+        Dict of data_class -> message string.
+    """
+    messages: dict[str, str] = {}
+
+    for data_class, entries in grouped.items():
+        if not entries:
+            continue
+
+        lines = [f"Monthly Review: {data_class}\n"]
+
+        for entry in entries:
+            short = _short_id(entry.element_id)
+            content_preview = entry.content[:MAX_CONTENT_LENGTH]
+            if len(entry.content) > MAX_CONTENT_LENGTH:
+                content_preview += "..."
+            date_str = _format_date(entry.created_at)
+
+            lines.append(f"{content_preview}")
+            lines.append(f"Stored: {date_str}")
+
+            if data_class == "world-event":
+                lines.append(
+                    f"/keep_{short}  /archive_{short}  /discard_{short}"
+                )
+            else:
+                lines.append(f"/keep_{short}  /discard_{short}")
+
+            lines.append("")  # blank line separator
+
+        messages[data_class] = "\n".join(lines).strip()
+
+    return messages
+
+
+def handle_keep(element_id: str) -> dict:
+    """Mark an entry as reviewed (keep it active).
+
+    Sets last_reviewed_at to current timestamp.
+
+    Returns:
+        Result dict with ok, action keys.
+    """
+    try:
+        driver = _get_driver()
+        now_ts = int(time.time())
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (m) WHERE elementId(m) = $id
+                SET m.last_reviewed_at = $now
+                RETURN count(m) AS count
+                """,
+                id=element_id,
+                now=now_ts,
+            )
+            record = result.single()
+            if record and record["count"] > 0:
+                logger.info("Kept entry %s (last_reviewed_at=%d)", element_id, now_ts)
+                return {"ok": True, "action": "keep"}
+            return {"ok": False, "error": f"Entry not found: {element_id}"}
+    except Exception as e:
+        logger.exception("handle_keep failed for %s", element_id)
+        return {"ok": False, "error": str(e)}
+
+
+def handle_archive(element_id: str) -> dict:
+    """Archive a world-event entry.
+
+    Reads the full entry from Neo4j, saves it to the ArchiveStore,
+    then marks it as archived in Neo4j.
+
+    Returns:
+        Result dict with ok, action keys.
+    """
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            # Read the full entry
+            result = session.run(
+                """
+                MATCH (m) WHERE elementId(m) = $id
+                RETURN m.content AS content,
+                       m.data_class AS data_class,
+                       m.tags AS tags,
+                       m.source AS source,
+                       m.agent_id AS agent_id,
+                       m.created_at AS created_at,
+                       properties(m) AS props
+                """,
+                id=element_id,
+            )
+            record = result.single()
+            if not record:
+                return {"ok": False, "error": f"Entry not found: {element_id}"}
+
+            data_class = record["data_class"]
+            if data_class != "world-event":
+                return {
+                    "ok": False,
+                    "error": f"Archive only allowed for world-event entries, got: {data_class}",
+                }
+
+            # Save to archive store
+            archived_entry = ArchivedEntry(
+                original_id=element_id,
+                content=record["content"],
+                data_class=data_class,
+                tags=record["tags"] or "",
+                source=record["source"] or "",
+                agent_id=record["agent_id"] or "ada",
+                created_at=record["created_at"] or 0,
+                archived_at=datetime.now(timezone.utc).isoformat(),
+                original_metadata=dict(record["props"]) if record["props"] else {},
+            )
+
+            store = _get_archive_store()
+            store.save(archived_entry)
+
+            # Mark as archived in Neo4j
+            now_ts = int(time.time())
+            session.run(
+                """
+                MATCH (m) WHERE elementId(m) = $id
+                SET m.archived = true, m.last_reviewed_at = $now
+                RETURN count(m) AS count
+                """,
+                id=element_id,
+                now=now_ts,
+            )
+
+            logger.info("Archived entry %s to store", element_id)
+            return {"ok": True, "action": "archive"}
+
+    except Exception as e:
+        logger.exception("handle_archive failed for %s", element_id)
+        return {"ok": False, "error": str(e)}
+
+
+def handle_discard(element_id: str) -> dict:
+    """Delete an entry from Neo4j.
+
+    Idempotent: does not raise if the entry does not exist.
+
+    Returns:
+        Result dict with ok, action keys.
+    """
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            session.run(
+                "MATCH (m) WHERE elementId(m) = $id DETACH DELETE m",
+                id=element_id,
+            )
+        logger.info("Discarded entry %s", element_id)
+        return {"ok": True, "action": "discard"}
+    except Exception as e:
+        logger.exception("handle_discard failed for %s", element_id)
+        return {"ok": False, "error": str(e)}
+
+
+def sweep_monthly_review() -> dict:
+    """Orchestrate the monthly review sweep.
+
+    Queries entries due for review, builds messages, and sends them
+    via Telegram grouped by data class.
+
+    Returns:
+        Summary dict with entries_found, messages_sent, errors.
+    """
+    entries_found = 0
+    messages_sent = 0
+    errors = 0
+
+    try:
+        grouped = query_entries_for_review()
+        entries_found = sum(len(v) for v in grouped.values())
+
+        if entries_found == 0:
+            logger.info("Monthly review sweep: no entries due for review")
+            return {"entries_found": 0, "messages_sent": 0, "errors": 0}
+
+        messages = build_review_messages(grouped)
+
+        for data_class, message in messages.items():
+            try:
+                _telegram_direct(message)
+                messages_sent += 1
+                logger.info(
+                    "Sent monthly review message for %s (%d entries)",
+                    data_class,
+                    len(grouped.get(data_class, [])),
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to send monthly review message for %s",
+                    data_class,
+                )
+                errors += 1
+
+    except Exception:
+        logger.exception("Monthly review sweep failed")
+        errors += 1
+
+    logger.info(
+        "Monthly review sweep complete: entries_found=%d, messages_sent=%d, errors=%d",
+        entries_found,
+        messages_sent,
+        errors,
+    )
+    return {
+        "entries_found": entries_found,
+        "messages_sent": messages_sent,
+        "errors": errors,
+    }

--- a/server.py
+++ b/server.py
@@ -263,6 +263,57 @@ async def epilogue_sweep(x_hitl_internal: str = Header(None)):
 
 
 # ---------------------------------------------------------------------------
+# Monthly Review Sweep
+# ---------------------------------------------------------------------------
+@app.post("/memory/monthly-review")
+async def memory_monthly_review(x_hitl_internal: str = Header(None)):
+    """Trigger monthly review sweep for world-event, intention, session-log entries."""
+    if not config.hitl_internal_token:
+        return JSONResponse({"error": "HITL not configured"}, status_code=500)
+    if x_hitl_internal != config.hitl_internal_token:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+    from core.monthly_review import sweep_monthly_review
+    results = await asyncio.to_thread(sweep_monthly_review)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Monthly Review Response
+# ---------------------------------------------------------------------------
+class ReviewRespondRequest(BaseModel):
+    element_id: str
+    action: str
+
+
+@app.post("/memory/review-respond")
+async def memory_review_respond(
+    body: ReviewRespondRequest,
+    x_hitl_internal: str = Header(None),
+):
+    """Handle keep/archive/discard response for a monthly review entry."""
+    if not config.hitl_internal_token:
+        return JSONResponse({"error": "HITL not configured"}, status_code=500)
+    if x_hitl_internal != config.hitl_internal_token:
+        return JSONResponse({"error": "unauthorized"}, status_code=401)
+
+    action = body.action.lower()
+    if action == "keep":
+        from core.monthly_review import handle_keep
+        return await asyncio.to_thread(handle_keep, body.element_id)
+    elif action == "archive":
+        from core.monthly_review import handle_archive
+        return await asyncio.to_thread(handle_archive, body.element_id)
+    elif action == "discard":
+        from core.monthly_review import handle_discard
+        return await asyncio.to_thread(handle_discard, body.element_id)
+    else:
+        return JSONResponse(
+            {"error": f"Invalid action: {body.action}. Must be keep, archive, or discard."},
+            status_code=400,
+        )
+
+
+# ---------------------------------------------------------------------------
 # WebSocket endpoint
 # ---------------------------------------------------------------------------
 @app.websocket("/sessions/{session_id}/stream")

--- a/tests/api/test_monthly_review.py
+++ b/tests/api/test_monthly_review.py
@@ -1,0 +1,173 @@
+"""API tests for the /memory/monthly-review and /memory/review-respond endpoints."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+_AUTH_HEADER = {"X-HITL-Internal": "test-token"}
+
+
+class TestMonthlyReviewEndpoint:
+    """Tests for POST /memory/monthly-review."""
+
+    def test_monthly_review_endpoint_returns_200(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg, \
+             patch("core.monthly_review.sweep_monthly_review", return_value={"entries_found": 3, "messages_sent": 2, "errors": 0}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/monthly-review", headers=_AUTH_HEADER)
+            assert response.status_code == 200
+
+    def test_monthly_review_rejects_missing_token(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/monthly-review")
+            assert response.status_code == 401
+
+    def test_monthly_review_rejects_wrong_token(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/monthly-review",
+                headers={"X-HITL-Internal": "wrong-token"},
+            )
+            assert response.status_code == 401
+
+    def test_monthly_review_returns_summary_counts(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg, \
+             patch("core.monthly_review.sweep_monthly_review", return_value={"entries_found": 5, "messages_sent": 3, "errors": 0}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/monthly-review", headers=_AUTH_HEADER)
+            data = response.json()
+            assert "entries_found" in data
+            assert "messages_sent" in data
+            assert "errors" in data
+            assert data["entries_found"] == 5
+            assert data["messages_sent"] == 3
+
+    def test_monthly_review_uses_to_thread(self) -> None:
+        """Assert that the endpoint runs sweep via asyncio.to_thread."""
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg, \
+             patch("core.monthly_review.sweep_monthly_review", return_value={"entries_found": 0, "messages_sent": 0, "errors": 0}) as mock_sweep, \
+             patch("server.asyncio") as mock_asyncio:
+            mock_cfg.hitl_internal_token = "test-token"
+
+            async def fake_to_thread(fn):
+                return fn()
+            mock_asyncio.to_thread = AsyncMock(side_effect=fake_to_thread)
+
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post("/memory/monthly-review", headers=_AUTH_HEADER)
+            assert response.status_code == 200
+            mock_asyncio.to_thread.assert_called_once_with(mock_sweep)
+
+
+class TestReviewRespondEndpoint:
+    """Tests for POST /memory/review-respond."""
+
+    def test_review_respond_keep_returns_200(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg, \
+             patch("core.monthly_review.handle_keep", return_value={"ok": True, "action": "keep"}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/review-respond",
+                headers=_AUTH_HEADER,
+                json={"element_id": "4:abc:123", "action": "keep"},
+            )
+            assert response.status_code == 200
+
+    def test_review_respond_archive_returns_200(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg, \
+             patch("core.monthly_review.handle_archive", return_value={"ok": True, "action": "archive"}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/review-respond",
+                headers=_AUTH_HEADER,
+                json={"element_id": "4:abc:123", "action": "archive"},
+            )
+            assert response.status_code == 200
+
+    def test_review_respond_discard_returns_200(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg, \
+             patch("core.monthly_review.handle_discard", return_value={"ok": True, "action": "discard"}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/review-respond",
+                headers=_AUTH_HEADER,
+                json={"element_id": "4:abc:123", "action": "discard"},
+            )
+            assert response.status_code == 200
+
+    def test_review_respond_invalid_action_returns_400(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/review-respond",
+                headers=_AUTH_HEADER,
+                json={"element_id": "4:abc:123", "action": "unknown"},
+            )
+            assert response.status_code == 400
+
+    def test_review_respond_rejects_missing_token(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/review-respond",
+                json={"element_id": "4:abc:123", "action": "keep"},
+            )
+            assert response.status_code == 401
+
+    def test_review_respond_returns_handler_result(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.config") as mock_cfg, \
+             patch("core.monthly_review.handle_keep", return_value={"ok": True, "action": "keep"}):
+            mock_cfg.hitl_internal_token = "test-token"
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.post(
+                "/memory/review-respond",
+                headers=_AUTH_HEADER,
+                json={"element_id": "4:abc:123", "action": "keep"},
+            )
+            data = response.json()
+            assert data["ok"] is True
+            assert data["action"] == "keep"

--- a/tests/integration/test_memory_metadata_flow.py
+++ b/tests/integration/test_memory_metadata_flow.py
@@ -77,6 +77,7 @@ class TestStoreRetrieveMetadataFlow:
             "expires_at": None,
             "superseded": False,
             "codebase_ref": None,
+            "archived": None,
         }[key]
         retrieve_result_mock = MagicMock()
         retrieve_result_mock.__iter__ = MagicMock(return_value=iter([record_mock]))

--- a/tests/integration/test_monthly_review_flow.py
+++ b/tests/integration/test_monthly_review_flow.py
@@ -1,0 +1,216 @@
+"""Integration tests for the monthly review flow.
+
+Tests the full flow from query to handler execution,
+composing the sweep query, handler functions, and archive store
+in realistic combinations.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock neo4j and agent_tooling for importing agents.memory / core modules."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver() -> MagicMock:
+    """Create a mock Neo4j driver."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_driver
+
+
+def _make_mock_driver_with_query_results(records: list[dict]) -> MagicMock:
+    """Create a mock Neo4j driver that returns given records from the query."""
+    mock_driver = _make_mock_driver()
+    mock_session = mock_driver.session.return_value.__enter__.return_value
+
+    mock_query_result = MagicMock()
+    mock_query_result.__iter__ = MagicMock(return_value=iter(records))
+    mock_session.run.return_value = mock_query_result
+
+    return mock_driver
+
+
+class TestFullReviewFlowKeep:
+    """Integration test: keep handler updates last_reviewed_at."""
+
+    def test_full_review_flow_keep_updates_last_reviewed_at(self) -> None:
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"count": 1}
+        mock_session.run.return_value = mock_result
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.handle_keep("4:abc:123")
+
+        assert result["ok"] is True
+        assert result["action"] == "keep"
+
+        # Verify the SET query was called with last_reviewed_at
+        cypher = mock_session.run.call_args[0][0]
+        assert "last_reviewed_at" in cypher
+        assert "SET" in cypher
+        # Verify timestamp was passed
+        params = mock_session.run.call_args[1]
+        assert "now" in params
+        assert isinstance(params["now"], int)
+
+
+class TestFullReviewFlowArchive:
+    """Integration test: archive handler saves to store AND marks archived in Neo4j."""
+
+    def test_full_review_flow_archive_saves_and_marks(self, tmp_path: Path) -> None:
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        # First call: entry lookup
+        mock_entry = MagicMock()
+        mock_entry.single.return_value = {
+            "content": "Earthquake in Turkey",
+            "data_class": "world-event",
+            "tags": "news",
+            "source": "user",
+            "agent_id": "ada",
+            "created_at": 1700000000,
+            "props": {"tier": "T3", "data_class": "world-event"},
+        }
+        # Second call: SET archived
+        mock_set_result = MagicMock()
+        mock_set_result.single.return_value = {"count": 1}
+        mock_session.run.side_effect = [mock_entry, mock_set_result]
+
+        from core import monthly_review
+        from core.archive_store import ArchiveStore
+
+        store = ArchiveStore(tmp_path / "archive.json")
+
+        with (
+            patch.object(monthly_review, "_get_driver", return_value=mock_driver),
+            patch.object(monthly_review, "_get_archive_store", return_value=store),
+        ):
+            result = monthly_review.handle_archive("4:abc:123")
+
+        assert result["ok"] is True
+        assert result["action"] == "archive"
+
+        # Verify entry was saved to archive store
+        entries = store.list_all()
+        assert len(entries) == 1
+        assert entries[0].content == "Earthquake in Turkey"
+        assert entries[0].original_id == "4:abc:123"
+
+        # Verify SET archived query was called
+        set_call = mock_session.run.call_args_list[-1]
+        cypher = set_call[0][0]
+        assert "archived" in cypher.lower()
+        assert "true" in cypher.lower()
+
+
+class TestFullReviewFlowDiscard:
+    """Integration test: discard handler runs DETACH DELETE."""
+
+    def test_full_review_flow_discard_deletes_entry(self) -> None:
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.handle_discard("4:abc:123")
+
+        assert result["ok"] is True
+        assert result["action"] == "discard"
+
+        cypher = mock_session.run.call_args[0][0]
+        assert "DETACH DELETE" in cypher
+        assert mock_session.run.call_args[1]["id"] == "4:abc:123"
+
+
+class TestMonthlyReviewSweepToTelegram:
+    """Integration test: sweep queries entries, builds messages, sends via Telegram."""
+
+    def test_monthly_review_sweep_to_telegram_message(self) -> None:
+        records = [
+            {
+                "content": "Earthquake in Turkey",
+                "data_class": "world-event",
+                "created_at": 1700000000,
+                "last_reviewed_at": None,
+                "id": "4:abc:123",
+            },
+            {
+                "content": "Learn Rust",
+                "data_class": "intention",
+                "created_at": 1700000001,
+                "last_reviewed_at": None,
+                "id": "4:def:456",
+            },
+        ]
+        mock_driver = _make_mock_driver_with_query_results(records)
+
+        from core import monthly_review
+
+        with (
+            patch.object(monthly_review, "_get_driver", return_value=mock_driver),
+            patch.object(monthly_review, "_telegram_direct", return_value=(True, "sent")) as mock_tg,
+        ):
+            result = monthly_review.sweep_monthly_review()
+
+        assert result["entries_found"] == 2
+        assert result["messages_sent"] == 2  # one per class
+        assert result["errors"] == 0
+
+        # Verify two Telegram messages were sent (one per class)
+        assert mock_tg.call_count == 2
+
+        # Verify message content
+        all_messages = [call[0][0] for call in mock_tg.call_args_list]
+        combined = "\n".join(all_messages)
+        assert "Earthquake in Turkey" in combined
+        assert "Learn Rust" in combined
+        assert "/keep_" in combined
+        assert "/discard_" in combined
+
+
+class TestArchivedEntryExcludedFromRetrieve:
+    """Integration test: after archiving, entry no longer appears in default memory_retrieve."""
+
+    def test_archived_entry_excluded_from_memory_retrieve(self) -> None:
+        """Verify that the memory_retrieve query includes the archived filter."""
+        mock_driver = _make_mock_driver()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_session.run.return_value = mock_result
+
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            mem_mod.memory_retrieve("earthquake")
+
+        cypher = mock_session.run.call_args[0][0]
+        # The default query should exclude archived entries
+        assert "m.archived IS NULL OR m.archived = false" in cypher

--- a/tests/unit/test_archive_store.py
+++ b/tests/unit/test_archive_store.py
@@ -1,0 +1,167 @@
+"""Unit tests for the archive store abstraction (core.archive_store)."""
+
+import json
+from pathlib import Path
+
+
+from core.archive_store import ArchivedEntry, ArchiveStore
+
+
+def _make_entry(
+    original_id: str = "4:abc:123",
+    content: str = "Test content",
+    data_class: str = "world-event",
+    tags: str = "test",
+    source: str = "user",
+    agent_id: str = "ada",
+    created_at: int = 1700000000,
+    archived_at: str = "2026-03-01T00:00:00Z",
+    original_metadata: dict | None = None,
+) -> ArchivedEntry:
+    return ArchivedEntry(
+        original_id=original_id,
+        content=content,
+        data_class=data_class,
+        tags=tags,
+        source=source,
+        agent_id=agent_id,
+        created_at=created_at,
+        archived_at=archived_at,
+        original_metadata=original_metadata or {"tier": "T3"},
+    )
+
+
+class TestArchiveStoreSave:
+    """Tests for ArchiveStore.save()."""
+
+    def test_save_creates_file_if_not_exists(self, tmp_path: Path) -> None:
+        """Saving to a non-existent file creates it and writes valid JSON."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+        entry = _make_entry()
+
+        store.save(entry)
+
+        assert store_path.exists()
+        data = json.loads(store_path.read_text())
+        assert isinstance(data, list)
+        assert len(data) == 1
+
+    def test_save_appends_to_existing_entries(self, tmp_path: Path) -> None:
+        """Saving a second entry results in two entries in the file."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+
+        store.save(_make_entry(original_id="id-1", content="First"))
+        store.save(_make_entry(original_id="id-2", content="Second"))
+
+        data = json.loads(store_path.read_text())
+        assert len(data) == 2
+        assert data[0]["original_id"] == "id-1"
+        assert data[1]["original_id"] == "id-2"
+
+    def test_save_writes_correct_schema_fields(self, tmp_path: Path) -> None:
+        """Saved JSON contains archived_at, original_id, content, data_class, original_metadata."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+        entry = _make_entry(
+            original_id="test-id",
+            content="World event content",
+            data_class="world-event",
+            archived_at="2026-03-01T12:00:00Z",
+            original_metadata={"tier": "T3", "as_of": "2026-01-15"},
+        )
+
+        store.save(entry)
+
+        data = json.loads(store_path.read_text())
+        saved = data[0]
+        assert saved["original_id"] == "test-id"
+        assert saved["content"] == "World event content"
+        assert saved["data_class"] == "world-event"
+        assert saved["archived_at"] == "2026-03-01T12:00:00Z"
+        assert saved["original_metadata"]["tier"] == "T3"
+        assert saved["tags"] == "test"
+        assert saved["source"] == "user"
+        assert saved["agent_id"] == "ada"
+        assert saved["created_at"] == 1700000000
+
+    def test_save_handles_concurrent_write_gracefully(self, tmp_path: Path) -> None:
+        """No data corruption on rapid sequential saves."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+
+        for i in range(20):
+            store.save(_make_entry(original_id=f"id-{i}", content=f"Entry {i}"))
+
+        data = json.loads(store_path.read_text())
+        assert len(data) == 20
+        ids = {entry["original_id"] for entry in data}
+        assert len(ids) == 20
+
+
+class TestArchiveStoreListAll:
+    """Tests for ArchiveStore.list_all()."""
+
+    def test_list_all_returns_saved_entries(self, tmp_path: Path) -> None:
+        """list_all returns all previously saved entries."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+        store.save(_make_entry(original_id="id-1"))
+        store.save(_make_entry(original_id="id-2"))
+
+        entries = store.list_all()
+
+        assert len(entries) == 2
+        assert entries[0].original_id == "id-1"
+        assert entries[1].original_id == "id-2"
+
+    def test_list_all_empty_file_returns_empty_list(self, tmp_path: Path) -> None:
+        """list_all returns [] when file is empty or missing."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+
+        entries = store.list_all()
+        assert entries == []
+
+    def test_list_all_returns_archived_entry_instances(self, tmp_path: Path) -> None:
+        """list_all returns ArchivedEntry dataclass instances."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+        store.save(_make_entry())
+
+        entries = store.list_all()
+        assert isinstance(entries[0], ArchivedEntry)
+
+
+class TestArchiveStoreGet:
+    """Tests for ArchiveStore.get()."""
+
+    def test_get_by_original_id_returns_entry(self, tmp_path: Path) -> None:
+        """get(id) returns the matching archived entry."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+        store.save(_make_entry(original_id="target-id", content="Found me"))
+
+        result = store.get("target-id")
+
+        assert result is not None
+        assert result.original_id == "target-id"
+        assert result.content == "Found me"
+
+    def test_get_by_original_id_not_found_returns_none(self, tmp_path: Path) -> None:
+        """get(id) returns None for unknown ID."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+        store.save(_make_entry(original_id="other-id"))
+
+        result = store.get("nonexistent-id")
+        assert result is None
+
+    def test_get_from_empty_store_returns_none(self, tmp_path: Path) -> None:
+        """get() returns None when store is empty."""
+        store_path = tmp_path / "archive.json"
+        store = ArchiveStore(store_path)
+
+        result = store.get("any-id")
+        assert result is None

--- a/tests/unit/test_memory_backward_compat.py
+++ b/tests/unit/test_memory_backward_compat.py
@@ -1,7 +1,6 @@
 """Unit tests for data_class requirement -- calling without data_class raises TypeError."""
 
 import json
-import logging
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -117,6 +116,7 @@ class TestMemoryRetrieveBackwardCompat:
             "expires_at": None,
             "superseded": False,
             "codebase_ref": None,
+            "archived": None,
         }[key]
 
         record_without_meta = MagicMock()
@@ -133,6 +133,7 @@ class TestMemoryRetrieveBackwardCompat:
             "expires_at": None,
             "superseded": None,
             "codebase_ref": None,
+            "archived": None,
         }[key]
 
         mock_result = MagicMock()

--- a/tests/unit/test_memory_retrieve_archived.py
+++ b/tests/unit/test_memory_retrieve_archived.py
@@ -1,0 +1,134 @@
+"""Unit tests for memory_retrieve archived entry filtering (agents.memory)."""
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock neo4j and agent_tooling for importing agents.memory."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_mock_driver_for_retrieve(records: list[dict]) -> MagicMock:
+    """Create a mock Neo4j driver that returns given records."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_result = MagicMock()
+    mock_result.__iter__ = MagicMock(return_value=iter(records))
+    mock_session.run.return_value = mock_result
+
+    return mock_driver
+
+
+class TestMemoryRetrieveArchived:
+    """Tests for the include_archived parameter on memory_retrieve."""
+
+    def test_memory_retrieve_excludes_archived_by_default(self) -> None:
+        """The Cypher query includes an archived filter when include_archived=False."""
+        mock_driver = _make_mock_driver_for_retrieve([])
+
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            mem_mod.memory_retrieve("test query")
+
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        cypher = mock_session.run.call_args[0][0]
+        assert "archived" in cypher.lower()
+        # Should filter out archived entries by default
+        assert "m.archived IS NULL OR m.archived = false" in cypher
+
+    def test_memory_retrieve_includes_archived_when_flag_set(self) -> None:
+        """The Cypher query does NOT filter on archived when include_archived=True."""
+        mock_driver = _make_mock_driver_for_retrieve([])
+
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            mem_mod.memory_retrieve("test query", include_archived=True)
+
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        cypher = mock_session.run.call_args[0][0]
+        # Should NOT have the archived filter
+        assert "m.archived IS NULL OR m.archived = false" not in cypher
+
+    def test_memory_retrieve_signature_has_include_archived_param(self) -> None:
+        """The function signature includes include_archived: bool = False."""
+        import agents.memory as mem_mod
+        import inspect
+        sig = inspect.signature(mem_mod.memory_retrieve)
+        assert "include_archived" in sig.parameters
+        param = sig.parameters["include_archived"]
+        assert param.default is False
+
+    def test_memory_retrieve_excludes_archived_with_tag_filter(self) -> None:
+        """The archived filter is also applied when tag_filter is provided."""
+        mock_driver = _make_mock_driver_for_retrieve([])
+
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            mem_mod.memory_retrieve("test query", tag_filter="news")
+
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        cypher = mock_session.run.call_args[0][0]
+        assert "m.archived IS NULL OR m.archived = false" in cypher
+
+    def test_memory_retrieve_returns_archived_field_in_results(self) -> None:
+        """Each result includes the archived field value."""
+        records = [
+            {
+                "content": "Test memory",
+                "tags": "test",
+                "source": "user",
+                "agent_id": "ada",
+                "created_at": 1700000000,
+                "score": 0.95,
+                "data_class": "world-event",
+                "tier": "T3",
+                "as_of": None,
+                "expires_at": None,
+                "superseded": False,
+                "codebase_ref": None,
+                "archived": False,
+            },
+        ]
+        mock_driver = _make_mock_driver_for_retrieve(records)
+
+        import agents.memory as mem_mod
+
+        with (
+            patch.object(mem_mod, "_get_driver", return_value=mock_driver),
+            patch.object(mem_mod, "_embed", return_value=[0.1] * 4096),
+            patch.object(mem_mod, "_index_created", True),
+        ):
+            result = json.loads(mem_mod.memory_retrieve("test query", include_archived=True))
+
+        assert "memories" in result
+        assert len(result["memories"]) == 1
+        assert "archived" in result["memories"][0]

--- a/tests/unit/test_memory_retrieve_metadata.py
+++ b/tests/unit/test_memory_retrieve_metadata.py
@@ -41,6 +41,7 @@ class TestMemoryRetrieveMetadata:
             expires_at=None,
             superseded=False,
             codebase_ref=None,
+            archived=None,
         )
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([record]))
@@ -74,6 +75,7 @@ class TestMemoryRetrieveMetadata:
             expires_at=None,
             superseded=False,
             codebase_ref=None,
+            archived=None,
         )
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([record]))
@@ -106,6 +108,7 @@ class TestMemoryRetrieveMetadata:
             expires_at=None,
             superseded=False,
             codebase_ref=None,
+            archived=None,
         )
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([record]))
@@ -141,6 +144,7 @@ class TestMemoryRetrieveMetadata:
             expires_at=None,
             superseded=None,
             codebase_ref=None,
+            archived=None,
         )
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([record]))

--- a/tests/unit/test_monthly_review.py
+++ b/tests/unit/test_monthly_review.py
@@ -1,0 +1,618 @@
+"""Unit tests for the monthly review module (core.monthly_review)."""
+
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock neo4j, agent_tooling, and keyring for importing agents.memory / core modules."""
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_review_record(
+    content: str = "Test content",
+    data_class: str = "world-event",
+    created_at: int = 1700000000,
+    last_reviewed_at: int | None = None,
+    element_id: str = "4:abc:123",
+    archived: bool | None = None,
+    tags: str = "",
+    source: str = "user",
+    agent_id: str = "ada",
+) -> dict:
+    """Create a mock record matching the review query result shape."""
+    return {
+        "content": content,
+        "data_class": data_class,
+        "created_at": created_at,
+        "last_reviewed_at": last_reviewed_at,
+        "id": element_id,
+    }
+
+
+def _make_mock_driver_with_results(records: list[dict]) -> MagicMock:
+    """Create a mock Neo4j driver that returns given records from the query."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+    mock_query_result = MagicMock()
+    mock_query_result.__iter__ = MagicMock(return_value=iter(records))
+
+    mock_session.run.return_value = mock_query_result
+    return mock_driver
+
+
+def _make_mock_driver_for_handlers() -> MagicMock:
+    """Create a mock Neo4j driver for handler tests (single record lookups)."""
+    mock_driver = MagicMock()
+    mock_session = MagicMock()
+    mock_driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_driver
+
+
+# =========================================================================
+# Step 2: Query tests
+# =========================================================================
+class TestQueryEntriesForReview:
+    """Tests for query_entries_for_review in core.monthly_review."""
+
+    def test_query_returns_entries_due_for_review_null_last_reviewed(self) -> None:
+        """Entries with last_reviewed_at=null are returned."""
+        records = [
+            _make_review_record(content="Event A", data_class="world-event", last_reviewed_at=None),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.query_entries_for_review()
+
+        assert "world-event" in result
+        assert len(result["world-event"]) == 1
+        assert result["world-event"][0].content == "Event A"
+
+    def test_query_returns_entries_reviewed_over_30_days_ago(self) -> None:
+        """Entries where last_reviewed_at is more than 30 days ago are returned."""
+        old_ts = int(time.time()) - (31 * 86400)
+        records = [
+            _make_review_record(content="Old entry", data_class="intention", last_reviewed_at=old_ts),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.query_entries_for_review()
+
+        assert "intention" in result
+        assert len(result["intention"]) == 1
+
+    def test_query_excludes_entries_reviewed_within_30_days(self) -> None:
+        """Recently-reviewed entries are NOT returned (query returns empty)."""
+        mock_driver = _make_mock_driver_with_results([])
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.query_entries_for_review()
+
+        # All groups should be empty
+        total = sum(len(v) for v in result.values())
+        assert total == 0
+
+    def test_query_filters_by_correct_data_classes(self) -> None:
+        """Only world-event, intention, session-log entries are returned."""
+        records = [
+            _make_review_record(content="E1", data_class="world-event"),
+            _make_review_record(content="E2", data_class="intention"),
+            _make_review_record(content="E3", data_class="session-log"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.query_entries_for_review()
+
+        assert "world-event" in result
+        assert "intention" in result
+        assert "session-log" in result
+
+    def test_query_excludes_archived_entries(self) -> None:
+        """The query Cypher includes an archived filter."""
+        mock_driver = _make_mock_driver_with_results([])
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            monthly_review.query_entries_for_review()
+
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+        cypher = mock_session.run.call_args[0][0]
+        assert "archived" in cypher.lower()
+
+    def test_entries_grouped_by_data_class(self) -> None:
+        """The return dict has keys for each class with entries as values."""
+        records = [
+            _make_review_record(content="W1", data_class="world-event", element_id="id-1"),
+            _make_review_record(content="I1", data_class="intention", element_id="id-2"),
+            _make_review_record(content="W2", data_class="world-event", element_id="id-3"),
+        ]
+        mock_driver = _make_mock_driver_with_results(records)
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.query_entries_for_review()
+
+        assert len(result["world-event"]) == 2
+        assert len(result["intention"]) == 1
+
+    def test_empty_results_returns_empty_groups(self) -> None:
+        """No error when no entries are due for review."""
+        mock_driver = _make_mock_driver_with_results([])
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.query_entries_for_review()
+
+        assert isinstance(result, dict)
+        total = sum(len(v) for v in result.values())
+        assert total == 0
+
+
+# =========================================================================
+# Regression: _short_id must be a no-op (C1 fix)
+# =========================================================================
+class TestShortIdNoOp:
+    """Verify _short_id returns the full element ID (no truncation)."""
+
+    def test_short_id_returns_full_element_id(self) -> None:
+        """_short_id must return the complete element ID for Neo4j lookups."""
+        from core.monthly_review import _short_id
+
+        full_id = "4:abcdef123456:789"
+        assert _short_id(full_id) == full_id
+
+    def test_short_id_preserves_colons(self) -> None:
+        """_short_id must preserve colons in Neo4j element IDs."""
+        from core.monthly_review import _short_id
+
+        assert ":" in _short_id("4:abc:123")
+
+
+# =========================================================================
+# Step 3: Message builder tests
+# =========================================================================
+class TestBuildReviewMessages:
+    """Tests for build_review_messages in core.monthly_review."""
+
+    def _make_review_entry(self, **kwargs):
+        from core.monthly_review import ReviewEntry
+        defaults = {
+            "element_id": "4:abc:123",
+            "content": "Test content",
+            "data_class": "world-event",
+            "created_at": 1700000000,
+            "last_reviewed_at": None,
+        }
+        defaults.update(kwargs)
+        return ReviewEntry(**defaults)
+
+    def test_build_review_message_groups_by_class(self) -> None:
+        """Message contains class-based section headers."""
+        from core.monthly_review import build_review_messages
+
+        grouped = {
+            "world-event": [self._make_review_entry(data_class="world-event")],
+            "intention": [self._make_review_entry(data_class="intention")],
+        }
+
+        messages = build_review_messages(grouped)
+
+        assert "world-event" in messages
+        assert "intention" in messages
+
+    def test_build_review_message_includes_entry_summary(self) -> None:
+        """Each entry's content (truncated) and date are in the message."""
+        from core.monthly_review import build_review_messages
+
+        grouped = {
+            "world-event": [
+                self._make_review_entry(content="Major earthquake in Turkey", created_at=1700000000),
+            ],
+        }
+
+        messages = build_review_messages(grouped)
+        msg = messages["world-event"]
+        assert "Major earthquake in Turkey" in msg
+
+    def test_build_review_message_includes_action_commands(self) -> None:
+        """Each entry has /keep_<id>, /archive_<id> (world-event), /discard_<id> commands with full element IDs."""
+        from core.monthly_review import build_review_messages
+
+        grouped = {
+            "world-event": [
+                self._make_review_entry(element_id="4:abcdef123456:789", data_class="world-event"),
+            ],
+        }
+
+        messages = build_review_messages(grouped)
+        msg = messages["world-event"]
+        # Full element ID must be used in commands (not truncated)
+        assert "/keep_4:abcdef123456:789" in msg
+        assert "/archive_4:abcdef123456:789" in msg
+        assert "/discard_4:abcdef123456:789" in msg
+
+    def test_build_review_message_archive_only_for_world_events(self) -> None:
+        """/archive_<id> only appears for world-event, not for intention or session-log."""
+        from core.monthly_review import build_review_messages
+
+        grouped = {
+            "intention": [
+                self._make_review_entry(element_id="4:int123456789:1", data_class="intention"),
+            ],
+            "session-log": [
+                self._make_review_entry(element_id="4:ses123456789:1", data_class="session-log"),
+            ],
+        }
+
+        messages = build_review_messages(grouped)
+
+        assert "/archive_" not in messages["intention"]
+        assert "/archive_" not in messages["session-log"]
+        # But keep and discard are there
+        assert "/keep_" in messages["intention"]
+        assert "/discard_" in messages["intention"]
+
+    def test_build_review_message_truncates_long_content(self) -> None:
+        """Entries with very long content are truncated."""
+        from core.monthly_review import build_review_messages
+
+        long_content = "A" * 500
+        grouped = {
+            "world-event": [
+                self._make_review_entry(content=long_content),
+            ],
+        }
+
+        messages = build_review_messages(grouped)
+        msg = messages["world-event"]
+        # Content should be truncated to 200 chars max in the message
+        assert "A" * 201 not in msg
+
+    def test_build_review_message_single_message_per_class(self) -> None:
+        """One message string is returned per class group."""
+        from core.monthly_review import build_review_messages
+
+        grouped = {
+            "world-event": [
+                self._make_review_entry(element_id="id-1", content="Entry 1"),
+                self._make_review_entry(element_id="id-2", content="Entry 2"),
+            ],
+        }
+
+        messages = build_review_messages(grouped)
+        assert isinstance(messages["world-event"], str)
+        assert "Entry 1" in messages["world-event"]
+        assert "Entry 2" in messages["world-event"]
+
+
+# =========================================================================
+# Step 4: Response handler tests
+# =========================================================================
+class TestHandleKeep:
+    """Tests for handle_keep in core.monthly_review."""
+
+    def test_handle_keep_sets_last_reviewed_at(self) -> None:
+        """Neo4j SET query updates last_reviewed_at to current timestamp."""
+        mock_driver = _make_mock_driver_for_handlers()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        # Simulate that the entry exists (counters > 0)
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"count": 1}
+        mock_session.run.return_value = mock_result
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.handle_keep("4:abc:123")
+
+        assert result["ok"] is True
+        assert result["action"] == "keep"
+
+        # Verify SET query was called
+        calls = mock_session.run.call_args_list
+        set_call = calls[-1]
+        cypher = set_call[0][0]
+        assert "last_reviewed_at" in cypher
+
+    def test_handle_keep_does_not_modify_other_fields(self) -> None:
+        """Only last_reviewed_at is changed."""
+        mock_driver = _make_mock_driver_for_handlers()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"count": 1}
+        mock_session.run.return_value = mock_result
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            monthly_review.handle_keep("4:abc:123")
+
+        calls = mock_session.run.call_args_list
+        set_call = calls[-1]
+        cypher = set_call[0][0]
+        # Should only SET last_reviewed_at, nothing else
+        assert "archived" not in cypher.lower() or "last_reviewed_at" in cypher
+
+    def test_handle_keep_unknown_id_returns_error(self) -> None:
+        """Error when element ID does not exist."""
+        mock_driver = _make_mock_driver_for_handlers()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        mock_result = MagicMock()
+        mock_result.single.return_value = {"count": 0}
+        mock_session.run.return_value = mock_result
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.handle_keep("nonexistent-id")
+
+        assert result["ok"] is False
+        assert "error" in result
+
+
+class TestHandleArchive:
+    """Tests for handle_archive in core.monthly_review."""
+
+    def test_handle_archive_marks_archived_true(self) -> None:
+        """Neo4j SET query sets archived=true."""
+        mock_driver = _make_mock_driver_for_handlers()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        # First call: lookup the entry
+        mock_entry = MagicMock()
+        mock_entry.single.return_value = {
+            "content": "World event",
+            "data_class": "world-event",
+            "tags": "",
+            "source": "user",
+            "agent_id": "ada",
+            "created_at": 1700000000,
+            "props": {"tier": "T3"},
+        }
+        # Second call: the SET query
+        mock_set_result = MagicMock()
+        mock_set_result.single.return_value = {"count": 1}
+        mock_session.run.side_effect = [mock_entry, mock_set_result]
+
+        from core import monthly_review
+
+        with (
+            patch.object(monthly_review, "_get_driver", return_value=mock_driver),
+            patch.object(monthly_review, "_get_archive_store") as mock_store_fn,
+        ):
+            mock_store = MagicMock()
+            mock_store_fn.return_value = mock_store
+            result = monthly_review.handle_archive("4:abc:123")
+
+        assert result["ok"] is True
+        assert result["action"] == "archive"
+
+        # Verify the SET query includes archived=true
+        set_call = mock_session.run.call_args_list[-1]
+        cypher = set_call[0][0]
+        assert "archived" in cypher.lower()
+
+    def test_handle_archive_saves_to_archive_store(self) -> None:
+        """ArchiveStore.save() is called with correct entry data."""
+        mock_driver = _make_mock_driver_for_handlers()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        mock_entry = MagicMock()
+        mock_entry.single.return_value = {
+            "content": "Earthquake in Turkey",
+            "data_class": "world-event",
+            "tags": "news",
+            "source": "user",
+            "agent_id": "ada",
+            "created_at": 1700000000,
+            "props": {"tier": "T3"},
+        }
+        mock_set_result = MagicMock()
+        mock_set_result.single.return_value = {"count": 1}
+        mock_session.run.side_effect = [mock_entry, mock_set_result]
+
+        from core import monthly_review
+
+        with (
+            patch.object(monthly_review, "_get_driver", return_value=mock_driver),
+            patch.object(monthly_review, "_get_archive_store") as mock_store_fn,
+        ):
+            mock_store = MagicMock()
+            mock_store_fn.return_value = mock_store
+            monthly_review.handle_archive("4:abc:123")
+
+        mock_store.save.assert_called_once()
+        saved_entry = mock_store.save.call_args[0][0]
+        assert saved_entry.content == "Earthquake in Turkey"
+        assert saved_entry.data_class == "world-event"
+        assert saved_entry.original_id == "4:abc:123"
+
+    def test_handle_archive_only_for_world_events(self) -> None:
+        """Archive returns error for non-world-event entries."""
+        mock_driver = _make_mock_driver_for_handlers()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        mock_entry = MagicMock()
+        mock_entry.single.return_value = {
+            "content": "Some intention",
+            "data_class": "intention",
+            "tags": "",
+            "source": "user",
+            "agent_id": "ada",
+            "created_at": 1700000000,
+            "props": {},
+        }
+        mock_session.run.return_value = mock_entry
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.handle_archive("4:abc:123")
+
+        assert result["ok"] is False
+        assert "world-event" in result["error"].lower()
+
+
+class TestHandleDiscard:
+    """Tests for handle_discard in core.monthly_review."""
+
+    def test_handle_discard_deletes_from_neo4j(self) -> None:
+        """DETACH DELETE Cypher is executed for the entry."""
+        mock_driver = _make_mock_driver_for_handlers()
+        mock_session = mock_driver.session.return_value.__enter__.return_value
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.handle_discard("4:abc:123")
+
+        assert result["ok"] is True
+        assert result["action"] == "discard"
+
+        cypher = mock_session.run.call_args[0][0]
+        assert "DETACH DELETE" in cypher
+
+    def test_handle_discard_returns_success(self) -> None:
+        """The function returns a success result dict."""
+        mock_driver = _make_mock_driver_for_handlers()
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.handle_discard("4:abc:123")
+
+        assert result["ok"] is True
+
+    def test_handle_discard_unknown_id_does_not_raise(self) -> None:
+        """No exception for missing entry (idempotent)."""
+        mock_driver = _make_mock_driver_for_handlers()
+
+        from core import monthly_review
+
+        with patch.object(monthly_review, "_get_driver", return_value=mock_driver):
+            result = monthly_review.handle_discard("nonexistent-id")
+
+        assert result["ok"] is True
+
+
+# =========================================================================
+# Step 5: Sweep orchestrator tests
+# =========================================================================
+class TestSweepMonthlyReview:
+    """Tests for sweep_monthly_review in core.monthly_review."""
+
+    def test_sweep_monthly_review_queries_and_sends_messages(self) -> None:
+        """Asserts query + message build + Telegram send flow."""
+        from core.monthly_review import ReviewEntry
+
+        entries = {
+            "world-event": [
+                ReviewEntry("id-1", "Event content", "world-event", 1700000000, None),
+            ],
+        }
+
+        from core import monthly_review
+
+        with (
+            patch.object(monthly_review, "query_entries_for_review", return_value=entries),
+            patch.object(
+                monthly_review,
+                "build_review_messages",
+                return_value={"world-event": "Review message here"},
+            ),
+            patch.object(monthly_review, "_telegram_direct", return_value=(True, "sent")) as mock_tg,
+        ):
+            result = monthly_review.sweep_monthly_review()
+
+        assert result["entries_found"] == 1
+        assert result["messages_sent"] == 1
+        mock_tg.assert_called_once()
+
+    def test_sweep_monthly_review_no_entries_sends_nothing(self) -> None:
+        """No Telegram call when no entries due for review."""
+        from core import monthly_review
+
+        with (
+            patch.object(monthly_review, "query_entries_for_review", return_value={}),
+            patch.object(monthly_review, "_telegram_direct") as mock_tg,
+        ):
+            result = monthly_review.sweep_monthly_review()
+
+        assert result["entries_found"] == 0
+        assert result["messages_sent"] == 0
+        mock_tg.assert_not_called()
+
+    def test_sweep_monthly_review_returns_summary_dict(self) -> None:
+        """Return dict has entries_found, messages_sent, errors keys."""
+        from core import monthly_review
+
+        with (
+            patch.object(monthly_review, "query_entries_for_review", return_value={}),
+            patch.object(monthly_review, "_telegram_direct"),
+        ):
+            result = monthly_review.sweep_monthly_review()
+
+        assert "entries_found" in result
+        assert "messages_sent" in result
+        assert "errors" in result
+
+    def test_sweep_monthly_review_handles_telegram_failure_gracefully(self) -> None:
+        """Sweep completes even if Telegram send fails."""
+        from core.monthly_review import ReviewEntry
+
+        entries = {
+            "world-event": [
+                ReviewEntry("id-1", "Event content", "world-event", 1700000000, None),
+            ],
+        }
+
+        from core import monthly_review
+
+        with (
+            patch.object(monthly_review, "query_entries_for_review", return_value=entries),
+            patch.object(
+                monthly_review,
+                "build_review_messages",
+                return_value={"world-event": "Review msg"},
+            ),
+            patch.object(
+                monthly_review,
+                "_telegram_direct",
+                side_effect=Exception("Telegram API down"),
+            ),
+        ):
+            result = monthly_review.sweep_monthly_review()
+
+        assert result["errors"] >= 1
+        assert result["messages_sent"] == 0

--- a/tests/unit/test_monthly_review_scheduler.py
+++ b/tests/unit/test_monthly_review_scheduler.py
@@ -1,0 +1,115 @@
+"""Unit tests for the monthly review sweep scheduler integration."""
+
+import logging
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock third-party dependencies for importing clients.scheduler."""
+    # Remove cached scheduler module so it gets reimported with our mocks
+    for mod_name in list(sys.modules.keys()):
+        if mod_name.startswith("clients.scheduler"):
+            del sys.modules[mod_name]
+
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+    # Mock apscheduler modules
+    apscheduler_mock = MagicMock()
+    apscheduler_schedulers_mock = MagicMock()
+    apscheduler_schedulers_asyncio_mock = MagicMock()
+    apscheduler_triggers_mock = MagicMock()
+    apscheduler_triggers_cron_mock = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "apscheduler", apscheduler_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.schedulers", apscheduler_schedulers_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.schedulers.asyncio", apscheduler_schedulers_asyncio_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers", apscheduler_triggers_mock)
+    monkeypatch.setitem(sys.modules, "apscheduler.triggers.cron", apscheduler_triggers_cron_mock)
+
+
+class TestMonthlyReviewSweepScheduler:
+    """Tests for _monthly_review_sweep in clients.scheduler."""
+
+    @pytest.mark.asyncio
+    async def test_monthly_review_sweep_calls_endpoint(self) -> None:
+        """Assert that _monthly_review_sweep POSTs to /memory/monthly-review with auth."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"entries_found": 3, "messages_sent": 2, "errors": 0})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _monthly_review_sweep
+            await _monthly_review_sweep()
+
+            mock_session.post.assert_called_once()
+            call_args = mock_session.post.call_args
+            assert "/memory/monthly-review" in call_args[0][0]
+            assert call_args[1]["headers"]["X-HITL-Internal"] == "test-token"
+
+    @pytest.mark.asyncio
+    async def test_monthly_review_sweep_logs_results(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Assert that sweep results are logged."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"entries_found": 5, "messages_sent": 3, "errors": 0})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(return_value=mock_resp)
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg, \
+             caplog.at_level(logging.INFO, logger="hive-mind-scheduler"):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _monthly_review_sweep
+            await _monthly_review_sweep()
+
+        assert any("entries_found=5" in record.message for record in caplog.records)
+        assert any("messages_sent=3" in record.message for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_monthly_review_sweep_handles_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Assert that sweep failure is handled gracefully."""
+        mock_session = AsyncMock()
+        mock_session.post = MagicMock(side_effect=Exception("Connection refused"))
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("clients.scheduler.aiohttp.ClientSession", return_value=mock_session), \
+             patch("clients.scheduler.config") as mock_cfg, \
+             caplog.at_level(logging.ERROR, logger="hive-mind-scheduler"):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.scheduler import _monthly_review_sweep
+            # Should not raise
+            await _monthly_review_sweep()
+
+        assert any("failed" in record.message.lower() for record in caplog.records)

--- a/tests/unit/test_monthly_review_telegram.py
+++ b/tests/unit/test_monthly_review_telegram.py
@@ -1,0 +1,210 @@
+"""Unit tests for the monthly review Telegram command handlers."""
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _mock_deps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Mock third-party dependencies for importing clients.telegram_bot."""
+    # Remove cached client modules so they get reimported with our mocks
+    for mod_name in list(sys.modules.keys()):
+        if mod_name.startswith("clients."):
+            del sys.modules[mod_name]
+
+    if "neo4j" not in sys.modules:
+        neo4j_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "neo4j", neo4j_mock)
+    if "agent_tooling" not in sys.modules:
+        at_mock = MagicMock()
+        at_mock.tool = MagicMock(return_value=lambda f: f)
+        monkeypatch.setitem(sys.modules, "agent_tooling", at_mock)
+
+
+def _make_update(text: str, user_id: int = 12345) -> MagicMock:
+    """Create a mock Telegram Update with the given text and user ID."""
+    update = MagicMock()
+    update.effective_user.id = user_id
+    update.message.text = text
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+class TestReviewKeepCommand:
+    """Tests for cmd_review_keep in clients.telegram_bot."""
+
+    @pytest.mark.asyncio
+    async def test_keep_command_calls_review_respond_endpoint(self) -> None:
+        """Handler POSTs to /memory/review-respond with action=keep and full Neo4j element_id."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"ok": True, "action": "keep"})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_http = MagicMock()
+        mock_http.post = MagicMock(return_value=mock_resp)
+
+        update = _make_update("/keep_4:abc:123")
+
+        with patch("clients.telegram_bot.config") as mock_cfg, \
+             patch("clients.telegram_bot.http", mock_http), \
+             patch("clients.telegram_bot.SERVER_URL", "http://localhost:8420"), \
+             patch("clients.telegram_bot._is_allowed_user", return_value=True):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.telegram_bot import cmd_review_keep
+            await cmd_review_keep(update, MagicMock())
+
+        mock_http.post.assert_called_once()
+        call_args = mock_http.post.call_args
+        assert "/memory/review-respond" in call_args[0][0]
+        # The JSON body should include the full element_id (with colons) and action
+        json_body = call_args[1].get("json", {})
+        assert json_body["action"] == "keep"
+        assert json_body["element_id"] == "4:abc:123"
+
+
+class TestReviewArchiveCommand:
+    """Tests for cmd_review_archive in clients.telegram_bot."""
+
+    @pytest.mark.asyncio
+    async def test_archive_command_calls_review_respond_endpoint(self) -> None:
+        """Handler POSTs to /memory/review-respond with action=archive."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"ok": True, "action": "archive"})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_http = MagicMock()
+        mock_http.post = MagicMock(return_value=mock_resp)
+
+        update = _make_update("/archive_4:def:456")
+
+        with patch("clients.telegram_bot.config") as mock_cfg, \
+             patch("clients.telegram_bot.http", mock_http), \
+             patch("clients.telegram_bot.SERVER_URL", "http://localhost:8420"), \
+             patch("clients.telegram_bot._is_allowed_user", return_value=True):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.telegram_bot import cmd_review_archive
+            await cmd_review_archive(update, MagicMock())
+
+        call_args = mock_http.post.call_args
+        json_body = call_args[1].get("json", {})
+        assert json_body["action"] == "archive"
+        assert json_body["element_id"] == "4:def:456"
+
+
+class TestReviewDiscardCommand:
+    """Tests for cmd_review_discard in clients.telegram_bot."""
+
+    @pytest.mark.asyncio
+    async def test_discard_command_calls_review_respond_endpoint(self) -> None:
+        """Handler POSTs to /memory/review-respond with action=discard."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"ok": True, "action": "discard"})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_http = MagicMock()
+        mock_http.post = MagicMock(return_value=mock_resp)
+
+        update = _make_update("/discard_4:ghi:789")
+
+        with patch("clients.telegram_bot.config") as mock_cfg, \
+             patch("clients.telegram_bot.http", mock_http), \
+             patch("clients.telegram_bot.SERVER_URL", "http://localhost:8420"), \
+             patch("clients.telegram_bot._is_allowed_user", return_value=True):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.telegram_bot import cmd_review_discard
+            await cmd_review_discard(update, MagicMock())
+
+        call_args = mock_http.post.call_args
+        json_body = call_args[1].get("json", {})
+        assert json_body["action"] == "discard"
+        assert json_body["element_id"] == "4:ghi:789"
+
+
+class TestReviewCommandParsing:
+    """Tests for element ID extraction from review commands."""
+
+    @pytest.mark.asyncio
+    async def test_review_command_extracts_id_from_command(self) -> None:
+        """Full Neo4j element ID (with colons) is correctly parsed from /keep_<id>."""
+        mock_resp = AsyncMock()
+        mock_resp.json = AsyncMock(return_value={"ok": True, "action": "keep"})
+        mock_resp.status = 200
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+        mock_http = MagicMock()
+        mock_http.post = MagicMock(return_value=mock_resp)
+
+        update = _make_update("/keep_4:abc:123")
+
+        with patch("clients.telegram_bot.config") as mock_cfg, \
+             patch("clients.telegram_bot.http", mock_http), \
+             patch("clients.telegram_bot.SERVER_URL", "http://localhost:8420"), \
+             patch("clients.telegram_bot._is_allowed_user", return_value=True):
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.telegram_bot import cmd_review_keep
+            await cmd_review_keep(update, MagicMock())
+
+        json_body = mock_http.post.call_args[1].get("json", {})
+        assert json_body["element_id"] == "4:abc:123"
+
+    @pytest.mark.asyncio
+    async def test_review_command_invalid_format_replies_error(self) -> None:
+        """Error message for malformed command (no ID after prefix)."""
+        update = _make_update("/keep_")
+
+        with patch("clients.telegram_bot._is_allowed_user", return_value=True), \
+             patch("clients.telegram_bot.config") as mock_cfg:
+            mock_cfg.hitl_internal_token = "test-token"
+
+            from clients.telegram_bot import cmd_review_keep
+            await cmd_review_keep(update, MagicMock())
+
+        update.message.reply_text.assert_called_once()
+        reply_text = update.message.reply_text.call_args[0][0]
+        assert "invalid" in reply_text.lower() or "usage" in reply_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_review_command_regex_accepts_neo4j_element_ids_with_colons(self) -> None:
+        """Telegram regex patterns must accept Neo4j element IDs containing colons (e.g. 4:abc:123)."""
+        import re
+
+        # These are the regex patterns used in telegram_bot.py for review commands
+        keep_pattern = r"^/keep_[^\s]+$"
+        archive_pattern = r"^/archive_[^\s]+$"
+        discard_pattern = r"^/discard_[^\s]+$"
+
+        # Neo4j element IDs contain colons
+        neo4j_id = "4:abc:123"
+        assert re.match(keep_pattern, f"/keep_{neo4j_id}")
+        assert re.match(archive_pattern, f"/archive_{neo4j_id}")
+        assert re.match(discard_pattern, f"/discard_{neo4j_id}")
+
+        # Verify the old \w+ pattern would NOT match (regression guard)
+        old_pattern = r"^/keep_\w+$"
+        assert re.match(old_pattern, f"/keep_{neo4j_id}") is None
+
+    @pytest.mark.asyncio
+    async def test_review_command_unauthorized_user_rejected(self) -> None:
+        """Non-allowed users cannot use review commands."""
+        update = _make_update("/keep_abc123", user_id=99999)
+
+        with patch("clients.telegram_bot._is_allowed_user", return_value=False):
+            from clients.telegram_bot import cmd_review_keep
+            await cmd_review_keep(update, MagicMock())
+
+        update.message.reply_text.assert_called_once()
+        reply_text = update.message.reply_text.call_args[0][0]
+        assert "not authorized" in reply_text.lower()

--- a/tests/unit/test_techconfig_codebase_ref.py
+++ b/tests/unit/test_techconfig_codebase_ref.py
@@ -127,6 +127,7 @@ class TestCodebaseRefInMemoryStore:
             "expires_at": None,
             "superseded": False,
             "codebase_ref": "server.py",
+            "archived": None,
         }
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([mock_record]))


### PR DESCRIPTION
## Summary
- Adds a monthly scheduler job (1st of month, 9:00 AM CT) that surfaces world-event, intention, and session-log memory entries due for review via Telegram
- Implements keep/archive/discard response handlers with gateway endpoints and Telegram bot slash commands
- Adds JSON file-backed archive store for world-event entries and updates memory_retrieve to exclude archived entries by default

## Acceptance Criteria
- [x] Scheduler job runs monthly and queries all entries with data_class in (world-event, intention, session-log) that have not been reviewed in the past 30 days
- [x] Batches entries by class and sends Daniel a Telegram review message
- [x] Review message format is grouped by class (world-events together, intentions together, session-logs together)
- [x] Each entry includes brief summary + date stored + options (keep / archive / discard)
- [x] Single batched message or thread per class group (not one message per entry)
- [x] Keep response sets last_reviewed_at = now, no other change
- [x] Archive response (world-event only) moves entry to long-term document store, removes from active vector store, marks archived=True
- [x] Discard response deletes entry from vector store and/or graph
- [x] Long-term archive store for world-events is implemented (placeholder using JSON file in /data/ with design for later migration)
- [x] memory_retrieve excludes archived entries by default and supports include_archived=True flag
- [x] Tests verify monthly job correctly identifies entries due for review
- [x] Tests verify Keep updates last_reviewed_at
- [x] Tests verify Archive moves entry to archive store and removes from active retrieval
- [x] Tests verify Discard removes entry entirely
- [x] Tests verify memory_retrieve excludes archived entries by default

## Test Plan
- All unit/integration tests pass (pytest)
- mypy and ruff clean

Implemented autonomously by Ada -- Hive Mind