### PR TITLE
feat: Install gh CLI in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,16 @@ FROM ubuntu:24.04
 
 WORKDIR /usr/src/app
 
-# System deps + Node.js (for Claude Code CLI)
+# System deps + Node.js (for Claude Code CLI) + GitHub CLI
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv python3-dev gcc libpq-dev curl \
     nodejs npm \
     ffmpeg git \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 RUN ln -sf /usr/bin/python3 /usr/bin/python

--- a/server.py
+++ b/server.py
@@ -31,7 +31,7 @@ log = logging.getLogger("hive-mind.server")
 # Keyring → env bridge: expose keyring secrets as env vars so non-Python
 # consumers (e.g. Claude Code reading .mcp.container.json) can resolve them.
 # ---------------------------------------------------------------------------
-_KEYRING_ENV_KEYS = ["MCP_AUTH_TOKEN", "HITL_INTERNAL_TOKEN"]
+_KEYRING_ENV_KEYS = ["MCP_AUTH_TOKEN", "HITL_INTERNAL_TOKEN", "GITHUB_TOKEN"]
 
 try:
     import keyring as _kr


### PR DESCRIPTION
## Summary
- Adds GitHub CLI () to the Dockerfile via official apt repo
- Bridges  from keyring into subprocess env in 

Enables in-container PR management without raw API calls.

## Test plan
- [ ] Rebuild container, verify  works
- [ ] Verify  authenticates via 

🤖 Generated with [Claude Code](https://claude.com/claude-code)