### PR TITLE
fix: Add torchcodec dependency for F5-TTS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ apscheduler>=3.10
 faster-whisper>=1.0.0
 kokoro>=0.9.0
 f5-tts>=1.0.0
+torchcodec
 torch
 soundfile
 numpy


### PR DESCRIPTION
## Summary
- F5-TTS uses `torchcodec` to decode the reference WAV during inference
- Without it, every TTS call fails silently and falls back to Kokoro
- One-line fix: add `torchcodec` to requirements.txt

## Test plan
- [ ] Rebuild voice-server container
- [ ] Send a voice message — should now use the Joanna Lumley clone, not bf_alice

🤖 Generated with [Claude Code](https://claude.com/claude-code)