### PR TITLE
chore: Add stories/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ documents/
 backups/sessions.db.bak.20260228
 backups/reminders.db.bak.20260228
 
+
+# Story files (working docs, not for GitHub)
+stories/


### PR DESCRIPTION
## Summary
- Story working files (STORY-DESCRIPTION.md, IMPLEMENTATION.md, CODE-REVIEW.md, etc.) now live in `stories/` instead of `documents/`
- `stories/` is gitignored — keeps dev working docs off GitHub
- `documents/` remains tracked and publishable
- All skill and agent files updated locally (they're gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)