### PR TITLE
fix: quote all Mermaid labels, remove ambiguous special characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,17 @@ A self-improving personal assistant powered by Claude Code. The system wraps the
 
 ```mermaid
 graph TD
-    DC[Discord] --> GW
-    TG[Telegram] --> GW
-    SC[Scheduler] --> GW
+    DC["Discord"] --> GW["FastAPI Gateway"]
+    TG["Telegram"] --> GW
+    SC["Scheduler"] --> GW
 
-    GW[FastAPI Gateway]
-    GW --> SM[Session Manager]
-    SM -->|stdin/stdout NDJSON| CL[claude --stream-json]
+    GW --> SM["Session Manager"]
+    SM -->|"stdin/stdout"| CL["claude subprocess"]
 
-    CL -->|stdio| INT[hive-mind-tools - internal MCP]
-    INT -->|results| CL
-    CL -->|SSE + bearer token| EXT[hive-mind-mcp - external MCP + HITL]
-    EXT -->|results| CL
+    CL -->|"stdio"| INT["hive-mind-tools (internal MCP)"]
+    INT -->|"results"| CL
+    CL -->|"SSE"| EXT["hive-mind-mcp (external MCP, HITL gated)"]
+    EXT -->|"results"| CL
 ```
 
 Each client is a thin HTTP wrapper. The gateway spawns Claude CLI subprocesses — one per session — with full MCP tool access. Claude Code does the heavy lifting; clients just relay messages and render responses.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ graph TD
     TG[Telegram] --> GW
     SC[Scheduler] --> GW
 
-    GW["FastAPI Gateway<br/>server.py :8420"]
-    GW --> SM["Session Manager<br/>core/sessions.py<br/>process pool + SQLite"]
-    SM -->|"stdin/stdout (NDJSON)"| CL["claude -p --stream-json<br/>one process per session"]
+    GW[FastAPI Gateway]
+    GW --> SM[Session Manager]
+    SM -->|stdin/stdout NDJSON| CL[claude --stream-json]
 
-    CL <-->|stdio| INT["hive-mind-tools<br/>internal MCP<br/>(full access)"]
-    CL <-->|"SSE + bearer token"| EXT["hive-mind-mcp :9421<br/>external MCP<br/>(writes + HITL gate)"]
+    CL -->|stdio| INT[hive-mind-tools - internal MCP]
+    INT -->|results| CL
+    CL -->|SSE + bearer token| EXT[hive-mind-mcp - external MCP + HITL]
+    EXT -->|results| CL
 ```
 
 Each client is a thin HTTP wrapper. The gateway spawns Claude CLI subprocesses — one per session — with full MCP tool access. Claude Code does the heavy lifting; clients just relay messages and render responses.


### PR DESCRIPTION
## Summary

Follow-up to #24. After merging, the diagram still didn't render — the remaining issues were ambiguous special characters in unquoted contexts:

- `--stream-json` (double-dash can confuse the Mermaid parser)
- `+` in node labels
- Edge labels without double-quotes

This PR: all node labels in double-quotes, all edge labels via `|"label"|`, `--stream-json` replaced with `claude subprocess`, `+` replaced with `,`.

## Test plan

- [ ] Verify Mermaid diagram renders on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)