### PR TITLE
fix: switch to flowchart TD, strip all special chars from Mermaid

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,18 +20,17 @@ A self-improving personal assistant powered by Claude Code. The system wraps the
 
 ```mermaid
 graph TD
-    DC[Discord] --> GW
-    TG[Telegram] --> GW
-    SC[Scheduler] --> GW
+    DC["Discord"] --> GW["FastAPI Gateway"]
+    TG["Telegram"] --> GW
+    SC["Scheduler"] --> GW
 
-    GW[FastAPI Gateway]
-    GW --> SM[Session Manager]
-    SM -->|stdin/stdout NDJSON| CL[claude --stream-json]
+    GW --> SM["Session Manager"]
+    SM -->|"stdin/stdout"| CL["claude subprocess"]
 
-    CL -->|stdio| INT[hive-mind-tools - internal MCP]
-    INT -->|results| CL
-    CL -->|SSE + bearer token| EXT[hive-mind-mcp - external MCP + HITL]
-    EXT -->|results| CL
+    CL -->|"stdio"| INT["hive-mind-tools (internal MCP)"]
+    INT -->|"results"| CL
+    CL -->|"SSE"| EXT["hive-mind-mcp (external MCP, HITL gated)"]
+    EXT -->|"results"| CL
 ```
 
 Each client is a thin HTTP wrapper. The gateway spawns Claude CLI subprocesses — one per session — with full MCP tool access. Claude Code does the heavy lifting; clients just relay messages and render responses.

--- a/README.md
+++ b/README.md
@@ -19,18 +19,16 @@ A self-improving personal assistant powered by Claude Code. The system wraps the
 ## Architecture
 
 ```mermaid
-graph TD
-    DC["Discord"] --> GW["FastAPI Gateway"]
-    TG["Telegram"] --> GW
-    SC["Scheduler"] --> GW
-
-    GW --> SM["Session Manager"]
-    SM -->|"stdin/stdout"| CL["claude subprocess"]
-
-    CL -->|"stdio"| INT["hive-mind-tools (internal MCP)"]
-    INT -->|"results"| CL
-    CL -->|"SSE"| EXT["hive-mind-mcp (external MCP, HITL gated)"]
-    EXT -->|"results"| CL
+flowchart TD
+    DC[Discord] --> GW[Gateway]
+    TG[Telegram] --> GW
+    SC[Scheduler] --> GW
+    GW --> SM[Session Manager]
+    SM -->|stdin/stdout| CL[claude subprocess]
+    CL -->|stdio| INT[hive-mind-tools]
+    INT -->|results| CL
+    CL -->|SSE| EXT[hive-mind-mcp]
+    EXT -->|results| CL
 ```
 
 Each client is a thin HTTP wrapper. The gateway spawns Claude CLI subprocesses — one per session — with full MCP tool access. Claude Code does the heavy lifting; clients just relay messages and render responses.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ graph TD
     TG[Telegram] --> GW
     SC[Scheduler] --> GW
 
-    GW["FastAPI Gateway<br/>server.py :8420"]
-    GW --> SM["Session Manager<br/>core/sessions.py<br/>process pool + SQLite"]
-    SM -->|"stdin/stdout (NDJSON)"| CL["claude -p --stream-json<br/>one process per session"]
+    GW[FastAPI Gateway]
+    GW --> SM[Session Manager]
+    SM -->|stdin/stdout NDJSON| CL[claude --stream-json]
 
-    CL <-->|stdio| INT["hive-mind-tools<br/>internal MCP<br/>(full access)"]
-    CL <-->|"SSE + bearer token"| EXT["hive-mind-mcp :9421<br/>external MCP<br/>(writes + HITL gate)"]
+    CL -->|stdio| INT[hive-mind-tools - internal MCP]
+    INT -->|results| CL
+    CL -->|SSE + bearer token| EXT[hive-mind-mcp - external MCP + HITL]
+    EXT -->|results| CL
 ```
 
 Each client is a thin HTTP wrapper. The gateway spawns Claude CLI subprocesses — one per session — with full MCP tool access. Claude Code does the heavy lifting; clients just relay messages and render responses.


### PR DESCRIPTION
## Summary

Three changes to fix Mermaid not rendering on GitHub:

- `flowchart TD` replaces `graph TD` — current Mermaid standard keyword
- Parentheses `()` removed from node labels — known parse-breaker on GitHub's Mermaid version
- Quoted edge labels `|"label"|` removed — unreliable on GitHub; plain `|label|` used instead

This is the absolute minimum safe Mermaid syntax.

## Test plan

- [ ] Verify diagram renders as a graph on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)