### PR TITLE
fix: pin discord.py>=2.0 to prevent package conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ py2neo
 dateparser
 
 # Discord bot
-discord.py[voice]
+discord.py[voice]>=2.0
 PyNaCl>=1.6.2
 
 # Telegram bot


### PR DESCRIPTION
## Summary
- Pin `discord.py[voice]>=2.0` to prevent pip from resolving the old `discord` package (v0.9.x) when `PyNaCl>=1.6.2` is also pinned
- Discord bot is currently crash-looping due to missing `app_commands` in the wrong package

## Test plan
- [x] pip-audit passes with no vulnerabilities
- [ ] Rebuild containers — discord bot should start cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)