### PR TITLE
feat: tool migration Phase 3 -- drop agent_tooling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,7 @@ RUN usermod -l hivemind -d /home/hivemind -m ubuntu \
 # Python venv + deps — installed to /opt/venv so bind mounts don't clobber it
 RUN python3 -m venv /opt/venv && /opt/venv/bin/pip install --upgrade pip
 COPY requirements.txt .
-RUN /opt/venv/bin/pip install --no-cache-dir --force-reinstall agent_tooling
-RUN /opt/venv/bin/pip install --no-cache-dir --force-reinstall -r requirements.txt
+RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.txt
 
 # Pre-download spaCy model (Kokoro/misaki needs it; can't pip-install at runtime as non-root)
 RUN /opt/venv/bin/python -m spacy download en_core_web_sm

--- a/core/kg_guards.py
+++ b/core/kg_guards.py
@@ -26,16 +26,16 @@ class DisambiguationResult:
 
 def _get_driver():
     """Lazy import to avoid circular dependency and allow mocking."""
-    from agents.knowledge_graph import _get_driver as _kg_get_driver
+    from tools.stateful.knowledge_graph import _get_driver as _kg_get_driver
 
     return _kg_get_driver()
 
 
 def _telegram_direct(message: str) -> tuple[bool, str]:
-    """Lazy import of the Telegram direct send function."""
-    from agents.notify import _telegram_direct as _notify_telegram
+    """Delegate to shared Telegram utility in core/."""
+    from core.notify_utils import telegram_direct
 
-    return _notify_telegram(message)
+    return telegram_direct(message)
 
 
 def check_disambiguation(

--- a/core/memory_expiry.py
+++ b/core/memory_expiry.py
@@ -16,14 +16,14 @@ logger = logging.getLogger(__name__)
 
 def _get_driver():
     """Lazy import to avoid circular dependency and allow mocking."""
-    from agents.memory import _get_driver as _mem_get_driver
+    from tools.stateful.memory import _get_driver as _mem_get_driver
     return _mem_get_driver()
 
 
 def _telegram_direct(message: str) -> tuple[bool, str]:
-    """Lazy import of the Telegram direct send function."""
-    from agents.notify import _telegram_direct as _notify_telegram
-    return _notify_telegram(message)
+    """Delegate to shared Telegram utility in core/."""
+    from core.notify_utils import telegram_direct
+    return telegram_direct(message)
 
 
 def sweep_expired_events() -> dict:

--- a/core/notify_utils.py
+++ b/core/notify_utils.py
@@ -1,0 +1,48 @@
+"""Shared notification utilities for core modules.
+
+Extracts _telegram_direct from agents/notify.py so that core/ modules
+(kg_guards, memory_expiry) can send Telegram messages without importing
+from agents/.
+"""
+
+import logging
+
+from core.secrets import get_credential
+
+logger = logging.getLogger(__name__)
+
+try:
+    import httpx
+except ImportError:
+    httpx = None  # type: ignore[assignment]
+
+
+def telegram_direct(message: str) -> tuple[bool, str]:
+    """Send via Telegram Bot API directly (bypasses gateway).
+
+    Args:
+        message: Text message to send to the owner.
+
+    Returns:
+        Tuple of (success, detail_message).
+    """
+    if httpx is None:
+        return False, "httpx not installed"
+
+    token = get_credential("TELEGRAM_BOT_TOKEN")
+    chat_id = get_credential("TELEGRAM_OWNER_CHAT_ID")
+
+    if not token or not chat_id:
+        return False, "TELEGRAM_BOT_TOKEN or TELEGRAM_OWNER_CHAT_ID not set"
+
+    try:
+        resp = httpx.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            json={"chat_id": chat_id, "text": message},
+            timeout=10,
+        )
+        if resp.status_code == 200:
+            return True, "delivered via Telegram"
+        return False, f"Telegram API returned {resp.status_code}"
+    except Exception as e:
+        return False, f"Telegram error: {type(e).__name__}"

--- a/mcp_server.py
+++ b/mcp_server.py
@@ -1,49 +1,37 @@
 """
 Hive Mind MCP Server.
 
-Exposes tools via FastMCP. Browser tools are registered directly from
-tools/stateful/browser.py (async Playwright). Other tools still use
-agent_tooling discovery during the migration transition.
+Exposes tools via FastMCP with direct registration from tools/stateful/.
+No agent_tooling dependency — all tools are imported and registered explicitly.
+
+Tool categories:
+  - Browser tools (async Playwright) from tools/stateful/browser.py
+  - Knowledge graph tools (Neo4j) from tools/stateful/knowledge_graph.py
+  - Memory tools (Neo4j + embeddings) from tools/stateful/memory.py
 
 Claude Code SDK connects to this server via stdio to access external integrations.
 """
 
 import logging
 
-from agent_tooling import discover_tools, get_tool_function, get_tool_schemas
 from mcp.server.fastmcp import FastMCP
 
 from core.audit import audit_wrap, get_audit_logger
 from tools.stateful.browser import BROWSER_TOOLS
+from tools.stateful.knowledge_graph import KG_TOOLS
+from tools.stateful.memory import MEMORY_TOOLS
 
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 log = logging.getLogger(__name__)
 
-# Discover tools from agents/ (excluding browser tools which are now direct)
-discover_tools(["agents"])
-
 mcp = FastMCP("hive-mind-tools")
 audit_logger = get_audit_logger()
 
-# Browser tool names to exclude from agent_tooling registration
-_BROWSER_TOOL_NAMES = {f.__name__ for f in BROWSER_TOOLS}
-
-# Register browser tools directly (async Playwright, no @tool decorator)
-for func in BROWSER_TOOLS:
-    log.info("[MCP] %s (direct)", func.__name__)
+# Register all stateful tools directly
+for func in BROWSER_TOOLS + KG_TOOLS + MEMORY_TOOLS:
+    log.info("[MCP] %s", func.__name__)
     wrapped = audit_wrap(func, audit_logger)
     mcp.tool()(wrapped)
-
-# Register remaining agent_tooling tools (excludes browser to avoid duplicates)
-for schema in get_tool_schemas():
-    name = schema["name"]
-    if name in _BROWSER_TOOL_NAMES:
-        continue  # Already registered directly above
-    func = get_tool_function(name)
-    if func:
-        log.info("[MCP] %s", name)
-        func = audit_wrap(func, audit_logger)
-        mcp.tool()(func)
 
 if __name__ == "__main__":
     log.info("Starting MCP server (stdio mode)")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 python-dotenv
 pyyaml
 requests
-agent_tooling
 openai
 setuptools
 keyring

--- a/tools/stateful/knowledge_graph.py
+++ b/tools/stateful/knowledge_graph.py
@@ -284,17 +284,17 @@ def graph_query(
             result = session.run(
                 f"""
                 MATCH (n {{agent_id: $agent_id}})
-                WHERE n.name = $query
-                   OR n.first_name = $query
-                   OR n.last_name = $query
-                   OR $query IN coalesce(n.aliases, [])
+                WHERE n.name = $search_name
+                   OR n.first_name = $search_name
+                   OR n.last_name = $search_name
+                   OR $search_name IN coalesce(n.aliases, [])
                 WITH n
                 OPTIONAL MATCH (n)-[r*1..{depth}]-(m)
                 RETURN n,
                        [rel IN r | {{type: type(rel), direction: 'out'}}] AS rels,
                        m
                 """,
-                query=entity_name,
+                search_name=entity_name,
                 agent_id=agent_id,
             )
             rows = result.data()

--- a/tools/stateful/knowledge_graph.py
+++ b/tools/stateful/knowledge_graph.py
@@ -1,0 +1,396 @@
+"""Neo4j knowledge graph tools for Ada — structured entity and relationship storage.
+
+Complements vector memory (episodic) with relational knowledge:
+who/what/how things connect.
+
+Node types: Person, Project, System, Concept, Preference
+Standard relationships: KNOWS_ABOUT, WORKS_ON, PREFERS, RELATED_TO, MANAGES
+
+Designed for direct FastMCP registration (no @tool() decorator).
+"""
+
+import json
+import logging
+import os
+import re
+import time
+
+import requests
+from core.secrets import get_credential
+from core.memory_schema import build_metadata, validate_source
+from neo4j import GraphDatabase
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8420")
+HITL_TTL = 180
+
+
+def _hitl_gate(summary: str) -> bool:
+    """Request HITL approval showing the exact graph operation to be written.
+
+    Returns True if approved, False if denied or timed out.
+    """
+    try:
+        resp = requests.post(
+            f"{GATEWAY_URL}/hitl/request",
+            json={"action": "graph_upsert", "summary": summary, "ttl": HITL_TTL},
+            timeout=HITL_TTL + 5,
+        )
+        resp.raise_for_status()
+        return resp.json().get("approved", False)
+    except Exception:
+        return False
+
+NEO4J_URI = get_credential("NEO4J_URI") or "bolt://neo4j:7687"
+NEO4J_AUTH_ENV = get_credential("NEO4J_AUTH") or "neo4j/hivemind-memory"
+_NEO4J_USER, _, _NEO4J_PASS = NEO4J_AUTH_ENV.partition("/")
+
+_driver = None
+_kg_index_created = False
+
+_VALID_ENTITY_TYPES = {"Person", "Project", "System", "Concept", "Preference"}
+_VALID_RELATIONS = {"KNOWS_ABOUT", "WORKS_ON", "PREFERS", "RELATED_TO", "MANAGES"}
+# Allow any uppercase/underscore relation beyond the standard set
+_RELATION_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+
+
+def _get_driver():
+    global _driver
+    if _driver is None:
+        _driver = GraphDatabase.driver(NEO4J_URI, auth=(_NEO4J_USER, _NEO4J_PASS))
+    return _driver
+
+
+def _validate_label(entity_type: str) -> str:
+    if entity_type not in _VALID_ENTITY_TYPES:
+        raise ValueError(
+            f"Invalid entity_type {entity_type!r}. Must be one of: {sorted(_VALID_ENTITY_TYPES)}"
+        )
+    return entity_type
+
+
+def _validate_relation(relation: str) -> str:
+    if not _RELATION_RE.match(relation):
+        raise ValueError(
+            f"Invalid relation {relation!r}. Must be uppercase letters/underscores."
+        )
+    return relation
+
+
+def _ensure_metadata_indexes(session) -> None:  # type: ignore[no-untyped-def]
+    """Create property indexes for metadata fields on entity nodes."""
+    global _kg_index_created
+    if _kg_index_created:
+        return
+
+    for label in _VALID_ENTITY_TYPES:
+        for field in ("tier", "data_class", "source"):
+            try:
+                session.run(  # type: ignore[union-attr]
+                    f"CREATE INDEX idx_{label.lower()}_{field} IF NOT EXISTS "
+                    f"FOR (n:{label}) ON (n.{field})"
+                )
+            except Exception:
+                logger.debug("Index idx_%s_%s may already exist", label.lower(), field)
+
+    _kg_index_created = True
+
+
+def graph_upsert_direct(
+    *,
+    entity_type: str,
+    name: str,
+    data_class: str,
+    properties: str = "{}",
+    relation: str = "",
+    target_name: str = "",
+    target_type: str = "",
+    agent_id: str = "ada",
+    as_of: str | None = None,
+    source: str = "user",
+) -> str:
+    """Write to the knowledge graph without HITL. Called by the epilogue after batch approval."""
+    try:
+        try:
+            validate_source(source)
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+
+        try:
+            meta = build_metadata(
+                data_class=data_class, source=source, as_of=as_of
+            )
+        except ValueError as e:
+            return json.dumps({"error": str(e)})
+
+        label = _validate_label(entity_type)
+        props = json.loads(properties) if properties.strip() != "{}" else {}
+
+        props.update(meta)
+        props["created_at"] = time.time()
+
+        driver = _get_driver()
+        with driver.session() as session:
+            _ensure_metadata_indexes(session)
+            result = session.run(
+                f"""
+                MERGE (n:{label} {{name: $name, agent_id: $agent_id}})
+                SET n += $props
+                RETURN elementId(n) AS id
+                """,
+                name=name,
+                agent_id=agent_id,
+                props=props,
+            )
+            node_id = result.single()["id"]
+
+            rel_created = False
+            if relation and target_name:
+                rel_type = _validate_relation(relation)
+                tgt_label = _validate_label(target_type or entity_type)
+                session.run(
+                    f"""
+                    MERGE (t:{tgt_label} {{name: $target_name, agent_id: $agent_id}})
+                    SET t += $meta_props
+                    WITH t
+                    MATCH (n:{label} {{name: $name, agent_id: $agent_id}})
+                    MERGE (n)-[r:{rel_type}]->(t)
+                    SET r.as_of = $meta_as_of, r.source = $meta_source,
+                        r.data_class = $meta_data_class, r.tier = $meta_tier
+                    """,
+                    target_name=target_name,
+                    agent_id=agent_id,
+                    name=name,
+                    meta_props=meta,
+                    meta_as_of=meta.get("as_of"),
+                    meta_source=meta.get("source", source),
+                    meta_data_class=meta.get("data_class"),
+                    meta_tier=meta.get("tier"),
+                )
+                rel_created = True
+
+        return json.dumps({
+            "upserted": True,
+            "id": node_id,
+            "entity_type": label,
+            "name": name,
+            "relation_created": rel_created,
+            "relation": f"-[:{relation}]->({target_name})" if rel_created else None,
+            "data_class": meta.get("data_class"),
+        })
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def graph_upsert(
+    *,
+    entity_type: str,
+    name: str,
+    data_class: str,
+    properties: str = "{}",
+    relation: str = "",
+    target_name: str = "",
+    target_type: str = "",
+    agent_id: str = "ada",
+    as_of: str | None = None,
+    source: str = "user",
+) -> str:
+    """Add or update a knowledge graph node, optionally linking it to another node.
+
+    Args:
+        entity_type: Node label — one of Person, Project, System, Concept, Preference.
+        name: Unique name for this entity (e.g. "Daniel", "Hive Mind").
+        properties: JSON string of extra properties to set (e.g. '{"role": "owner"}').
+        relation: Relationship type to create (e.g. MANAGES, WORKS_ON). Leave empty for node-only.
+        target_name: Name of the target node to link to. Required if relation is set.
+        target_type: Entity type of the target node (defaults to entity_type if omitted).
+        agent_id: Which agent's graph this belongs to (default "ada").
+        data_class: Data class for this entry (e.g. "person", "preference", "technical-config").
+        as_of: ISO datetime for when the fact was established (defaults to now).
+        source: Origin of the entry — "user", "tool", "session", or "self".
+
+    Returns:
+        JSON confirmation with node id and relationship created (if any).
+    """
+    try:
+        from core.kg_guards import check_disambiguation, check_orphan_guard, send_disambiguation_message
+
+        label = _validate_label(entity_type)
+        props = json.loads(properties) if properties.strip() != "{}" else {}
+
+        allowed, orphan_msg = check_orphan_guard(relation, target_name)
+        if not allowed:
+            return json.dumps({"upserted": False, "reason": orphan_msg})
+
+        disambig = check_disambiguation(name, entity_type, agent_id)
+        if disambig.action == "disambiguate":
+            send_disambiguation_message(name, disambig.existing_nodes)
+            return json.dumps({
+                "upserted": False,
+                "reason": "disambiguation_required",
+                "similar_nodes": disambig.existing_nodes,
+            })
+
+        props_str = f" {json.dumps(props)}" if props else ""
+        node_repr = f"({label}:{name}{props_str})"
+        if relation and target_name:
+            tgt = target_type or entity_type
+            hitl_summary = f"{node_repr} --[{relation}]--> ({tgt}:{target_name})"
+        else:
+            hitl_summary = node_repr
+
+        if not _hitl_gate(hitl_summary):
+            return json.dumps({"upserted": False, "reason": "denied by HITL"})
+
+        return graph_upsert_direct(
+            entity_type=entity_type,
+            name=name,
+            properties=properties,
+            relation=relation,
+            target_name=target_name,
+            target_type=target_type,
+            agent_id=agent_id,
+            data_class=data_class,
+            as_of=as_of,
+            source=source,
+        )
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def graph_query(
+    entity_name: str,
+    agent_id: str = "ada",
+    depth: int = 1,
+) -> str:
+    """Retrieve knowledge graph node(s) and their connected relationships.
+
+    Searches by full name (exact), first_name, last_name, or aliases.
+    Returns all matching nodes — if multiple match, disambiguate before acting.
+
+    Args:
+        entity_name: Name or name fragment to search (e.g. "Wil", "Vark", "Wil Vark", "Coach").
+        agent_id: Which agent's graph to search (default "ada").
+        depth: How many hops to traverse (default 1, max 3).
+
+    Returns:
+        JSON with matching nodes, their properties, and connected relationships.
+    """
+    depth = min(max(depth, 1), 3)
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            result = session.run(
+                f"""
+                MATCH (n {{agent_id: $agent_id}})
+                WHERE n.name = $query
+                   OR n.first_name = $query
+                   OR n.last_name = $query
+                   OR $query IN coalesce(n.aliases, [])
+                WITH n
+                OPTIONAL MATCH (n)-[r*1..{depth}]-(m)
+                RETURN n,
+                       [rel IN r | {{type: type(rel), direction: 'out'}}] AS rels,
+                       m
+                """,
+                query=entity_name,
+                agent_id=agent_id,
+            )
+            rows = result.data()
+
+        if not rows:
+            return json.dumps({"found": False, "entity": entity_name})
+
+        nodes: dict[str, dict] = {}
+        for row in rows:
+            node = dict(row["n"])
+            key = node.get("name", str(node))
+            if key not in nodes:
+                nodes[key] = {"properties": node, "connections": []}
+            if row["m"]:
+                nodes[key]["connections"].append({
+                    "node": dict(row["m"]),
+                    "via": row["rels"],
+                })
+
+        matches = list(nodes.values())
+        return json.dumps({
+            "found": True,
+            "count": len(matches),
+            "matches": matches,
+        })
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+def search_person(
+    first_name: str = "",
+    last_name: str = "",
+    title: str = "",
+    relationship: str = "",
+    agent_id: str = "ada",
+) -> str:
+    """Search for Person nodes by any known name fragment or relationship to Daniel.
+
+    All parameters are optional but at least one must be provided.
+    Matching is case-insensitive substring (CONTAINS) — pass whatever you know.
+    Multiple params are combined with AND (all must match).
+
+    Args:
+        first_name: Given name fragment (e.g. "Wil", "manny").
+        last_name: Surname fragment (e.g. "Vark", "stew").
+        title: Title or honorific fragment (e.g. "Coach", "Dr").
+        relationship: How this person relates to Daniel (e.g. "wife", "doctor", "child").
+        agent_id: Which agent's graph to search (default "ada").
+
+    Returns:
+        JSON with matching Person nodes and their properties.
+    """
+    if not any([first_name, last_name, title, relationship]):
+        return json.dumps({"error": "At least one search parameter must be provided."})
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (n:Person {agent_id: $agent_id})
+                WHERE ($first_name = '' OR toLower(coalesce(n.first_name, '')) CONTAINS toLower($first_name))
+                  AND ($last_name = '' OR toLower(coalesce(n.last_name, '')) CONTAINS toLower($last_name))
+                  AND ($title = '' OR toLower(coalesce(n.title, '')) CONTAINS toLower($title))
+                  AND ($relationship = '' OR ANY(r IN coalesce(n.relationship, []) WHERE toLower(r) CONTAINS toLower($relationship)))
+                RETURN n
+                """,
+                first_name=first_name,
+                last_name=last_name,
+                title=title,
+                relationship=relationship,
+                agent_id=agent_id,
+            )
+            rows = result.data()
+
+        if not rows:
+            return json.dumps({"found": False, "query": {
+                "first_name": first_name,
+                "last_name": last_name,
+                "title": title,
+                "relationship": relationship,
+            }})
+
+        matches = [dict(row["n"]) for row in rows]
+        return json.dumps({
+            "found": True,
+            "count": len(matches),
+            "matches": matches,
+        })
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+# All knowledge graph tool functions for registration
+KG_TOOLS = [
+    graph_upsert,
+    graph_upsert_direct,
+    graph_query,
+    search_person,
+]

--- a/tools/stateful/memory.py
+++ b/tools/stateful/memory.py
@@ -1,0 +1,497 @@
+"""Semantic memory tools for Ada — vector-backed persistent memory via Neo4j.
+
+Stores experiences, observations, and session summaries as embeddings.
+Retrieves the most relevant memories by semantic similarity.
+
+Model: qwen3-embedding:8b via Ollama (4096-dim)
+Backend: Neo4j with native vector index (cosine similarity)
+
+Designed for direct FastMCP registration (no @tool() decorator).
+"""
+
+import json
+import logging
+import os
+import time
+from typing import Optional
+
+import requests
+from core.secrets import get_credential
+from core.memory_schema import build_metadata, validate_source
+from neo4j import GraphDatabase
+
+logger = logging.getLogger(__name__)
+
+GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8420")
+HITL_TTL = 180
+
+
+def _hitl_gate(content: str) -> bool:
+    """Request HITL approval showing the exact content to be stored.
+
+    Returns True if approved, False if denied or timed out.
+    """
+    try:
+        resp = requests.post(
+            f"{GATEWAY_URL}/hitl/request",
+            json={"action": "memory_store", "summary": content, "ttl": HITL_TTL},
+            timeout=HITL_TTL + 5,
+        )
+        resp.raise_for_status()
+        return resp.json().get("approved", False)
+    except Exception:
+        logger.exception("HITL gate failed — denying memory write by default")
+        return False
+
+# --- Lazy singletons ---
+_driver = None
+_index_created = False
+
+NEO4J_URI = get_credential("NEO4J_URI") or "bolt://neo4j:7687"
+NEO4J_AUTH_ENV = get_credential("NEO4J_AUTH") or "neo4j/hivemind-memory"
+_NEO4J_USER, _, _NEO4J_PASS = NEO4J_AUTH_ENV.partition("/")
+
+OLLAMA_BASE_URL = get_credential("OLLAMA_BASE_URL") or "http://192.168.4.64:11434"
+EMBEDDING_MODEL = "qwen3-embedding:8b"
+EMBEDDING_DIM = 4096
+VECTOR_INDEX = "memory_embedding"
+
+
+def _get_driver():
+    global _driver
+    if _driver is None:
+        _driver = GraphDatabase.driver(NEO4J_URI, auth=(_NEO4J_USER, _NEO4J_PASS))
+    return _driver
+
+
+def _ensure_index(session):
+    global _index_created
+    if _index_created:
+        return
+    session.run(
+        """
+        CREATE VECTOR INDEX memory_embedding IF NOT EXISTS
+        FOR (m:Memory) ON (m.embedding)
+        OPTIONS {indexConfig: {
+            `vector.dimensions`: 4096,
+            `vector.similarity_function`: 'cosine'
+        }}
+        """
+    )
+    for field in ("tier", "data_class", "expires_at", "source", "recurring"):
+        try:
+            session.run(
+                f"CREATE INDEX idx_memory_{field} IF NOT EXISTS "
+                f"FOR (m:Memory) ON (m.{field})"
+            )
+        except Exception:
+            logger.debug("Index idx_memory_%s may already exist", field)
+    _index_created = True
+
+
+def _embed(text: str) -> list[float]:
+    resp = requests.post(
+        f"{OLLAMA_BASE_URL}/api/embed",
+        json={"model": EMBEDDING_MODEL, "input": text},
+        timeout=30,
+    )
+    resp.raise_for_status()
+    return resp.json()["embeddings"][0]
+
+
+def memory_store_direct(
+    *,
+    content: str,
+    data_class: str,
+    tags: str = "",
+    source: str = "user",
+    agent_id: str = "ada",
+    as_of: str | None = None,
+    expires_at: str | None = None,
+    recurring: bool | None = None,
+    codebase_ref: str | None = None,
+) -> str:
+    """Write to vector memory without HITL. Called by the epilogue after batch approval."""
+    try:
+        try:
+            validate_source(source)
+        except ValueError as e:
+            return json.dumps({"stored": False, "error": str(e)})
+
+        try:
+            meta = build_metadata(
+                data_class=data_class,
+                source=source,
+                as_of=as_of,
+                expires_at=expires_at,
+                recurring=recurring,
+                content=content,
+            )
+        except ValueError as e:
+            return json.dumps({"stored": False, "error": str(e), "prompt": str(e)})
+
+        embedding = _embed(content)
+        driver = _get_driver()
+        with driver.session() as session:
+            _ensure_index(session)
+            result = session.run(
+                """
+                CREATE (m:Memory {
+                    content: $content,
+                    tags: $tags,
+                    source: $source,
+                    agent_id: $agent_id,
+                    created_at: $created_at,
+                    embedding: $embedding,
+                    data_class: $data_class,
+                    tier: $tier,
+                    as_of: $as_of,
+                    expires_at: $expires_at,
+                    superseded: $superseded,
+                    recurring: $recurring,
+                    codebase_ref: $codebase_ref
+                })
+                RETURN elementId(m) AS id
+                """,
+                content=content,
+                tags=tags,
+                source=meta.get("source", source),
+                agent_id=agent_id,
+                created_at=int(time.time()),
+                embedding=embedding,
+                data_class=meta.get("data_class"),
+                tier=meta.get("tier"),
+                as_of=meta.get("as_of"),
+                expires_at=meta.get("expires_at"),
+                superseded=meta.get("superseded", False),
+                recurring=meta.get("recurring"),
+                codebase_ref=codebase_ref,
+            )
+            record = result.single()
+            memory_id = record["id"] if record else "unknown"
+        return json.dumps({
+            "stored": True,
+            "id": memory_id,
+            "agent_id": agent_id,
+            "data_class": meta.get("data_class"),
+        })
+    except Exception as e:
+        logger.exception("memory_store_direct failed")
+        return json.dumps({"error": str(e)})
+
+
+def memory_store(
+    *,
+    content: str,
+    data_class: str,
+    tags: str = "",
+    source: str = "user",
+    agent_id: str = "ada",
+    as_of: str | None = None,
+    expires_at: str | None = None,
+    recurring: bool | None = None,
+    codebase_ref: str | None = None,
+) -> str:
+    """Store a memory as a semantic embedding in Neo4j.
+
+    Args:
+        content: The text to remember (experience, observation, fact, etc.)
+        data_class: Memory data class (e.g. "person", "preference", "technical-config"). Required.
+        tags: Comma-separated tags for categorisation (e.g. "session,preference")
+        source: Origin of the memory -- "user", "tool", "session", "self"
+        agent_id: Which agent this memory belongs to (default "ada")
+        as_of: ISO datetime for when the fact was established (defaults to now)
+        expires_at: ISO datetime for when a timed-event expires (required for timed-event)
+        recurring: Explicit recurring flag for timed-events (overrides heuristic detection)
+        codebase_ref: Optional file path or symbol reference in the codebase this entry
+            is about (e.g. "core/sessions.py", "SessionManager.send_message"). Used by
+            the technical-config pruning pass to verify accuracy.
+
+    Returns:
+        JSON with the stored memory ID and confirmation.
+    """
+    try:
+        return memory_store_direct(
+            content=content,
+            tags=tags,
+            source=source,
+            agent_id=agent_id,
+            data_class=data_class,
+            as_of=as_of,
+            expires_at=expires_at,
+            recurring=recurring,
+            codebase_ref=codebase_ref,
+        )
+    except Exception as e:
+        logger.exception("memory_store failed")
+        return json.dumps({"error": str(e)})
+
+
+def memory_list(
+    offset: int = 0,
+    limit: int = 25,
+    agent_id: str = "ada",
+) -> str:
+    """List all Memory nodes sequentially by creation time for review and cleanup.
+
+    Args:
+        offset: Number of entries to skip (for pagination).
+        limit: Number of entries to return (default 25, max 100).
+        agent_id: Which agent's memories to list (default "ada").
+
+    Returns:
+        JSON with entries (id, content, tags, source, data_class, created_at),
+        offset, limit, and total count.
+    """
+    limit = min(limit, 100)
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            _ensure_index(session)
+            total_result = session.run(
+                "MATCH (m:Memory) WHERE m.agent_id = $agent_id RETURN count(m) AS total",
+                agent_id=agent_id,
+            )
+            total = total_result.single()["total"]
+            result = session.run(
+                """
+                MATCH (m:Memory)
+                WHERE m.agent_id = $agent_id
+                RETURN elementId(m) AS id,
+                       m.content AS content,
+                       m.tags AS tags,
+                       m.source AS source,
+                       m.data_class AS data_class,
+                       m.created_at AS created_at
+                ORDER BY m.created_at ASC
+                SKIP $offset
+                LIMIT $limit
+                """,
+                agent_id=agent_id,
+                offset=offset,
+                limit=limit,
+            )
+            entries = [
+                {
+                    "id": record["id"],
+                    "content": record["content"],
+                    "tags": record["tags"],
+                    "source": record["source"],
+                    "data_class": record["data_class"],
+                    "created_at": record["created_at"],
+                }
+                for record in result
+            ]
+        return json.dumps({"entries": entries, "offset": offset, "limit": limit, "total": total})
+    except Exception as e:
+        logger.exception("memory_list failed")
+        return json.dumps({"error": str(e)})
+
+
+def memory_delete(memory_id: str) -> str:
+    """Delete a Memory node from Neo4j by its element ID.
+
+    Args:
+        memory_id: The elementId of the memory to delete (from memory_list).
+
+    Returns:
+        JSON confirming deletion or error.
+    """
+    try:
+        driver = _get_driver()
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (m:Memory)
+                WHERE elementId(m) = $memory_id
+                WITH m, m.content AS content
+                DETACH DELETE m
+                RETURN content
+                """,
+                memory_id=memory_id,
+            )
+            record = result.single()
+            if record:
+                return json.dumps({"deleted": True, "id": memory_id, "content": record["content"]})
+            return json.dumps({"deleted": False, "reason": "not found", "id": memory_id})
+    except Exception as e:
+        logger.exception("memory_delete failed")
+        return json.dumps({"error": str(e)})
+
+
+def memory_update(
+    memory_id: str,
+    content: str = "",
+    data_class: str = "",
+    tags: str = "",
+) -> str:
+    """Update an existing Memory node.
+
+    Allows updating content (re-embeds automatically), data_class, and tags.
+    Any combination of fields can be provided; omitted fields are unchanged.
+
+    Args:
+        memory_id: The elementId of the memory to update (from memory_list).
+        content: New content to store. Re-embeds automatically. Leave empty to leave unchanged.
+        data_class: New data class to assign (e.g., "technical-config", "person").
+                    Must be a valid registered class. Leave empty to leave unchanged.
+        tags: Comma-separated tags to replace existing tags.
+              Leave empty to leave unchanged.
+
+    Returns:
+        JSON with updated memory details or error.
+    """
+    from core.memory_schema import DATA_CLASS_REGISTRY, validate_data_class
+
+    try:
+        updates: dict = {}
+        if content:
+            updates["content"] = content
+            updates["embedding"] = _embed(content)
+        if data_class:
+            try:
+                validate_data_class(data_class)
+            except ValueError as e:
+                return json.dumps({"updated": False, "error": str(e)})
+            updates["data_class"] = data_class
+            updates["tier"] = DATA_CLASS_REGISTRY[data_class].tier
+        if tags:
+            updates["tags"] = tags
+
+        if not updates:
+            return json.dumps({"updated": False, "error": "no fields provided to update"})
+
+        driver = _get_driver()
+        with driver.session() as session:
+            result = session.run(
+                """
+                MATCH (m:Memory)
+                WHERE elementId(m) = $memory_id
+                SET m += $updates
+                RETURN elementId(m) AS id, m.data_class AS data_class,
+                       left(m.content, 80) AS preview
+                """,
+                memory_id=memory_id,
+                updates=updates,
+            )
+            record = result.single()
+            if not record:
+                return json.dumps({"updated": False, "error": "not found", "id": memory_id})
+            return json.dumps({
+                "updated": True,
+                "id": record["id"],
+                "data_class": record["data_class"],
+                "preview": record["preview"],
+            })
+    except Exception as e:
+        logger.exception("memory_update failed")
+        return json.dumps({"error": str(e)})
+
+
+def memory_retrieve(
+    query: str,
+    k: int = 10,
+    agent_id: str = "ada",
+    tag_filter: Optional[str] = None,
+) -> str:
+    """Retrieve the most semantically relevant memories for a query.
+
+    Args:
+        query: Natural language query to search for related memories.
+        k: Number of results to return (default 10, max 50).
+        agent_id: Which agent's memories to search (default "ada").
+        tag_filter: Optional tag to filter results (e.g. "session").
+
+    Returns:
+        JSON array of memories sorted by relevance (highest first), each with
+        content, tags, source, agent_id, created_at, and similarity score.
+    """
+    k = min(k, 50)
+    try:
+        embedding = _embed(query)
+        driver = _get_driver()
+        with driver.session() as session:
+            _ensure_index(session)
+            if tag_filter:
+                result = session.run(
+                    """
+                    CALL db.index.vector.queryNodes($index, $k, $embedding)
+                    YIELD node AS m, score
+                    WHERE m.agent_id = $agent_id AND m.tags CONTAINS $tag_filter
+                    RETURN m.content AS content,
+                           m.tags AS tags,
+                           m.source AS source,
+                           m.agent_id AS agent_id,
+                           m.created_at AS created_at,
+                           m.data_class AS data_class,
+                           m.tier AS tier,
+                           m.as_of AS as_of,
+                           m.expires_at AS expires_at,
+                           m.superseded AS superseded,
+                           m.codebase_ref AS codebase_ref,
+                           score
+                    ORDER BY score DESC
+                    """,
+                    index=VECTOR_INDEX,
+                    k=k,
+                    embedding=embedding,
+                    agent_id=agent_id,
+                    tag_filter=tag_filter,
+                )
+            else:
+                result = session.run(
+                    """
+                    CALL db.index.vector.queryNodes($index, $k, $embedding)
+                    YIELD node AS m, score
+                    WHERE m.agent_id = $agent_id
+                    RETURN m.content AS content,
+                           m.tags AS tags,
+                           m.source AS source,
+                           m.agent_id AS agent_id,
+                           m.created_at AS created_at,
+                           m.data_class AS data_class,
+                           m.tier AS tier,
+                           m.as_of AS as_of,
+                           m.expires_at AS expires_at,
+                           m.superseded AS superseded,
+                           m.codebase_ref AS codebase_ref,
+                           score
+                    ORDER BY score DESC
+                    """,
+                    index=VECTOR_INDEX,
+                    k=k,
+                    embedding=embedding,
+                    agent_id=agent_id,
+                )
+            memories = [
+                {
+                    "content": record["content"],
+                    "tags": record["tags"],
+                    "source": record["source"],
+                    "agent_id": record["agent_id"],
+                    "created_at": record["created_at"],
+                    "score": round(record["score"], 4),
+                    "data_class": record["data_class"],
+                    "tier": record["tier"],
+                    "as_of": record["as_of"],
+                    "expires_at": record["expires_at"],
+                    "superseded": record["superseded"],
+                    "codebase_ref": record["codebase_ref"],
+                }
+                for record in result
+            ]
+        return json.dumps({"memories": memories, "count": len(memories)})
+    except Exception as e:
+        logger.exception("memory_retrieve failed")
+        return json.dumps({"error": str(e)})
+
+
+# All memory tool functions for registration
+MEMORY_TOOLS = [
+    memory_store,
+    memory_store_direct,
+    memory_list,
+    memory_delete,
+    memory_update,
+    memory_retrieve,
+]


### PR DESCRIPTION
## Summary
- MCP server now loads all 17 tools directly from `tools/stateful/` via FastMCP — no `agent_tooling` dependency
- `knowledge_graph.py` and `memory.py` copied to `tools/stateful/` with `@tool()` decorators removed
- `_telegram_direct` extracted to `core/notify_utils.py` as shared utility for `core/kg_guards.py` and `core/memory_expiry.py`
- `agent_tooling` removed from `requirements.txt` and `Dockerfile` (eliminates force-reinstall hack)
- `agents/` directory left intact as fallback per migration spec

## What changes for Claude
- Stateful MCP tools (browser, knowledge graph, memory) continue working identically
- Stateless tools (weather, crypto, planka, reminders, etc.) are no longer registered as MCP tools — they're available via their scripts in `tools/stateless/`

## Test plan
- [ ] `docker compose down && docker compose up -d --build` on `hive_mind_mcp`
- [ ] Verify browser tools work (navigate, screenshot, close)
- [ ] Verify memory tools work (memory_retrieve, memory_store)
- [ ] Verify knowledge graph tools work (graph_query, search_person)
- [ ] Verify stateless tools still work via Bash scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)