### PR TITLE
fix: restore message queuing + planka board IDs

### DIFF
--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -598,30 +598,31 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     chat_id = update.effective_chat.id
     lock = get_lock(chat_id)
+    queue = get_queue(chat_id)
+
+    # STT happens outside the lock so we have text to queue if busy
+    try:
+        voice_file = await update.message.voice.get_file()
+        ogg_bytes = bytes(await voice_file.download_as_bytearray())
+        text = await _stt(ogg_bytes)
+    except Exception:
+        log.exception("STT failed in chat %s", chat_id)
+        await update.message.reply_text("Couldn't transcribe your audio.")
+        return
+
+    log.info("STT: %r", text[:80])
+    if not text.strip():
+        await update.message.reply_text("Couldn't transcribe audio.")
+        return
 
     if lock.locked():
-        await update.message.reply_text("Still processing your previous message — yours is queued and will follow.")
+        pos = queue.qsize() + 1
+        await queue.put(text)
+        await update.message.reply_text(f"Still processing — yours is queued (#{pos}).")
+        return
 
     async with lock:
         try:
-            # Download OGG/Opus from Telegram
-            voice_file = await update.message.voice.get_file()
-            ogg_bytes = bytes(await voice_file.download_as_bytearray())
-
-            # STT via voice-server
-            try:
-                text = await _stt(ogg_bytes)
-            except Exception:
-                log.exception("STT failed in chat %s", chat_id)
-                await update.message.reply_text("Couldn't transcribe your audio.")
-                return
-
-            log.info("STT: %r", text[:80])
-            if not text.strip():
-                await update.message.reply_text("Couldn't transcribe audio.")
-                return
-
-            # Stream response: text updates live, voice chunks sent progressively
             sent = await update.message.reply_text("\u2026")
             final_chunks = await _stream_to_message(
                 sent, update.effective_user.id, chat_id, text,
@@ -629,10 +630,24 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
             )
             for extra in final_chunks[1:]:
                 await update.effective_chat.send_message(extra)
-
         except Exception:
             log.exception("Unexpected error in voice handler for chat %s", chat_id)
             await update.message.reply_text("Something went wrong with voice processing.")
+
+        # Drain queue in a loop — new messages may arrive during batch processing
+        while not queue.empty():
+            queued: list[str] = []
+            while not queue.empty():
+                queued.append(queue.get_nowait())
+            batch = _format_queue_batch(queued)
+            try:
+                sent2 = await update.effective_chat.send_message("\u2026")
+                final_chunks2 = await _stream_to_message(sent2, update.effective_user.id, chat_id, batch)
+                for extra in final_chunks2[1:]:
+                    await update.effective_chat.send_message(extra)
+            except Exception:
+                log.exception("Error processing queued batch in chat %s", chat_id)
+                await update.effective_chat.send_message("Something went wrong processing your queued messages.")
 
 
 # ---------------------------------------------------------------------------

--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -466,8 +466,6 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
             log.exception("Error processing message in chat %s", chat_id)
             await update.message.reply_text("Something went wrong. Try again or use /clear.")
 
-        # Brief collection window — lets in-flight voice STTs finish and queue up
-        await asyncio.sleep(3)
 
         # Drain queue in a loop — new messages may arrive during batch processing
         while not queue.empty():
@@ -637,8 +635,6 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
             log.exception("Unexpected error in voice handler for chat %s", chat_id)
             await update.message.reply_text("Something went wrong with voice processing.")
 
-        # Brief collection window — lets in-flight voice STTs finish and queue up
-        await asyncio.sleep(3)
 
         # Drain queue in a loop — new messages may arrive during batch processing
         while not queue.empty():
@@ -700,8 +696,6 @@ async def handle_unknown_command(update: Update, context: ContextTypes.DEFAULT_T
             log.exception("Error processing unknown command in chat %s", chat_id)
             await update.message.reply_text("Something went wrong. Try again or use /clear.")
 
-        # Brief collection window — lets in-flight voice STTs finish and queue up
-        await asyncio.sleep(3)
 
         # Drain queue in a loop — new messages may arrive during batch processing
         while not queue.empty():

--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -466,6 +466,9 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
             log.exception("Error processing message in chat %s", chat_id)
             await update.message.reply_text("Something went wrong. Try again or use /clear.")
 
+        # Brief collection window — lets in-flight voice STTs finish and queue up
+        await asyncio.sleep(3)
+
         # Drain queue in a loop — new messages may arrive during batch processing
         while not queue.empty():
             queued: list[str] = []
@@ -634,6 +637,9 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
             log.exception("Unexpected error in voice handler for chat %s", chat_id)
             await update.message.reply_text("Something went wrong with voice processing.")
 
+        # Brief collection window — lets in-flight voice STTs finish and queue up
+        await asyncio.sleep(3)
+
         # Drain queue in a loop — new messages may arrive during batch processing
         while not queue.empty():
             queued: list[str] = []
@@ -693,6 +699,9 @@ async def handle_unknown_command(update: Update, context: ContextTypes.DEFAULT_T
         except Exception:
             log.exception("Error processing unknown command in chat %s", chat_id)
             await update.message.reply_text("Something went wrong. Try again or use /clear.")
+
+        # Brief collection window — lets in-flight voice STTs finish and queue up
+        await asyncio.sleep(3)
 
         # Drain queue in a loop — new messages may arrive during batch processing
         while not queue.empty():

--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -466,11 +466,11 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
             log.exception("Error processing message in chat %s", chat_id)
             await update.message.reply_text("Something went wrong. Try again or use /clear.")
 
-        # Drain any messages that queued up while we were busy
-        queued: list[str] = []
+        # Drain queue in a loop — new messages may arrive during batch processing
         while not queue.empty():
-            queued.append(queue.get_nowait())
-        if queued:
+            queued: list[str] = []
+            while not queue.empty():
+                queued.append(queue.get_nowait())
             batch = _format_queue_batch(queued)
             try:
                 sent2 = await update.effective_chat.send_message("\u2026")
@@ -679,11 +679,11 @@ async def handle_unknown_command(update: Update, context: ContextTypes.DEFAULT_T
             log.exception("Error processing unknown command in chat %s", chat_id)
             await update.message.reply_text("Something went wrong. Try again or use /clear.")
 
-        # Drain any messages that queued up while we were busy
-        queued: list[str] = []
+        # Drain queue in a loop — new messages may arrive during batch processing
         while not queue.empty():
-            queued.append(queue.get_nowait())
-        if queued:
+            queued: list[str] = []
+            while not queue.empty():
+                queued.append(queue.get_nowait())
             batch = _format_queue_batch(queued)
             try:
                 sent2 = await update.effective_chat.send_message("\u2026")

--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -26,7 +26,7 @@ from telegram.ext import (
 )
 
 from config import config
-from core.gateway_client import GatewayClient, get_lock, get_skills, time_ago
+from core.gateway_client import GatewayClient, get_lock, get_queue, get_skills, time_ago
 
 logging.basicConfig(
     level=logging.INFO,
@@ -221,6 +221,17 @@ async def _stream_to_message(
 # ---------------------------------------------------------------------------
 # Server command formatters
 # ---------------------------------------------------------------------------
+def _format_queue_batch(messages: list[str]) -> str:
+    """Combine queued messages into one prompt so Claude replies once."""
+    if len(messages) == 1:
+        return messages[0]
+    items = "\n".join(f"{i + 1}. {m}" for i, m in enumerate(messages))
+    return (
+        "While you were processing my previous message, I sent several more. "
+        "Please address all of them in one reply:\n\n" + items
+    )
+
+
 def _format_sessions(sessions: list[dict]) -> str:
     if not sessions:
         return "No sessions found."
@@ -437,9 +448,12 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     chat_id = update.effective_chat.id
     lock = get_lock(chat_id)
+    queue = get_queue(chat_id)
 
     if lock.locked():
-        await update.message.reply_text("Still processing your previous message, please wait.")
+        pos = queue.qsize() + 1
+        await queue.put(content)
+        await update.message.reply_text(f"Still processing — yours is queued (#{pos}).")
         return
 
     async with lock:
@@ -451,6 +465,21 @@ async def handle_text(update: Update, context: ContextTypes.DEFAULT_TYPE):
         except Exception:
             log.exception("Error processing message in chat %s", chat_id)
             await update.message.reply_text("Something went wrong. Try again or use /clear.")
+
+        # Drain any messages that queued up while we were busy
+        queued: list[str] = []
+        while not queue.empty():
+            queued.append(queue.get_nowait())
+        if queued:
+            batch = _format_queue_batch(queued)
+            try:
+                sent2 = await update.effective_chat.send_message("\u2026")
+                final_chunks2 = await _stream_to_message(sent2, update.effective_user.id, chat_id, batch)
+                for extra in final_chunks2[1:]:
+                    await update.effective_chat.send_message(extra)
+            except Exception:
+                log.exception("Error processing queued batch in chat %s", chat_id)
+                await update.effective_chat.send_message("Something went wrong processing your queued messages.")
 
 
 # ---------------------------------------------------------------------------
@@ -476,8 +505,7 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
     lock = get_lock(chat_id)
 
     if lock.locked():
-        await update.message.reply_text("Still processing your previous message, please wait.")
-        return
+        await update.message.reply_text("Still processing your previous message — yours is queued and will follow.")
 
     async with lock:
         try:
@@ -572,8 +600,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
     lock = get_lock(chat_id)
 
     if lock.locked():
-        await update.message.reply_text("Still processing your previous message, please wait.")
-        return
+        await update.message.reply_text("Still processing your previous message — yours is queued and will follow.")
 
     async with lock:
         try:
@@ -634,9 +661,12 @@ async def handle_unknown_command(update: Update, context: ContextTypes.DEFAULT_T
 
     chat_id = update.effective_chat.id
     lock = get_lock(chat_id)
+    queue = get_queue(chat_id)
 
     if lock.locked():
-        await update.message.reply_text("Still processing your previous message, please wait.")
+        pos = queue.qsize() + 1
+        await queue.put(content)
+        await update.message.reply_text(f"Still processing — yours is queued (#{pos}).")
         return
 
     async with lock:
@@ -648,6 +678,21 @@ async def handle_unknown_command(update: Update, context: ContextTypes.DEFAULT_T
         except Exception:
             log.exception("Error processing unknown command in chat %s", chat_id)
             await update.message.reply_text("Something went wrong. Try again or use /clear.")
+
+        # Drain any messages that queued up while we were busy
+        queued: list[str] = []
+        while not queue.empty():
+            queued.append(queue.get_nowait())
+        if queued:
+            batch = _format_queue_batch(queued)
+            try:
+                sent2 = await update.effective_chat.send_message("\u2026")
+                final_chunks2 = await _stream_to_message(sent2, update.effective_user.id, chat_id, batch)
+                for extra in final_chunks2[1:]:
+                    await update.effective_chat.send_message(extra)
+            except Exception:
+                log.exception("Error processing queued batch in chat %s", chat_id)
+                await update.effective_chat.send_message("Something went wrong processing your queued messages.")
 
 
 # ---------------------------------------------------------------------------

--- a/core/gateway_client.py
+++ b/core/gateway_client.py
@@ -17,6 +17,7 @@ import aiohttp
 
 _SKILLS_DIR = os.path.expanduser("~/.claude/skills")
 _locks: dict[int, asyncio.Lock] = {}
+_chat_queues: dict[int, asyncio.Queue] = {}
 
 
 # ---------------------------------------------------------------------------
@@ -54,6 +55,12 @@ def get_lock(chat_id: int) -> asyncio.Lock:
     if chat_id not in _locks:
         _locks[chat_id] = asyncio.Lock()
     return _locks[chat_id]
+
+
+def get_queue(chat_id: int) -> asyncio.Queue:
+    if chat_id not in _chat_queues:
+        _chat_queues[chat_id] = asyncio.Queue()
+    return _chat_queues[chat_id]
 
 
 def time_ago(ts: float) -> str:

--- a/specs/skills/planka/SKILL.md
+++ b/specs/skills/planka/SKILL.md
@@ -25,6 +25,18 @@ Interact with the Planka Kanban board.
 - `assign-label --card-id <id> --label-id <id>` -- Assign label
 - `create-card --list-id <id> --name "..." [--description "..."] [--card-type story]` -- Create card
 
+## Known IDs (Hive Mind board)
+
+| Name | Type | ID |
+|------|------|----|
+| Hive Mind | Project | `1720152515468592132` |
+| Development | Board | `1720152515644752902` |
+| Backlog | List | `1720152629494940682` |
+| In Progress | List | `1720153348214096907` |
+| Done | List | `1720153348432200716` |
+
+Use these directly in commands — no need to look them up first.
+
 ## Output
 
 JSON with operation results.

--- a/tests/unit/test_sessions_queuing_removal.py
+++ b/tests/unit/test_sessions_queuing_removal.py
@@ -1,0 +1,49 @@
+"""Tests verifying message queuing infrastructure was cleanly removed from sessions.py."""
+import ast
+import inspect
+
+
+def _get_source():
+    """Read sessions.py source."""
+    from pathlib import Path
+    return (Path(__file__).resolve().parents[2] / "core" / "sessions.py").read_text()
+
+
+def test_no_queues_attribute():
+    """_queues dict should not exist in SessionManager."""
+    source = _get_source()
+    assert "_queues" not in source, "_queues still referenced in sessions.py"
+
+
+def test_no_busy_attribute():
+    """_busy dict should not exist in SessionManager."""
+    source = _get_source()
+    assert "_busy" not in source, "_busy still referenced in sessions.py"
+
+
+def test_no_format_queue_batch():
+    """_format_queue_batch method should not exist."""
+    source = _get_source()
+    assert "_format_queue_batch" not in source, "_format_queue_batch still in sessions.py"
+
+
+def test_no_do_send():
+    """_do_send should be inlined back into send_message."""
+    source = _get_source()
+    assert "_do_send" not in source, "_do_send still in sessions.py"
+
+
+def test_send_message_exists():
+    """send_message must still exist as an async generator."""
+    source = _get_source()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == "send_message":
+            return
+    raise AssertionError("send_message async method not found")
+
+
+def test_syntax_valid():
+    """sessions.py must parse without syntax errors."""
+    source = _get_source()
+    ast.parse(source)  # raises SyntaxError if invalid

--- a/tests/unit/test_telegram_lock_fix.py
+++ b/tests/unit/test_telegram_lock_fix.py
@@ -1,0 +1,42 @@
+"""Tests verifying lock.locked() guards are present in telegram_bot.py handlers.
+
+These guards provide user feedback when a message is already being processed,
+preventing messages from silently queuing behind the lock.
+"""
+import ast
+
+
+def _get_source():
+    from pathlib import Path
+    return (Path(__file__).resolve().parents[2] / "clients" / "telegram_bot.py").read_text()
+
+
+def test_lock_locked_guards_present():
+    """lock.locked() early-exit guards must be present in all four handlers."""
+    source = _get_source()
+    assert source.count("lock.locked()") >= 4, (
+        "Expected at least 4 lock.locked() guards (handle_text, handle_photo, "
+        "handle_voice, handle_unknown_command)"
+    )
+
+
+def test_still_processing_message_present():
+    """The 'Still processing' user-facing feedback must be present."""
+    source = _get_source()
+    assert "Still processing" in source, (
+        "'Still processing' message not found in telegram_bot.py"
+    )
+
+
+def test_async_with_lock_blocks_remain():
+    """All four handlers must still have 'async with lock:' blocks."""
+    source = _get_source()
+    count = source.count("async with lock:")
+    # handle_text, handle_photo, handle_voice, handle_unknown_command, cmd_skill = 5
+    assert count >= 4, f"Expected at least 4 'async with lock:' blocks, found {count}"
+
+
+def test_syntax_valid():
+    """telegram_bot.py must parse without syntax errors."""
+    source = _get_source()
+    ast.parse(source)


### PR DESCRIPTION
## Summary
- Restores per-chat message queuing in the Telegram bot — silently removed during the tool migration refactor
- When a message arrives while the bot is busy, it is queued and the user is notified of their position (#N)
- After the primary response, the handler drains all queued messages into one batch prompt so Claude replies once rather than once per queued message
- Drain loop runs inside the lock and repeats until empty, catching messages that arrive during batch processing
- Adds Planka board/list IDs to the planka skill for quick reference (no more lookup required)

## Changes
- `core/gateway_client.py` — adds `_chat_queues` dict and `get_queue()` accessor
- `clients/telegram_bot.py` — queue logic in `handle_text`, `handle_voice`, `handle_unknown_command`; `_format_queue_batch()` helper
- `specs/skills/planka/SKILL.md` + `.claude/skills/planka/SKILL.md` — known IDs table
- Two unit test files added

## Test plan
- [ ] Send a slow request (tool call), then immediately send 3+ voice messages — verify they arrive as one batched reply
- [ ] Verify "Still processing — yours is queued (#N)" notification fires when busy
- [ ] Verify normal (non-queued) messages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)