### PR TITLE
feat: add update-documentation skill

### DIFF
--- a/specs/skills/commit/SKILL.md
+++ b/specs/skills/commit/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: commit
+description: Stage, commit, push, and open a PR. Use when the user asks to commit changes, push a branch, or create a pull request. Handles master branch protection automatically.
+user-invocable: true
+argument-hint: "[commit message]"
+---
+
+# Commit
+
+## IMPORTANT: master is branch-protected — never push directly to master. Always use a feature branch.
+
+## Step 1 — Parse Arguments
+
+- `$@` = commit message (required). If not provided, ask the user before proceeding.
+
+## Step 2 — Assess current branch
+
+Run `git branch --show-current`.
+
+- Already on a feature branch (not `master`) → skip to Step 4
+- On `master` → Step 3
+
+## Step 3 — Create feature branch
+
+Derive a branch name from the commit message:
+- Lowercase, hyphens instead of spaces, strip special characters
+- Prefix: `feat/` (new), `fix/` (bug), `chore/` (everything else)
+
+```bash
+git checkout -b <branch-name>
+```
+
+## Step 4 — Stage and commit
+
+```bash
+git add <relevant files>   # specific files, not git add -A
+git status                 # verify staged
+git commit -m "<message>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+```
+
+If nothing to commit, say so and stop.
+
+## Step 5 — Push branch
+
+```bash
+git push -u origin <branch-name>
+```
+
+## Step 6 — Create PR
+
+```bash
+gh pr create --title "<commit message>" --body "$(cat <<'EOF'
+## Summary
+<bullet points from commit message>
+
+## Test plan
+- [ ] Verify changes work as expected
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Return the PR URL to the user.

--- a/specs/skills/update-documentation/SKILL.md
+++ b/specs/skills/update-documentation/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: update-documentation
+description: Update README and linked docs to match the current state of the codebase. Use when a code change has been made and docs may be stale, or when a specific doc error is spotted.
+user-invocable: true
+argument-hint: "[optional: feature name, commit SHA, or description of doc issue]"
+---
+
+# Update Documentation
+
+## Step 0 — Determine scope
+
+Before touching anything, assess what kind of update this is.
+
+**If a context argument was provided:**
+- Classify it: is this about a code change, or a specific doc error?
+- Code change → Step 1A
+- Doc error → Step 1B
+
+**If no argument was provided:**
+- Run `git log --oneline -10`
+- Identify commits that likely affect docs (new features, renames, removals, architectural changes)
+- Treat those commits as context → Step 1A
+
+**Scope decision — make this before doing any edits:**
+- Specific thing (one feature, one file, one paragraph) → **surgical mode**: fix only what's affected, then stop
+- Broad (full audit, major refactor) → **full sweep mode**: walk every linked doc
+
+State which mode you're in before proceeding.
+
+---
+
+## Step 1A — Code-change entry point
+
+1. If a commit SHA or feature name was given, run `git show <sha> --stat` or `git log --oneline --all | grep <feature>`
+2. Identify which files/modules changed
+3. Search docs for references to those files/modules:
+   ```bash
+   grep -r "<module or feature name>" docs/ specs/ README.md CLAUDE.md
+   ```
+4. For each doc that references the changed area → Step 2
+
+---
+
+## Step 1B — Doc-issue entry point
+
+1. Identify which file and section the issue is in
+2. Read that file in full
+3. Locate the stale/incorrect content
+4. Verify the correct state by reading the actual source (code file, config, etc.)
+5. Fix the specific issue → Step 3 (check for ripple effects)
+
+---
+
+## Step 2 — Update affected docs
+
+For each doc identified in Step 1A:
+
+- Read it in full
+- Find the section(s) that reference the changed code/feature
+- Verify the correct state by reading the actual source
+- Edit only what's wrong — do not rewrite for style or reorganise
+- Note each change made
+
+Key files to check (in priority order):
+- `README.md` — architecture diagram, file structure, API table, Adding New Tools section
+- `CLAUDE.md` — file structure listing, design principles
+- `specs/hive-mind-architecture.md` — patterns and architectural decisions
+- `specs/tool-migration.md` — stateless/stateful hybrid pattern
+- Any other spec that grep found a reference in
+
+---
+
+## Step 3 — Check for ripple effects
+
+After any edit, check whether the changed doc links to other docs that may also need updating:
+
+```bash
+grep -o '\[.*\](.*\.md)' <edited-file>
+```
+
+For each linked file, ask: could the change you just made require an update there too? If yes, read it and fix. If no, move on.
+
+In surgical mode: stop after one level of ripple checking.
+In full sweep mode: follow links recursively until no more updates are needed.
+
+---
+
+## Step 4 — Verify no broken links
+
+```bash
+grep -rh '\[.*\](.*\.md)' docs/ specs/ README.md CLAUDE.md | grep -o '([^)]*\.md)' | tr -d '()' | sort -u
+```
+
+For each unique `.md` path found, verify the file exists. Report any that don't.
+
+---
+
+## Step 5 — Summarise
+
+Output:
+- Mode used (surgical / full sweep) and why
+- Files changed, with a one-line description of what was fixed in each
+- Any broken links found and whether they were fixed
+- Anything that couldn't be verified automatically and needs human review


### PR DESCRIPTION
## Summary
- New `/update-documentation` skill with 5-step procedure
- Step 0: Scope assessment — classifies as surgical or full-sweep before any edits
- Step 1A/1B: Dual entry points for code-change vs doc-issue triggers
- Steps 2-5: Update docs, ripple check, broken link verification, summarise

## Test plan
- [ ] Invoke `/update-documentation` with no args — should fall back to recent git log
- [ ] Invoke with a feature name — should grep docs and fix only affected sections
- [ ] Invoke with a doc issue description — should fix only that section (surgical mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)