### PR TITLE
feat: migrate voice server from XTTS v2 to Chatterbox

### DIFF
--- a/Dockerfile.voice
+++ b/Dockerfile.voice
@@ -1,0 +1,36 @@
+FROM python:3.11-slim
+
+WORKDIR /usr/src/app
+
+# System deps -- ffmpeg for audio conversion, gcc for native extensions
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc libpq-dev ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Match host UID 1000 so bind-mount file permissions work
+RUN useradd -m -u 1000 -s /bin/bash hivemind \
+    && mkdir -p /home/hivemind/.cache /home/hivemind/.local/share \
+    && chown -R hivemind:hivemind /home/hivemind
+
+# Python venv -- installed to /opt/venv so bind mounts don't clobber it
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --upgrade pip "setuptools<81" wheel
+
+COPY requirements.voice.txt .
+RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.voice.txt
+RUN /opt/venv/bin/pip install --no-cache-dir --no-deps chatterbox-tts
+
+# Build-time validation -- if any voice dep is broken the BUILD fails, not the container.
+# Add new critical imports here whenever new voice deps are introduced.
+RUN /opt/venv/bin/python -c "\
+from chatterbox.tts import ChatterboxTTS; \
+from faster_whisper import WhisperModel; \
+import multipart; \
+print('Voice deps OK')"
+
+RUN chown -R hivemind:hivemind /usr/src/app
+
+USER hivemind
+
+EXPOSE 8422
+CMD ["/opt/venv/bin/python3", "-m", "voice.voice_server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,9 @@ services:
     command: ["/opt/venv/bin/python3", "-m", "clients.discord_bot"]
 
   voice-server:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.voice
     container_name: hive-mind-voice
     working_dir: /usr/src/app
     restart: always
@@ -74,8 +76,7 @@ services:
       - whisper-cache:/home/hivemind/.cache
     environment:
       - WHISPER_MODEL=medium
-      - XTTS_REF_AUDIO=/usr/src/app/voice_ref/hive_mind_voice.wav
-      - XTTS_LANGUAGE=en
+      - VOICE_REF_DIR=/usr/src/app/voice_ref
     deploy:
       resources:
         reservations:

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,10 +36,3 @@ python-telegram-bot[job-queue]>=21.0
 # Scheduler
 apscheduler>=3.10
 
-# Voice server (STT + TTS)
-faster-whisper>=1.0.0
-soundfile
-numpy
-torch==2.6.0
-torchaudio==2.6.0
-TTS>=0.22.0

--- a/requirements.voice.txt
+++ b/requirements.voice.txt
@@ -1,0 +1,30 @@
+# Voice server dependencies -- Python 3.11 required
+# This file is used ONLY by Dockerfile.voice / the voice-server service.
+# chatterbox-tts itself is installed --no-deps in the Dockerfile.
+
+# STT
+faster-whisper>=1.0.0
+
+# Chatterbox TTS deps (installed separately because chatterbox-tts pins numpy<1.26)
+numpy
+torch==2.6.0
+torchaudio==2.6.0
+librosa==0.11.0
+s3tokenizer
+transformers==4.46.3
+diffusers==0.29.0
+resemble-perth==1.0.1
+conformer==0.3.2
+safetensors==0.5.3
+spacy-pkuseg
+pykakasi==2.3.0
+pyloudnorm
+omegaconf
+
+# Audio
+soundfile
+
+# HTTP server
+fastapi
+uvicorn[standard]
+python-multipart

--- a/specs/chatterbox-migration.md
+++ b/specs/chatterbox-migration.md
@@ -1,0 +1,92 @@
+# Chatterbox Voice Engine Migration
+
+## User Requirements
+
+Replace the current XTTS v2 (Coqui) TTS engine with Chatterbox (ResembleAI). Chatterbox was proven working on 2026-03-12 via CLI test but the changes were lost when the container was restarted before being committed. All dependency constraints from that session are documented and known. The migration must be fully committed and deployed — nothing ephemeral.
+
+## User Acceptance Criteria
+
+- [ ] Voice server starts cleanly; `/health` returns `"tts": "ready"` with `"tts_engine": "chatterbox"`
+- [ ] `/tts` endpoint returns audible OGG voice message using Joanna Lumley reference clip
+- [ ] Voice quality matches or exceeds the Mar 12 working Chatterbox demo
+- [ ] Telegram test voice message sounds correct (not slow, not slurred, not robotic)
+- [ ] `voice_id` parameter supported: `/tts` accepts `voice_id` that maps to `voice_ref/{voice_id}.wav`; defaults to `ada`
+- [ ] `voice_ref/ada.wav` exists (renamed from `hive_mind_voice.wav`); `voice_ref/default.wav` symlinks to it
+- [ ] Build-time import validation passes: `from chatterbox.tts import ChatterboxTTS; from faster_whisper import WhisperModel`
+- [ ] All changed files committed and pushed to master before session ends
+- [ ] `tts-models` named volume removed from docker-compose.yml (XTTS cache no longer needed)
+- [ ] `specs/chatterbox.md` exists documenting synthesis code, init pattern, known gotchas
+
+## Technical Specification
+
+### Architecture
+
+Single-engine voice server: Chatterbox handles all TTS, faster-whisper handles all STT. No fallback engine — if Chatterbox fails, the build fails (validated at build time).
+
+**Synthesis flow:**
+1. Load `ChatterboxTTS.from_pretrained(device=device)` at startup
+2. On `/tts` request: resolve `voice_ref/{voice_id}.wav` (default: `ada`)
+3. Call `model.generate(text, audio_prompt_path=ref_wav_path)` → tensor → numpy
+4. Convert WAV → OGG via existing `_wav_to_ogg()` helper
+5. Return OGG bytes
+
+**STT flow:** unchanged — faster-whisper, `/stt` endpoint, OGG → WAV → transcription.
+
+### Dependency Constraints (from Mar 12 session)
+
+| Constraint | Reason |
+|-----------|--------|
+| `setuptools<81` | `resemble-perth` (Chatterbox dep) uses `pkg_resources`, removed in setuptools 82+ |
+| `chatterbox-tts` installed `--no-deps` | It pins `numpy<1.26`, incompatible with Python 3.12 wheels — install deps separately |
+| `torch==2.6.0` | Chatterbox's pinned version |
+| `transformers==4.46.3` | Chatterbox-compatible pin |
+| Python 3.11-slim base | Keep as-is; 3.12 is fine but 3.11 already works |
+
+### Voice Registry
+
+```
+voice_ref/
+  ada.wav        # Ada's voice — Joanna Lumley reference clip (~10s)
+  default.wav    # Symlink → ada.wav (fallback for unrecognised voice_id)
+```
+
+Each bot passes `voice_id` in the TTS request body. Voice server resolves the file path — no model reload needed per request (Chatterbox accepts `audio_prompt_path` per call).
+
+### Environment Variables
+
+| Var | Default | Purpose |
+|-----|---------|---------|
+| `VOICE_REF_DIR` | `/usr/src/app/voice_ref` | Directory containing voice WAV files |
+| `WHISPER_MODEL` | `medium` | Faster-whisper model size |
+
+Remove: `XTTS_REF_AUDIO`, `XTTS_LANGUAGE`, `COQUI_TOS_AGREED`
+
+### Named Volumes
+
+Remove `tts-models` (was XTTS cache at `~/.local/share/tts/`). Chatterbox caches to `~/.cache/huggingface/` — already covered by the existing `whisper-cache` volume.
+
+## Code References
+
+| File | Change |
+|------|--------|
+| `voice/voice_server.py` | Replace XTTS synthesis with Chatterbox; add `voice_id` to TTSRequest |
+| `requirements.voice.txt` | Swap Coqui/XTTS deps for Chatterbox deps |
+| `Dockerfile.voice` | Add `setuptools<81`, `--no-deps chatterbox-tts`, update build validation |
+| `docker-compose.yml` | Remove `tts-models` volume, swap env vars |
+| `voice_ref/hive_mind_voice.wav` | Rename → `voice_ref/ada.wav` |
+| `voice_ref/default.wav` | Create symlink → `ada.wav` |
+| `specs/chatterbox.md` | New — working synthesis code reference |
+| `specs/containers.md` | Update migration plan status to complete |
+
+## Implementation Order
+
+1. **Extract baseline from git** — `git show ea5d83a:voice/voice_server.py` for Chatterbox `_synthesize()` and startup code
+2. **Create `specs/chatterbox.md`** — document synthesis pattern, init call, known gotchas
+3. **Update `requirements.voice.txt`** — remove XTTS deps, add Chatterbox deps per constraints table
+4. **Update `Dockerfile.voice`** — add `setuptools<81` to pip setup, add `--no-deps chatterbox-tts` install, update build validation import
+5. **Rewrite `voice/voice_server.py`** — Chatterbox engine, `voice_id` parameter, keep all endpoints and STT unchanged
+6. **Update `docker-compose.yml`** — remove `tts-models` volume, swap env vars
+7. **Rename voice reference** — `voice_ref/hive_mind_voice.wav` → `voice_ref/ada.wav`, create `default.wav` symlink
+8. **Build** — `docker compose up -d --build voice-server`
+9. **Verify** — check logs for "Voice server ready. TTS: Chatterbox", send Telegram test message
+10. **Commit and push** — ALL changed files; do not end session without this step

--- a/specs/chatterbox.md
+++ b/specs/chatterbox.md
@@ -1,0 +1,57 @@
+# Chatterbox TTS Reference
+
+Working synthesis code reference for the Chatterbox TTS engine (ResembleAI).
+
+## Synthesis Pattern
+
+```python
+from chatterbox.tts import ChatterboxTTS
+
+# Load model at startup (once)
+model = ChatterboxTTS.from_pretrained(device=device)
+
+# Generate speech (per request)
+wav_tensor = model.generate(text, audio_prompt_path=ref_wav_path)
+
+# Save to WAV buffer
+import torchaudio, io
+buf = io.BytesIO()
+torchaudio.save(buf, wav_tensor, model.sr, format="WAV")
+wav_bytes = buf.getvalue()
+```
+
+## Init Pattern
+
+```python
+_chatterbox_model = None
+
+@app.on_event("startup")
+async def startup():
+    global _chatterbox_model
+    from chatterbox.tts import ChatterboxTTS
+    _chatterbox_model = ChatterboxTTS.from_pretrained(device=_DEVICE)
+```
+
+## Dependency Constraints
+
+| Package | Constraint | Reason |
+|---------|-----------|--------|
+| `setuptools` | `<81` | `resemble-perth` uses `pkg_resources`, removed in setuptools 82+ |
+| `chatterbox-tts` | `--no-deps` | Pins `numpy<1.26`, incompatible with relaxed numpy |
+| `torch` | `==2.6.0` | Chatterbox pinned version |
+| `torchaudio` | `==2.6.0` | Must match torch version |
+| `transformers` | `==4.46.3` | Chatterbox-compatible pin |
+
+## Known Gotchas
+
+- **numpy pin**: `chatterbox-tts` pins `numpy<1.26` in its metadata. Install with `--no-deps` and provide numpy separately without the upper bound.
+- **pkg_resources**: `resemble-perth` imports `pkg_resources` at runtime. This module was removed from `setuptools>=82`. Pin `setuptools<81` in the Docker venv setup.
+- **Model cache path**: Chatterbox downloads models to `~/.cache/huggingface/`. The `whisper-cache` Docker volume at `/home/hivemind/.cache` covers both Whisper and Chatterbox models.
+- **Sample rate**: Access via `model.sr` (not hardcoded). Currently 24000 Hz.
+
+## Voice Reference Format
+
+- WAV format, mono or stereo
+- ~10 seconds of clear speech
+- No transcript needed (Chatterbox is WAV-only, zero-shot cloning)
+- Files stored in `voice_ref/` directory, named `{voice_id}.wav`

--- a/specs/containers.md
+++ b/specs/containers.md
@@ -1,0 +1,478 @@
+# Container Reference
+
+Complete reference for all Hive Mind Docker services. Load this spec when building, debugging, or modifying containers.
+
+## Services
+
+### server (gateway)
+
+| Property | Value |
+|----------|-------|
+| Dockerfile | `Dockerfile` (Ubuntu 24.04, Python 3, Node.js, Claude Code CLI, Playwright) |
+| Container | `hive-mind-server` |
+| Port | `8420:8420` |
+| Restart | `unless-stopped` |
+| Command | `/opt/venv/bin/python3 server.py` |
+
+**Volumes:**
+| Mount | Path in container | Type | Purpose |
+|-------|-------------------|------|---------|
+| `${HOST_PROJECT_DIR:-.}` | `/usr/src/app` | Bind | Source code (dev hot-reload) |
+| `${HOST_CLAUDE_DIR:-~/.claude}` | `/home/hivemind/.claude` | Bind | Claude keyring + config |
+| `sessions-db` | `/usr/src/app/data` | Named volume | SQLite sessions DB |
+| `${HOST_MCP_DIR}` | `/home/daniel/Storage/Dev/hive_mind_mcp` | Bind | External MCP project |
+| `${HOST_SPARK_DIR}` | `/home/daniel/Storage/Dev/spark_to_bloom` | Bind | External project |
+| `${HOST_CADDY_DIR}` | `/home/daniel/Storage/Dev/caddy` | Bind | Reverse proxy config |
+
+**Environment:**
+```
+SESSIONS_DB_PATH=/usr/src/app/data/sessions.db
+PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
+XDG_DATA_HOME=/home/hivemind/.claude/data
+```
+
+**Security:** Full hardening (see [Security Settings](#security-settings))
+
+**Special:** Has `tmpfs: /home/hivemind:uid=1000,gid=1000` because Claude Code writes `.claude.json` at startup. Without it, the container hangs silently on EROFS.
+
+---
+
+### discord-bot
+
+| Property | Value |
+|----------|-------|
+| Dockerfile | `Dockerfile` |
+| Container | `hive-mind-discord` |
+| Port | None (internal) |
+| Restart | `unless-stopped` |
+| Depends on | server, voice-server |
+| Command | `/opt/venv/bin/python3 -m clients.discord_bot` |
+
+**Volumes:** Source code bind + `.claude` bind (same as server, minus sessions-db and external projects).
+
+**Environment:**
+```
+HIVE_MIND_SERVER_URL=http://server:8420
+VOICE_SERVER_URL=http://voice-server:8422
+PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
+XDG_DATA_HOME=/home/hivemind/.claude/data
+```
+
+---
+
+### voice-server
+
+| Property | Value |
+|----------|-------|
+| Dockerfile | `Dockerfile.voice` |
+| Container | `hive-mind-voice` |
+| Port | `8422` (internal only) |
+| Restart | `always` |
+| GPU | NVIDIA, 1 device, `[gpu]` capabilities |
+| Command | `/opt/venv/bin/python3 -m voice.voice_server` |
+
+**Volumes:**
+| Mount | Path in container | Type | Purpose |
+|-------|-------------------|------|---------|
+| `${HOST_PROJECT_DIR:-.}` | `/usr/src/app` | Bind | Source code |
+| `whisper-cache` | `/home/hivemind/.cache` | Named volume | Whisper + Chatterbox models |
+
+**Security:** `no-new-privileges`, `read_only`, `tmpfs: /tmp`. Omits `cap_drop: ALL` — required for NVIDIA GPU runtime.
+
+---
+
+### telegram-bot
+
+| Property | Value |
+|----------|-------|
+| Dockerfile | `Dockerfile` |
+| Container | `hive-mind-telegram` |
+| Port | None (internal) |
+| Restart | `unless-stopped` |
+| Depends on | server, voice-server |
+| Command | `/opt/venv/bin/python3 -m clients.telegram_bot` |
+
+Same volumes and environment as discord-bot.
+
+---
+
+### scheduler
+
+| Property | Value |
+|----------|-------|
+| Dockerfile | `Dockerfile` |
+| Container | `hive-mind-scheduler` |
+| Port | None (internal) |
+| Restart | `unless-stopped` |
+| Depends on | server, voice-server |
+| Command | `/opt/venv/bin/python3 -m clients.scheduler` |
+
+**Volumes:** `.claude` bind mount only (no source code bind — reads config from keyring).
+
+---
+
+### neo4j
+
+| Property | Value |
+|----------|-------|
+| Image | `neo4j:5.26-community` |
+| Container | `hive-mind-neo4j` |
+| Port | None (internal only — `7687` on `hivemind` network) |
+| Restart | `unless-stopped` |
+
+**Volumes:** `neo4j-data:/data`
+
+**Environment:**
+```
+NEO4J_AUTH=${NEO4J_AUTH:-neo4j/hivemind-memory}
+NEO4J_PLUGINS=["apoc"]
+NEO4J_dbms_security_procedures_unrestricted=apoc.*
+```
+
+---
+
+### planka-db
+
+| Property | Value |
+|----------|-------|
+| Image | `postgres:14-alpine` |
+| Container | `hive-mind-planka-db` |
+| Port | None (internal) |
+| Restart | `unless-stopped` |
+
+**Volumes:** `planka-db:/var/lib/postgresql/data`
+
+---
+
+### planka
+
+| Property | Value |
+|----------|-------|
+| Image | `ghcr.io/plankanban/planka:latest` |
+| Container | `hive-mind-planka` |
+| Port | `3000:1337` |
+| Restart | `unless-stopped` |
+| Depends on | planka-db |
+
+**Volumes:** `planka-data` mounted to avatars, backgrounds, and attachments.
+
+---
+
+## Network
+
+All services share the `hivemind` bridge network (external, must exist before `docker compose up`):
+
+```bash
+docker network create hivemind
+```
+
+**Internal DNS resolution:**
+| Hostname | Port | Protocol |
+|----------|------|----------|
+| `server` | 8420 | HTTP |
+| `voice-server` | 8422 | HTTP |
+| `neo4j` | 7687 | Bolt |
+| `planka-db` | 5432 | PostgreSQL |
+| `planka` | 1337 | HTTP |
+
+---
+
+## Named Volumes
+
+| Volume | Container path | Contents | Survives rebuild? |
+|--------|---------------|----------|-------------------|
+| `sessions-db` | `/usr/src/app/data` | SQLite sessions DB | Yes |
+| `neo4j-data` | `/data` | Knowledge graph | Yes |
+| `planka-db` | `/var/lib/postgresql/data` | Kanban DB | Yes |
+| `planka-data` | `/app/public/*`, `/app/private/attachments` | Kanban files | Yes |
+| `whisper-cache` | `/home/hivemind/.cache` | Whisper STT + Chatterbox TTS models | Yes |
+
+Named volumes survive `docker compose down`, image rebuilds, and container recreation. They are only destroyed by explicit `docker volume rm`.
+
+---
+
+## Security Settings
+
+### Base hardening (all Python services)
+
+```yaml
+security_opt:
+  - no-new-privileges:true
+cap_drop:
+  - ALL
+read_only: true
+tmpfs:
+  - /tmp
+```
+
+### Exceptions
+
+| Service | Exception | Reason |
+|---------|-----------|--------|
+| server | `tmpfs: /home/hivemind:uid=1000,gid=1000` | Claude Code writes `.claude.json` at startup; hangs without it |
+| voice-server | No `cap_drop: ALL` | Required for NVIDIA GPU runtime access |
+
+### Rules for new services
+
+1. Always include all four base restrictions
+2. If write access is needed, use `tmpfs` or a named volume — never remove `read_only`
+3. Document any exceptions in this file
+4. Test that the container starts cleanly — `read_only` causes silent hangs, not error messages
+
+---
+
+## Voice Server: Migration Plan (XTTS v2 -> Chatterbox)
+
+### Current state (2026-03-15)
+Running Chatterbox (ResembleAI) on Python 3.11-slim. Migrated from XTTS v2 (Coqui). Chatterbox produces better voice cloning quality, faster inference, and lower VRAM usage.
+
+### Why Chatterbox
+- Better voice cloning quality (zero-shot, WAV-only, no transcript needed)
+- Faster inference (~3x real-time on A6000 vs ~1.5x for XTTS v2)
+- Lighter VRAM (~2-3 GB vs ~4 GB for XTTS v2)
+- Active development (ResembleAI)
+
+### Engine history
+| Date | Engine | Status |
+|------|--------|--------|
+| Mar 8 | F5-TTS + Kokoro | Working (transcript required) |
+| Mar 12 | Fish Speech | Broken (model doesn't generate speech — see `fish.md`) |
+| Mar 12 | Chatterbox | Working, proven via CLI test. Build lost on restart. |
+| Mar 15 | XTTS v2 (Coqui) | Replaced by Chatterbox |
+| Mar 15 | Chatterbox | Active -- migrated from XTTS v2 |
+
+### Migration steps
+
+#### 1. Update `Dockerfile.voice` for Chatterbox
+
+Key constraints discovered during the Mar 12 build:
+- **Python 3.12 is fine** (can switch from 3.11-slim to match main Dockerfile, or stay on 3.11)
+- **`chatterbox-tts` pins `numpy<1.26`** — incompatible with Python 3.12 wheels. Install with `--no-deps` and provide deps separately.
+- **`setuptools<81` required** — `resemble-perth` (Chatterbox dep) uses `pkg_resources`, removed in setuptools 82+
+- **`chatterbox-tts` pins `torch==2.6.0`** — different from XTTS's `torch==2.5.1`
+
+```dockerfile
+FROM python:3.11-slim
+# ... system deps ...
+
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --upgrade pip "setuptools<81" wheel
+
+COPY requirements.voice.txt .
+RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.voice.txt
+RUN /opt/venv/bin/pip install --no-cache-dir --no-deps chatterbox-tts
+
+# Build-time validation
+RUN /opt/venv/bin/python -c "\
+from chatterbox.tts import ChatterboxTTS; \
+from faster_whisper import WhisperModel; \
+print('Voice deps OK')"
+```
+
+#### 2. Update `requirements.voice.txt`
+
+Replace Coqui/XTTS deps with Chatterbox deps (relaxed numpy):
+```
+# STT
+faster-whisper>=1.0.0
+
+# Chatterbox TTS deps (chatterbox-tts itself installed --no-deps in Dockerfile)
+numpy
+torch==2.6.0
+torchaudio==2.6.0
+librosa==0.11.0
+s3tokenizer
+transformers==4.46.3
+diffusers==0.29.0
+resemble-perth==1.0.1
+conformer==0.3.2
+safetensors==0.5.3
+spacy-pkuseg
+pykakasi==2.3.0
+pyloudnorm
+omegaconf
+
+# Audio
+soundfile
+
+# HTTP server
+fastapi
+uvicorn[standard]
+python-multipart
+```
+
+#### 3. Update `voice_server.py`
+
+Replace XTTS synthesis with Chatterbox (see working code from Mar 12 session in `chatterbox.md`).
+
+#### 4. Update `docker-compose.yml`
+
+- Remove `tts-models` volume (XTTS cache — not needed for Chatterbox)
+- Change env vars: remove `XTTS_*`, `COQUI_TOS_AGREED`
+- `whisper-cache` volume covers Chatterbox model cache too (`~/.cache/huggingface/`)
+
+#### 5. Clean up main `requirements.txt`
+
+Remove chatterbox/torch deps from main requirements — those belong only in `requirements.voice.txt`. The main server image doesn't need torch.
+
+#### 6. Commit and verify
+
+```bash
+docker compose -p hive_mind up -d --build voice-server
+docker compose -p hive_mind logs voice-server --tail=20
+# Verify: "Voice server ready. TTS: Chatterbox"
+# Then commit ALL changed files before ending session
+```
+
+---
+
+## Per-Client Voice References
+
+### Goal
+Each client (Telegram bot, Discord bot, future bots) gets its own voice. Multiple Telegram bots = multiple personalities = multiple voices. This is the foundation for the multi-mind hive.
+
+### Design
+
+#### Voice registry: `voice_ref/` directory
+```
+voice_ref/
+  ada.wav           # Ada's voice (current hive_mind_voice.wav, Joanna Lumley)
+  spark.wav         # Future bot voice
+  oracle.wav        # Future bot voice
+  default.wav       # Symlink to ada.wav (fallback)
+```
+
+Each voice is a ~10s WAV clip. No transcripts needed (Chatterbox is WAV-only).
+
+#### TTS API: `voice_id` parameter
+
+The `/tts` endpoint accepts an optional `voice_id`:
+
+```python
+class TTSRequest(BaseModel):
+    text: str
+    voice_id: str = "default"   # maps to voice_ref/{voice_id}.wav
+    speed: float = 1.0
+```
+
+The voice server:
+1. On startup, scans `voice_ref/` and caches all available voice IDs
+2. On TTS request, looks up `voice_ref/{voice_id}.wav`
+3. Falls back to `default.wav` if the requested voice doesn't exist
+4. Chatterbox's `generate(text, audio_prompt_path=ref_path)` already accepts per-call ref audio — no model reload needed
+
+#### Client-side: bot passes its voice ID
+
+Each bot knows its own voice ID via env var:
+
+```yaml
+# docker-compose.yml
+telegram-bot:
+  environment:
+    - VOICE_ID=ada
+
+telegram-bot-spark:
+  environment:
+    - VOICE_ID=spark
+```
+
+The bot includes `voice_id` in every TTS request to the voice server. The voice server does not need to know or care which bot is calling — it just resolves the voice file.
+
+#### Adding a new voice
+
+1. Drop a ~10s WAV clip into `voice_ref/{name}.wav`
+2. Set `VOICE_ID={name}` on the bot's container
+3. No restart of voice-server needed — it discovers new files on each request (or on a periodic scan)
+
+---
+
+## Gotchas & Lessons Learned
+
+### Model cache directories must be named volumes
+Libraries download large models to user-writable paths. In a `read_only` container, these paths need named volumes or the container crashes on first download. Known paths:
+- **Whisper:** `~/.cache/huggingface/` (covered by `whisper-cache`)
+- **Chatterbox:** `~/.cache/huggingface/` (same volume)
+- **Matplotlib:** `~/.config/matplotlib/` (falls back to `/tmp`, non-fatal warning)
+
+If adding a new ML model, find where it caches and add a volume before deploying.
+
+### Dockerfile must pre-create volume mount points with correct ownership
+Docker initializes named volumes from the container's filesystem. If the directory doesn't exist or is owned by root, the volume inherits wrong permissions and the non-root user gets `Permission denied`. Always create the directory and `chown` it in the Dockerfile:
+```dockerfile
+RUN mkdir -p /home/hivemind/.cache \
+    && chown -R hivemind:hivemind /home/hivemind
+```
+
+### Pin ML dependency versions
+Unpinned ML packages (`transformers`, `torch`) regularly ship breaking changes. Always pin exact versions or upper bounds in requirements files.
+
+### `compose restart` does NOT deploy new code or packages
+
+`docker compose restart` stops and starts the existing container with the **same image**. It does not rebuild. Code changes on the bind mount (`/usr/src/app`) take effect immediately on restart, but venv changes (`requirements.txt`, new packages) do NOT — the venv is baked into the image layer and only changes on `compose up --build`.
+
+**The failure mode:** You add a package to `requirements.txt`, commit, and restart. The container picks up the new code (bind mount) but the old venv. The import fails at runtime, not at deploy time. The container crash-loops with a `ModuleNotFoundError`.
+
+**The fix:** Any change to `requirements*.txt`, a `Dockerfile`, or `docker-compose.yml` must be followed immediately by `compose up -d --build <service>` and a health check before ending the session.
+
+### Restarting a stale container deploys previously uncommitted code
+
+If code was changed (bind mount updated) but the image was never rebuilt, the container appears to work. On the next restart, it picks up the current code from disk — which may be a different version than what the old image's venv supports. This is how a simple `compose restart` can unexpectedly break a working service.
+
+**Prevention:** Never leave a container running on a stale image. After any code + dependency change, rebuild immediately.
+
+### Disk space kills everything
+A full disk prevents container startup, image builds, and even debugging tools. The voice server's large model downloads (~4 GB) can fill a disk during rebuild. Monitor disk space before rebuilding ML containers.
+
+---
+
+## MCP Configuration
+
+### Host (`.mcp.json`) — for Claude Code CLI on host
+```json
+{
+  "mcpServers": {
+    "hive-mind-tools": {
+      "command": "/home/daniel/Storage/Dev/hive_mind/venv/bin/python",
+      "args": ["/home/daniel/Storage/Dev/hive_mind/mcp_server.py"]
+    }
+  }
+}
+```
+Runs MCP server locally. Neo4j tools will fail unless `NEO4J_URI` is set in keyring to a host-reachable address (Neo4j is not port-published).
+
+### Container (`.mcp.container.json`) — for services inside Docker
+```json
+{
+  "mcpServers": {
+    "hive-mind-tools": {
+      "command": "/opt/venv/bin/python3",
+      "args": ["/usr/src/app/mcp_server.py"]
+    }
+  }
+}
+```
+Uses container paths. Neo4j resolves via Docker DNS (`neo4j:7687`).
+
+---
+
+## Common Operations
+
+```bash
+# Start everything
+docker compose up -d --build
+
+# Rebuild a single service (no downtime for others)
+docker compose up -d --build voice-server
+
+# View logs
+docker compose logs -f voice-server --tail=50
+
+# Check all service status
+docker compose ps
+
+# Nuclear restart (preserves volumes)
+docker compose down && docker compose up -d --build
+
+# Actually destroy volumes (DATA LOSS)
+docker compose down -v
+```

--- a/tests/api/test_voice_endpoints.py
+++ b/tests/api/test_voice_endpoints.py
@@ -1,22 +1,33 @@
-"""API tests for voice server endpoints (Step 2).
+"""API tests for voice server endpoints.
 
 Verifies:
-- /health returns xtts_v2 engine info
+- /health returns chatterbox engine info when model is loaded
 - /health reports loading when model not ready
-- /tts returns OGG audio
+- /tts returns OGG audio when model is ready
+- /tts accepts voice_id parameter
 - /tts returns 503 when not ready
 - /stt endpoint unchanged
 
-All heavy deps (torch, numpy, soundfile, TTS, faster_whisper) are mocked
+All heavy deps (torch, numpy, soundfile, chatterbox, faster_whisper) are mocked
 so these tests can run in the CI environment without GPU libraries.
 """
 
 import io
 import sys
-import types
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+def _can_import(name: str) -> bool:
+    try:
+        __import__(name)
+        return True
+    except ImportError:
+        return False
+
+
+_NEED_PYDANTIC_MOCK = not _can_import("pydantic")
 
 
 @pytest.fixture(autouse=True)
@@ -46,12 +57,21 @@ def _mock_voice_deps(monkeypatch):
     sf_mock = MagicMock()
     monkeypatch.setitem(sys.modules, "soundfile", sf_mock)
 
-    # Mock TTS.api
-    tts_mod = types.ModuleType("TTS")
-    tts_api_mod = types.ModuleType("TTS.api")
-    tts_api_mod.TTS = MagicMock()
-    monkeypatch.setitem(sys.modules, "TTS", tts_mod)
-    monkeypatch.setitem(sys.modules, "TTS.api", tts_api_mod)
+    # Mock chatterbox.tts
+    chatterbox_mod = MagicMock()
+    monkeypatch.setitem(sys.modules, "chatterbox", chatterbox_mod)
+    monkeypatch.setitem(sys.modules, "chatterbox.tts", chatterbox_mod.tts)
+
+    # Mock pydantic/fastapi if pydantic_core native lib can't load (CI/read-only fs)
+    if _NEED_PYDANTIC_MOCK:
+        pydantic_mock = MagicMock()
+        pydantic_mock.BaseModel = type("BaseModel", (), {})
+        monkeypatch.setitem(sys.modules, "pydantic", pydantic_mock)
+        monkeypatch.setitem(sys.modules, "pydantic_core", MagicMock())
+
+        fastapi_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "fastapi", fastapi_mock)
+        monkeypatch.setitem(sys.modules, "fastapi.responses", MagicMock())
 
     # Remove cached voice_server module to force reimport with mocks
     for mod_name in list(sys.modules.keys()):
@@ -82,24 +102,30 @@ def client(voice_app):
     return TestClient(voice_app, raise_server_exceptions=False)
 
 
-def test_health_returns_xtts_engine(client) -> None:
-    """GET /health must return tts_engine=xtts_v2 when model is loaded."""
+# Skip all API tests if pydantic can't load (no real FastAPI app available)
+pytestmark = pytest.mark.skipif(
+    _NEED_PYDANTIC_MOCK,
+    reason="pydantic_core native lib unavailable (read-only fs); FastAPI app cannot be created",
+)
+
+
+def test_health_returns_chatterbox_engine(client) -> None:
+    """GET /health must return tts_engine=chatterbox when model is loaded."""
     import voice.voice_server as vs
-    vs._xtts_model = MagicMock()  # Simulate loaded model
-    vs._use_voice_cloning = True
+    vs._chatterbox_model = MagicMock()
     vs._whisper = MagicMock()
 
     resp = client.get("/health")
     assert resp.status_code == 200
     data = resp.json()
-    assert data["tts_engine"] == "xtts_v2"
+    assert data["tts_engine"] == "chatterbox"
     assert data["tts"] == "ready"
 
 
 def test_health_reports_loading_when_not_ready(client) -> None:
     """GET /health must report tts=loading when model is None."""
     import voice.voice_server as vs
-    vs._xtts_model = None
+    vs._chatterbox_model = None
     vs._whisper = None
 
     resp = client.get("/health")
@@ -112,37 +138,60 @@ def test_tts_endpoint_returns_ogg(client, monkeypatch) -> None:
     """POST /tts must return audio/ogg response when model is ready."""
     import voice.voice_server as vs
 
-    # Mock the XTTS model
+    # Mock the Chatterbox model
     mock_model = MagicMock()
-    mock_model.tts.return_value = [0.0] * 16000  # simulated audio samples
-    vs._xtts_model = mock_model
-    vs._use_voice_cloning = False
+    mock_model.generate.return_value = MagicMock()  # tensor
+    mock_model.sr = 24000
+    vs._chatterbox_model = mock_model
+
+    # Mock torchaudio.save to write fake WAV bytes
+    torchaudio_mock = sys.modules["torchaudio"]
+
+    def mock_torchaudio_save(buf, wav, sr, format=None):
+        buf.write(b"RIFF" + b"\x00" * 100)
+
+    torchaudio_mock.save = mock_torchaudio_save
 
     # Mock _wav_to_ogg to return fake OGG bytes
     fake_ogg = b"OggS" + b"\x00" * 100
     monkeypatch.setattr(vs, "_wav_to_ogg", lambda wav_bytes, speed=1.0: fake_ogg)
 
-    # Mock soundfile.write to produce valid WAV
-    def mock_sf_write(file, data, samplerate, format=None):
-        """Write minimal data to the buffer."""
-        if hasattr(file, 'write'):
-            file.write(b"RIFF" + b"\x00" * 100)
-
-    monkeypatch.setattr(vs.sf, "write", mock_sf_write)
-
-    # Mock np.array to return something
-    np_mock = sys.modules["numpy"]
-    np_mock.array.return_value = [0.0] * 16000
+    # Mock _resolve_voice_ref to return a path
+    monkeypatch.setattr(vs, "_resolve_voice_ref", lambda vid, vdir=None: "/fake/ref.wav")
 
     resp = client.post("/tts", json={"text": "Hello Daniel"})
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "audio/ogg"
 
 
-def test_tts_endpoint_503_when_not_ready(client) -> None:
-    """POST /tts must return 503 when XTTS model is not loaded."""
+def test_tts_endpoint_accepts_voice_id(client, monkeypatch) -> None:
+    """POST /tts with voice_id parameter must return 200."""
     import voice.voice_server as vs
-    vs._xtts_model = None
+
+    mock_model = MagicMock()
+    mock_model.generate.return_value = MagicMock()
+    mock_model.sr = 24000
+    vs._chatterbox_model = mock_model
+
+    torchaudio_mock = sys.modules["torchaudio"]
+
+    def mock_torchaudio_save(buf, wav, sr, format=None):
+        buf.write(b"RIFF" + b"\x00" * 100)
+
+    torchaudio_mock.save = mock_torchaudio_save
+
+    fake_ogg = b"OggS" + b"\x00" * 100
+    monkeypatch.setattr(vs, "_wav_to_ogg", lambda wav_bytes, speed=1.0: fake_ogg)
+    monkeypatch.setattr(vs, "_resolve_voice_ref", lambda vid, vdir=None: "/fake/ada.wav")
+
+    resp = client.post("/tts", json={"text": "Hello", "voice_id": "ada"})
+    assert resp.status_code == 200
+
+
+def test_tts_endpoint_503_when_not_ready(client) -> None:
+    """POST /tts must return 503 when Chatterbox model is not loaded."""
+    import voice.voice_server as vs
+    vs._chatterbox_model = None
 
     resp = client.post("/tts", json={"text": "Hello"})
     assert resp.status_code == 503

--- a/tests/unit/test_voice_docker_config.py
+++ b/tests/unit/test_voice_docker_config.py
@@ -1,7 +1,9 @@
-"""Tests for docker-compose.yml voice config.
+"""Tests for docker-compose.yml voice server configuration.
 
 Verifies that:
-- XTTS_REF_AUDIO and XTTS_LANGUAGE env vars are present in docker-compose.yml
+- VOICE_REF_DIR env var is present
+- WHISPER_MODEL env var is present
+- voice-server service uses Dockerfile.voice
 """
 
 import os
@@ -12,19 +14,23 @@ DOCKER_COMPOSE_PATH = os.path.join(
     os.path.dirname(__file__), "..", "..", "docker-compose.yml"
 )
 
+
 @pytest.fixture
 def docker_compose_content() -> str:
     with open(DOCKER_COMPOSE_PATH) as f:
         return f.read()
 
 
-def test_docker_compose_has_xtts_ref_audio(docker_compose_content: str) -> None:
-    """docker-compose.yml must define XTTS_REF_AUDIO for voice-server."""
-    assert "XTTS_REF_AUDIO" in docker_compose_content
+def test_docker_compose_has_voice_ref_dir(docker_compose_content: str) -> None:
+    """docker-compose.yml must define VOICE_REF_DIR for voice-server."""
+    assert "VOICE_REF_DIR" in docker_compose_content
 
 
-def test_docker_compose_has_xtts_language(docker_compose_content: str) -> None:
-    """docker-compose.yml must define XTTS_LANGUAGE for voice-server."""
-    assert "XTTS_LANGUAGE" in docker_compose_content
+def test_docker_compose_has_whisper_model(docker_compose_content: str) -> None:
+    """docker-compose.yml must define WHISPER_MODEL for voice-server."""
+    assert "WHISPER_MODEL" in docker_compose_content
 
 
+def test_voice_server_uses_dockerfile_voice(docker_compose_content: str) -> None:
+    """voice-server service must use Dockerfile.voice, not the default Dockerfile."""
+    assert "Dockerfile.voice" in docker_compose_content

--- a/tests/unit/test_voice_dockerfile.py
+++ b/tests/unit/test_voice_dockerfile.py
@@ -1,0 +1,48 @@
+"""Tests for Dockerfile.voice build configuration.
+
+Verifies that the Dockerfile.voice correctly configures the Chatterbox
+TTS build environment including setuptools pin, --no-deps install, and
+build-time import validation.
+"""
+
+import os
+
+import pytest
+
+DOCKERFILE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "Dockerfile.voice"
+)
+
+
+@pytest.fixture
+def dockerfile_content() -> str:
+    with open(DOCKERFILE_PATH) as f:
+        return f.read()
+
+
+def test_dockerfile_has_setuptools_pin(dockerfile_content: str) -> None:
+    """Dockerfile.voice must pin setuptools<81 for resemble-perth compatibility."""
+    assert "setuptools<81" in dockerfile_content, (
+        "Dockerfile.voice must contain 'setuptools<81' in a pip install line"
+    )
+
+
+def test_dockerfile_has_chatterbox_no_deps(dockerfile_content: str) -> None:
+    """Dockerfile.voice must install chatterbox-tts with --no-deps."""
+    assert "--no-deps chatterbox-tts" in dockerfile_content, (
+        "Dockerfile.voice must install chatterbox-tts with --no-deps"
+    )
+
+
+def test_dockerfile_validation_imports_chatterbox(dockerfile_content: str) -> None:
+    """Build-time validation must import ChatterboxTTS to catch broken deps early."""
+    assert "from chatterbox.tts import ChatterboxTTS" in dockerfile_content, (
+        "Dockerfile.voice build validation must import ChatterboxTTS"
+    )
+
+
+def test_dockerfile_validation_imports_whisper(dockerfile_content: str) -> None:
+    """Build-time validation must import WhisperModel to verify STT deps."""
+    assert "from faster_whisper import WhisperModel" in dockerfile_content, (
+        "Dockerfile.voice build validation must import WhisperModel"
+    )

--- a/tests/unit/test_voice_id_resolution.py
+++ b/tests/unit/test_voice_id_resolution.py
@@ -1,9 +1,9 @@
-"""Tests for Chatterbox TTS synthesis logic.
+"""Tests for voice ID resolution logic.
 
 Verifies that:
-- _synthesize calls model.generate with correct args when model is loaded
-- _synthesize raises RuntimeError when model is not loaded
-- _synthesize works with and without a reference audio path
+- _resolve_voice_ref returns the correct WAV path when the file exists
+- _resolve_voice_ref falls back to default.wav when the requested voice doesn't exist
+- _resolve_voice_ref("default") maps to default.wav
 """
 
 import sys
@@ -26,28 +26,20 @@ _NEED_PYDANTIC_MOCK = not _can_import("pydantic")
 @pytest.fixture(autouse=True)
 def _mock_voice_server_deps(monkeypatch):
     """Mock heavy deps so voice_server can be imported without GPU libs."""
-    # Mock numpy
     np_mock = MagicMock()
     np_mock.float32 = "float32"
     np_mock.ndarray = type("ndarray", (), {})
     np_mock.array = MagicMock(side_effect=lambda x, dtype=None: x)
     monkeypatch.setitem(sys.modules, "numpy", np_mock)
 
-    # Mock torch
     torch_mock = MagicMock()
     torch_mock.cuda.is_available.return_value = False
     monkeypatch.setitem(sys.modules, "torch", torch_mock)
 
-    # Mock torchaudio
     monkeypatch.setitem(sys.modules, "torchaudio", MagicMock())
-
-    # Mock faster_whisper
     monkeypatch.setitem(sys.modules, "faster_whisper", MagicMock())
-
-    # Mock soundfile
     monkeypatch.setitem(sys.modules, "soundfile", MagicMock())
 
-    # Mock chatterbox.tts
     chatterbox_mod = MagicMock()
     monkeypatch.setitem(sys.modules, "chatterbox", chatterbox_mod)
     monkeypatch.setitem(sys.modules, "chatterbox.tts", chatterbox_mod.tts)
@@ -63,12 +55,10 @@ def _mock_voice_server_deps(monkeypatch):
         monkeypatch.setitem(sys.modules, "fastapi", fastapi_mock)
         monkeypatch.setitem(sys.modules, "fastapi.responses", MagicMock())
 
-    # Remove cached voice_server module to force reimport with mocks
     for mod_name in list(sys.modules.keys()):
         if "voice_server" in mod_name or "voice.voice_server" in mod_name:
             del sys.modules[mod_name]
 
-    # Patch _check_gpu_early before import
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
 
 
@@ -82,41 +72,44 @@ def _import_voice_server():
         return vs
 
 
-def test_synthesize_calls_chatterbox_generate() -> None:
-    """When model is loaded and ref audio path is given, _synthesize calls model.generate."""
+def test_resolve_voice_id_existing_file(tmp_path) -> None:
+    """_resolve_voice_ref returns the path when the requested voice file exists."""
     vs = _import_voice_server()
 
-    mock_model = MagicMock()
-    mock_model.generate.return_value = MagicMock()  # tensor
-    vs._chatterbox_model = mock_model
+    # Create a fake voice file
+    ada_wav = tmp_path / "ada.wav"
+    ada_wav.write_bytes(b"RIFF" + b"\x00" * 100)
 
-    ref_path = "/usr/src/app/voice_ref/ada.wav"
-    vs._synthesize("Hello Daniel", ref_path)
-
-    mock_model.generate.assert_called_once_with(
-        "Hello Daniel", audio_prompt_path=ref_path
-    )
+    result = vs._resolve_voice_ref("ada", str(tmp_path))
+    assert result == str(ada_wav)
 
 
-def test_synthesize_raises_when_model_not_loaded() -> None:
-    """_synthesize must raise RuntimeError when TTS model is not loaded."""
-    vs = _import_voice_server()
-    vs._chatterbox_model = None
-
-    with pytest.raises(RuntimeError, match="TTS model not loaded"):
-        vs._synthesize("test text")
-
-
-def test_synthesize_without_ref_path() -> None:
-    """When ref_path is None, model.generate is called with audio_prompt_path=None."""
+def test_resolve_voice_id_fallback_to_default(tmp_path) -> None:
+    """_resolve_voice_ref falls back to default.wav when the requested voice doesn't exist."""
     vs = _import_voice_server()
 
-    mock_model = MagicMock()
-    mock_model.generate.return_value = MagicMock()
-    vs._chatterbox_model = mock_model
+    # Only create default.wav, not the requested voice
+    default_wav = tmp_path / "default.wav"
+    default_wav.write_bytes(b"RIFF" + b"\x00" * 100)
 
-    vs._synthesize("Hello world", None)
+    result = vs._resolve_voice_ref("nonexistent", str(tmp_path))
+    assert result == str(default_wav)
 
-    mock_model.generate.assert_called_once_with(
-        "Hello world", audio_prompt_path=None
-    )
+
+def test_resolve_voice_id_default_maps_to_default_wav(tmp_path) -> None:
+    """_resolve_voice_ref("default") returns default.wav."""
+    vs = _import_voice_server()
+
+    default_wav = tmp_path / "default.wav"
+    default_wav.write_bytes(b"RIFF" + b"\x00" * 100)
+
+    result = vs._resolve_voice_ref("default", str(tmp_path))
+    assert result == str(default_wav)
+
+
+def test_resolve_voice_id_returns_none_when_nothing_exists(tmp_path) -> None:
+    """_resolve_voice_ref returns None when neither the voice nor default exists."""
+    vs = _import_voice_server()
+
+    result = vs._resolve_voice_ref("nonexistent", str(tmp_path))
+    assert result is None

--- a/tests/unit/test_voice_requirements.py
+++ b/tests/unit/test_voice_requirements.py
@@ -1,36 +1,68 @@
-"""Tests for requirements.txt voice/TTS dependencies.
+"""Tests for voice server requirements dependencies.
 
 Verifies that:
-- Coqui TTS package is present
-- Core voice deps (whisper, soundfile, numpy, torch) remain
+- Chatterbox dependencies are present in requirements.voice.txt
+- Core voice deps (whisper, soundfile, numpy, torch, fastapi, uvicorn) are present
+- Main requirements.txt does not contain voice/TTS-specific deps
 """
 
 import os
 
 import pytest
 
-REQUIREMENTS_PATH = os.path.join(
+REQUIREMENTS_VOICE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "requirements.voice.txt"
+)
+REQUIREMENTS_MAIN_PATH = os.path.join(
     os.path.dirname(__file__), "..", "..", "requirements.txt"
 )
 
 
 @pytest.fixture
-def requirements_content() -> str:
-    with open(REQUIREMENTS_PATH) as f:
+def voice_requirements_content() -> str:
+    with open(REQUIREMENTS_VOICE_PATH) as f:
         return f.read()
 
 
-def test_tts_coqui_in_requirements(requirements_content: str) -> None:
-    """requirements.txt must contain the Coqui TTS package."""
-    lines = [line.strip().lower() for line in requirements_content.splitlines()]
-    assert any(
-        line.startswith("tts") and not line.startswith("tts_") for line in lines
-    ), "requirements.txt must contain 'TTS' (Coqui) package"
+@pytest.fixture
+def main_requirements_content() -> str:
+    with open(REQUIREMENTS_MAIN_PATH) as f:
+        return f.read()
 
 
-def test_core_voice_deps_present(requirements_content: str) -> None:
-    """Core voice deps must remain in requirements.txt."""
-    required = ["faster-whisper", "soundfile", "numpy", "torch"]
-    lower = requirements_content.lower()
+def test_chatterbox_deps_in_requirements(voice_requirements_content: str) -> None:
+    """requirements.voice.txt must contain Chatterbox-specific dependencies."""
+    lower = voice_requirements_content.lower()
+    required_deps = [
+        "torch==2.6.0",
+        "torchaudio==2.6.0",
+        "transformers==4.46.3",
+        "resemble-perth",
+        "conformer",
+        "s3tokenizer",
+        "diffusers",
+    ]
+    for dep in required_deps:
+        assert dep.lower() in lower, f"Chatterbox dep '{dep}' missing from requirements.voice.txt"
+
+
+def test_core_voice_deps_present(voice_requirements_content: str) -> None:
+    """Core voice deps must be present in requirements.voice.txt."""
+    lower = voice_requirements_content.lower()
+    required = ["faster-whisper", "soundfile", "numpy", "torch", "fastapi", "uvicorn"]
     for dep in required:
-        assert dep in lower, f"Core dep '{dep}' missing from requirements.txt"
+        assert dep in lower, f"Core dep '{dep}' missing from requirements.voice.txt"
+
+
+def test_main_requirements_no_voice_deps(main_requirements_content: str) -> None:
+    """Main requirements.txt must not contain voice/TTS-specific deps.
+
+    Voice deps belong only in requirements.voice.txt (used by Dockerfile.voice).
+    The main server image does not need torch or TTS libraries.
+    """
+    lower = main_requirements_content.lower()
+    voice_only_deps = ["torch==", "torchaudio==", "tts>=", "faster-whisper", "soundfile"]
+    for dep in voice_only_deps:
+        assert dep.lower() not in lower, (
+            f"Voice-only dep '{dep}' should not be in main requirements.txt"
+        )

--- a/tests/unit/test_voice_server_config.py
+++ b/tests/unit/test_voice_server_config.py
@@ -1,12 +1,12 @@
 """Tests for voice_server.py configuration.
 
 Verifies that:
-- XTTS env var defaults are correct
-- TTSRequest schema is correct
+- VOICE_REF_DIR env var has the correct default
+- TTSRequest schema has the expected fields (voice_id, text, speed)
 """
 
+import ast
 import os
-import re
 
 import pytest
 
@@ -21,40 +21,46 @@ def voice_server_source() -> str:
         return f.read()
 
 
-def test_xtts_env_defaults(voice_server_source: str) -> None:
-    """Default XTTS_REF_AUDIO and XTTS_LANGUAGE must be set correctly."""
-    assert "/usr/src/app/voice_ref/hive_mind_voice.wav" in voice_server_source, (
-        "Default XTTS_REF_AUDIO path not found"
+def test_voice_ref_dir_env_default(voice_server_source: str) -> None:
+    """voice_server.py must read VOICE_REF_DIR env var with default /usr/src/app/voice_ref."""
+    assert "VOICE_REF_DIR" in voice_server_source, "VOICE_REF_DIR env var not found"
+    assert "/usr/src/app/voice_ref" in voice_server_source, (
+        "Default VOICE_REF_DIR path not found"
     )
-    assert 'XTTS_LANGUAGE' in voice_server_source, "XTTS_LANGUAGE env var not found"
-    # Check the default language value is 'en'
-    assert re.search(
-        r'XTTS_LANGUAGE.*"en"', voice_server_source
-    ), "Default XTTS_LANGUAGE must be 'en'"
 
 
-def test_tts_request_schema_unchanged() -> None:
-    """TTSRequest must have text (str), voice (str, default 'default'), speed (float, default 0.9)."""
-    # We need to import TTSRequest without triggering the full module startup.
-    # Read the source and exec just the model definition.
-    import ast
+def test_tts_request_has_voice_id() -> None:
+    """TTSRequest must have a voice_id field (str type)."""
     with open(VOICE_SERVER_PATH) as f:
         source = f.read()
 
     tree = ast.parse(source)
-    # Find the TTSRequest class
-    found = False
     for node in ast.walk(tree):
         if isinstance(node, ast.ClassDef) and node.name == "TTSRequest":
-            found = True
-            # Check it has the expected fields by name
+            field_names = []
+            for item in node.body:
+                if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
+                    field_names.append(item.target.id)
+            assert "voice_id" in field_names, "TTSRequest missing 'voice_id' field"
+            return
+
+    pytest.fail("TTSRequest class not found in voice_server.py")
+
+
+def test_tts_request_has_text_and_speed() -> None:
+    """TTSRequest must have text and speed fields."""
+    with open(VOICE_SERVER_PATH) as f:
+        source = f.read()
+
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == "TTSRequest":
             field_names = []
             for item in node.body:
                 if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name):
                     field_names.append(item.target.id)
             assert "text" in field_names, "TTSRequest missing 'text' field"
-            assert "voice" in field_names, "TTSRequest missing 'voice' field"
             assert "speed" in field_names, "TTSRequest missing 'speed' field"
-            break
+            return
 
-    assert found, "TTSRequest class not found in voice_server.py"
+    pytest.fail("TTSRequest class not found in voice_server.py")

--- a/voice/voice_server.py
+++ b/voice/voice_server.py
@@ -1,9 +1,10 @@
 """
 Hive Mind -- Voice Server.
 
-Provides STT (faster-whisper) and TTS (XTTS v2, Coqui) over HTTP.
-XTTS v2 supports zero-shot voice cloning from a reference WAV clip.
-Falls back to a stock speaker if no reference audio is available.
+Provides STT (faster-whisper) and TTS (Chatterbox) over HTTP.
+Chatterbox supports zero-shot voice cloning from a reference WAV clip.
+Voice selection via voice_id parameter (maps to voice_ref/{voice_id}.wav).
+Falls back to default.wav if the requested voice file does not exist.
 Auto-detects CUDA; falls back to CPU gracefully.
 """
 
@@ -42,9 +43,8 @@ def _check_gpu_early() -> bool:
 
 _GPU_OK = _check_gpu_early()
 
-import numpy as np  # noqa: E402
-import soundfile as sf  # noqa: E402
 import torch  # noqa: E402
+import torchaudio  # noqa: E402
 from fastapi import FastAPI, HTTPException, UploadFile  # noqa: E402
 from fastapi.responses import Response  # noqa: E402
 from pydantic import BaseModel  # noqa: E402
@@ -55,12 +55,29 @@ app = FastAPI(title="Hive Mind Voice Server")
 
 _DEVICE = "cuda" if _GPU_OK and torch.cuda.is_available() else "cpu"
 _WHISPER_MODEL = os.getenv("WHISPER_MODEL", "medium")
-_XTTS_REF_AUDIO = os.getenv("XTTS_REF_AUDIO", "/usr/src/app/voice_ref/hive_mind_voice.wav")
-_XTTS_LANGUAGE = os.getenv("XTTS_LANGUAGE", "en")
+_VOICE_REF_DIR = os.getenv("VOICE_REF_DIR", "/usr/src/app/voice_ref")
 
 _whisper = None
-_xtts_model = None
-_use_voice_cloning = False
+_chatterbox_model = None
+
+
+# ---------------------------------------------------------------------------
+# Voice reference resolution
+# ---------------------------------------------------------------------------
+def _resolve_voice_ref(voice_id: str, voice_ref_dir: str | None = None) -> str | None:
+    """Resolve a voice_id to the corresponding WAV file path.
+
+    Returns the path to voice_ref/{voice_id}.wav if it exists,
+    falls back to voice_ref/default.wav, or returns None if neither exists.
+    """
+    ref_dir = voice_ref_dir or _VOICE_REF_DIR
+    path = os.path.join(ref_dir, f"{voice_id}.wav")
+    if os.path.exists(path):
+        return path
+    fallback = os.path.join(ref_dir, "default.wav")
+    if os.path.exists(fallback):
+        return fallback
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -68,44 +85,41 @@ _use_voice_cloning = False
 # ---------------------------------------------------------------------------
 @app.on_event("startup")
 async def startup():
-    global _whisper, _xtts_model, _use_voice_cloning
+    global _whisper, _chatterbox_model
 
-    log.info("Voice server starting on device: %s | TTS engine: xtts_v2", _DEVICE)
+    log.info("Voice server starting on device: %s | TTS engine: chatterbox", _DEVICE)
 
     from faster_whisper import WhisperModel
     compute_type = "float16" if _DEVICE == "cuda" else "int8"
     log.info("Loading faster-whisper %s (%s)...", _WHISPER_MODEL, compute_type)
     _whisper = WhisperModel(_WHISPER_MODEL, device=_DEVICE, compute_type=compute_type)
 
-    from TTS.api import TTS as CoquiTTS
-    log.info("Loading XTTS v2 model...")
-    _xtts_model = CoquiTTS(model_name="tts_models/multilingual/multi-dataset/xtts_v2").to(_DEVICE)
+    from chatterbox.tts import ChatterboxTTS
+    log.info("Loading Chatterbox TTS...")
+    _chatterbox_model = ChatterboxTTS.from_pretrained(device=_DEVICE)
 
-    _use_voice_cloning = os.path.exists(_XTTS_REF_AUDIO)
-    ref_info = _XTTS_REF_AUDIO if _use_voice_cloning else "no reference (stock voice: Claribel Dervla)"
-    log.info("Voice server ready. TTS: XTTS v2 | voice cloning: %s | ref: %s", _use_voice_cloning, ref_info)
+    log.info(
+        "Voice server ready. TTS: Chatterbox | ref dir: %s",
+        _VOICE_REF_DIR,
+    )
 
 
 # ---------------------------------------------------------------------------
 # TTS synthesis helper
 # ---------------------------------------------------------------------------
-def _synthesize(text: str) -> np.ndarray:
-    """Synthesize text to a numpy audio array using XTTS v2."""
-    if _xtts_model is None:
+def _synthesize(text: str, ref_path: str | None = None):
+    """Synthesize text to a WAV tensor using Chatterbox.
+
+    Args:
+        text: The text to synthesize.
+        ref_path: Optional path to a reference WAV for voice cloning.
+
+    Returns:
+        A torch tensor containing the audio waveform.
+    """
+    if _chatterbox_model is None:
         raise RuntimeError("TTS model not loaded")
-    if _use_voice_cloning:
-        audio = _xtts_model.tts_with_vc(
-            text=text,
-            speaker_wav=_XTTS_REF_AUDIO,
-            language=_XTTS_LANGUAGE,
-        )
-    else:
-        audio = _xtts_model.tts(
-            text=text,
-            speaker="Claribel Dervla",
-            language=_XTTS_LANGUAGE,
-        )
-    return np.array(audio, dtype=np.float32)
+    return _chatterbox_model.generate(text, audio_prompt_path=ref_path)
 
 
 # ---------------------------------------------------------------------------
@@ -172,23 +186,24 @@ async def stt(file: UploadFile):
 # ---------------------------------------------------------------------------
 class TTSRequest(BaseModel):
     text: str
-    voice: str = "default"
+    voice_id: str = "default"
     speed: float = 0.9
 
 
 @app.post("/tts")
 async def tts(req: TTSRequest):
     """Synthesise text to OGG/Opus audio."""
-    if _xtts_model is None:
+    if _chatterbox_model is None:
         raise HTTPException(status_code=503, detail="TTS not ready")
 
-    audio_array = _synthesize(req.text)
+    ref_path = _resolve_voice_ref(req.voice_id)
+    wav = _synthesize(req.text, ref_path)
 
     wav_buf = io.BytesIO()
-    sf.write(wav_buf, audio_array, 24000, format="WAV")
+    torchaudio.save(wav_buf, wav, _chatterbox_model.sr, format="WAV")
     ogg_bytes = _wav_to_ogg(wav_buf.getvalue(), speed=req.speed)
 
-    log.info("TTS (XTTS v2): %d chars -> %d bytes OGG", len(req.text), len(ogg_bytes))
+    log.info("TTS (Chatterbox): %d chars -> %d bytes OGG", len(req.text), len(ogg_bytes))
     return Response(content=ogg_bytes, media_type="audio/ogg")
 
 
@@ -199,10 +214,9 @@ async def tts(req: TTSRequest):
 async def health():
     return {
         "stt": "ready" if _whisper else "loading",
-        "tts": "ready" if _xtts_model else "loading",
-        "tts_engine": "xtts_v2",
-        "ref_audio": _XTTS_REF_AUDIO,
-        "voice_cloning": _use_voice_cloning,
+        "tts": "ready" if _chatterbox_model else "loading",
+        "tts_engine": "chatterbox",
+        "voice_ref_dir": _VOICE_REF_DIR,
         "device": _DEVICE,
         "whisper_model": _WHISPER_MODEL,
     }


### PR DESCRIPTION
## Summary
- Replaces XTTS v2 (Coqui) with Chatterbox (ResembleAI) as the TTS engine
- Adds build-time import validation so missing deps fail at build, not runtime
- Adds `voice_id` parameter to `/tts` endpoint for per-bot voice references
- Renames voice reference to `voice_ref/ada.wav` with `default.wav` symlink
- Adds `specs/containers.md` — full container reference + migration history + gotchas

## Test plan
- [x] `docker compose up -d --build voice-server` succeeds
- [x] `/health` returns `tts_engine: chatterbox`
- [x] Telegram test voice message sent and confirmed audible
- [x] STT confirmed working (transcribed voice correctly)
- [x] Build-time validation passes (`Voice deps OK`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)