### PR TITLE
fix: increase notify TTS timeout to 120s

### DIFF
--- a/tools/stateless/notify/notify.py
+++ b/tools/stateless/notify/notify.py
@@ -147,7 +147,7 @@ def cmd_voice(args: argparse.Namespace) -> int:
             return 1
 
         tts_resp = httpx.post(
-            f"{voice_url}/tts", json={"text": args.message}, timeout=30,
+            f"{voice_url}/tts", json={"text": args.message}, timeout=120,
         )
         if tts_resp.status_code != 200:
             print(json.dumps({"success": False, "error": f"TTS failed: {tts_resp.status_code}"}))


### PR DESCRIPTION
## Summary
- Increases TTS request timeout in the notify tool from 30s to 120s
- Long briefing texts (1pm, 7am) take 60-90s to synthesise via Chatterbox — the 30s timeout was causing voice delivery failures

## Test plan
- [x] On-demand 1pm briefing voice note delivered successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)