### PR TITLE
fix: drain stale CLI stdout to prevent (No response)

### DIFF
--- a/core/sessions.py
+++ b/core/sessions.py
@@ -210,6 +210,7 @@ class SessionManager:
         self._db: aiosqlite.Connection | None = None
         self._procs: dict[str, Any] = {}  # Process (Ada/CLI) or dict (Nagatha/SDK)
         self._mind_ids: dict[str, str] = {}  # session_id -> mind_id
+        self._cli_clean: dict[str, bool] = {}  # True = last CLI read completed
         self._locks: dict[str, asyncio.Lock] = {}
         self._reaper_task: asyncio.Task | None = None
         self._guard_task: asyncio.Task | None = None
@@ -474,6 +475,16 @@ class SessionManager:
                 # CLI path: stdin/stdout on the subprocess
                 proc = self._procs[session_id]
 
+                # Drain stale stdout before writing.  Two scenarios:
+                # (a) Post-result hook events (Stop hook / self-reflect) —
+                #     already buffered, drained in <100ms.
+                # (b) Previous stream interrupted (client disconnect) —
+                #     CLI may still be producing output, need longer wait.
+                if not self._cli_clean.get(session_id, True):
+                    await self._drain_stale_stdout(session_id, proc, timeout=30.0)
+                else:
+                    await self._drain_stale_stdout(session_id, proc, timeout=0.1)
+
                 # Build message content — multimodal array when images present
                 if images:
                     message_content: str | list = [{"type": "text", "text": stamped_content}]
@@ -496,69 +507,87 @@ class SessionManager:
                 proc.stdin.write(msg.encode())
                 await proc.stdin.drain()
 
-                retried = False
-                while True:
-                    async for line in proc.stdout:
-                        line = line.decode().strip()
-                        if not line:
-                            continue
-                        try:
-                            event = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
+                cli_completed = False
+                try:
+                    retried = False
+                    while True:
+                        async for line in proc.stdout:
+                            line = line.decode().strip()
+                            if not line:
+                                continue
+                            try:
+                                event = json.loads(line)
+                            except json.JSONDecodeError:
+                                continue
 
-                        # Detect stale --resume (conversation lost after rebuild)
-                        if (
-                            not retried
-                            and event.get("type") == "result"
-                            and event.get("is_error")
-                            and any(
-                                "No conversation found" in e
-                                for e in event.get("errors", [])
-                            )
-                        ):
-                            log.warning(
-                                "Stale resume for session %s — clearing claude_sid "
-                                "and retrying",
-                                session_id,
-                            )
-                            retried = True
-                            await self._kill_process(session_id)
-                            await self._db.execute(
-                                "UPDATE sessions SET claude_sid = NULL WHERE id = ?",
-                                (session_id,),
-                            )
-                            await self._db.commit()
-                            await self._spawn(
-                                session_id, session["model"],
-                                autopilot=bool(session["autopilot"]),
-                                mind_id=mind_id,
-                            )
-                            proc = self._procs[session_id]
-                            proc.stdin.write(msg.encode())
-                            await proc.stdin.drain()
-                            break
-
-                        yield event
-
-                        now = time.time()
-                        await self._db.execute(
-                            "UPDATE sessions SET last_active = ? WHERE id = ?",
-                            (now, session_id),
-                        )
-
-                        if event.get("type") == "result":
-                            claude_sid = event.get("session_id")
-                            if claude_sid:
-                                await self._db.execute(
-                                    "UPDATE sessions SET claude_sid = ? WHERE id = ?",
-                                    (claude_sid, session_id),
+                            # Detect stale --resume (conversation lost after rebuild)
+                            if (
+                                not retried
+                                and event.get("type") == "result"
+                                and event.get("is_error")
+                                and any(
+                                    "No conversation found" in e
+                                    for e in event.get("errors", [])
                                 )
-                            await self._db.commit()
-                            return  # done — exit the generator
-                    else:
-                        # for-loop exhausted without break (EOF) — we're done
-                        return
+                            ):
+                                log.warning(
+                                    "Stale resume for session %s — clearing claude_sid "
+                                    "and retrying",
+                                    session_id,
+                                )
+                                retried = True
+                                await self._kill_process(session_id)
+                                await self._db.execute(
+                                    "UPDATE sessions SET claude_sid = NULL WHERE id = ?",
+                                    (session_id,),
+                                )
+                                await self._db.commit()
+                                await self._spawn(
+                                    session_id, session["model"],
+                                    autopilot=bool(session["autopilot"]),
+                                    mind_id=mind_id,
+                                )
+                                proc = self._procs[session_id]
+                                proc.stdin.write(msg.encode())
+                                await proc.stdin.drain()
+                                break
+
+                            # Process result bookkeeping BEFORE yield so
+                            # that if the caller never resumes us (client
+                            # disconnect after reading the result event),
+                            # the flags are already correct.
+                            is_result = event.get("type") == "result"
+                            if is_result:
+                                claude_sid = event.get("session_id")
+                                if claude_sid:
+                                    await self._db.execute(
+                                        "UPDATE sessions SET claude_sid = ? WHERE id = ?",
+                                        (claude_sid, session_id),
+                                    )
+                                await self._db.commit()
+                                cli_completed = True
+                                self._cli_clean[session_id] = True
+
+                            yield event
+
+                            now = time.time()
+                            await self._db.execute(
+                                "UPDATE sessions SET last_active = ? WHERE id = ?",
+                                (now, session_id),
+                            )
+
+                            if is_result:
+                                return  # done — exit the generator
+                        else:
+                            # for-loop exhausted without break (EOF) — we're done
+                            cli_completed = True
+                            self._cli_clean[session_id] = True
+                            return
+                finally:
+                    if not cli_completed:
+                        # Client disconnected mid-stream — mark dirty so
+                        # the next send_message drains before writing.
+                        self._cli_clean[session_id] = False
 
     # ------------------------------------------------------------------
     # Model switching
@@ -647,6 +676,49 @@ class SessionManager:
             "uptime_seconds": uptime,
             "status": "closed",
         }
+
+    # ------------------------------------------------------------------
+    # Stdout drain helper
+    # ------------------------------------------------------------------
+    async def _drain_stale_stdout(
+        self, session_id: str, proc: Any, timeout: float = 30.0,
+    ) -> None:
+        """Consume leftover stdout from a previously interrupted CLI response.
+
+        Called when the prior send_message generator was abandoned (client
+        disconnect).  Reads until the stale result event arrives or timeout.
+        """
+        if proc.stdout.at_eof():
+            return
+        drained = 0
+        while True:
+            try:
+                raw = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+                if not raw:
+                    break  # EOF
+                drained += 1
+                line = raw.decode().strip()
+                if not line:
+                    continue
+                try:
+                    ev = json.loads(line)
+                    if ev.get("type") == "result":
+                        # Preserve claude_sid from the stale result
+                        claude_sid = ev.get("session_id")
+                        if claude_sid:
+                            await self._db.execute(
+                                "UPDATE sessions SET claude_sid = ? WHERE id = ?",
+                                (claude_sid, session_id),
+                            )
+                            await self._db.commit()
+                        break
+                except json.JSONDecodeError:
+                    continue
+            except asyncio.TimeoutError:
+                break
+        if drained:
+            log.info("Drained %d stale stdout lines for session %s", drained, session_id)
+        self._cli_clean[session_id] = True
 
     # ------------------------------------------------------------------
     # Subprocess management

--- a/specs/multi-mind.md
+++ b/specs/multi-mind.md
@@ -37,7 +37,7 @@ Session Manager (sessions.py)  ← reads mind_id, looks up config
         ↓
   ┌──────────────────────────────────┐
   │  Ada         Nagatha     Skippy  │
-  │  CLI Claude  SDK Claude  Ollama  │
+  │  CLI Claude  Codex       Ollama  │
   │  own soul    own soul    own soul│
   │  own db      own db      own db  │
   └──────────────────────────────────┘
@@ -64,7 +64,7 @@ graph TD
     subgraph Pods ["🧠 Isolated Mind Pods"]
         direction LR
         ADA["Ada\n· own soul.md\n· own SQLite\n· own MCP config\n· CLI Claude"]
-        NAG["Nagatha\n· own soul.md\n· own SQLite\n· own MCP config\n· SDK Claude"]
+        NAG["Nagatha\n· own soul.md\n· own SQLite\n· own MCP config\n· Codex harness [codex]"]
         SKIP["Skippy\n· own soul.md\n· own SQLite\n· own MCP config\n· Ollama"]
     end
 
@@ -94,8 +94,8 @@ minds:
     db: data/ada.db
     mcp_config: .mcp.ada.json
   nagatha:
-    backend: sdk_claude
-    model: sonnet
+    backend: codex_cli
+    model: codex
     soul: souls/nagatha.md
     db: data/nagatha.db
     mcp_config: .mcp.nagatha.json
@@ -108,6 +108,9 @@ minds:
 ```
 
 Each mind is just a parameter set. No new classes. No new modules.
+
+[codex] Nagatha remains `mind_id="nagatha"`. We are replacing the backend implementation behind that
+mind, not renaming the mind itself.
 
 ---
 
@@ -130,7 +133,12 @@ mcp_cfg   = mind_cfg["mcp_config"]
 backend   = mind_cfg["backend"]
 ```
 
-Then spawns the subprocess with those values — same spawn logic as today, just parameterised.
+Then dispatches using those values. CLI-backed minds still spawn a subprocess. SDK-backed minds keep
+per-session client state and stream results through the same event bus.
+
+[codex] For Nagatha, the implementation should continue to live at `minds/nagatha/implementation.py`
+and preserve the existing `spawn(...)`, `send(...)`, and `kill(...)` contract used by
+`core/sessions.py`.
 
 ---
 
@@ -142,6 +150,43 @@ Each mind gets:
 - `.mcp.<name>.json` — its own MCP tool permissions (optional: restrict what each mind can see)
 
 Ada's soul is already written. The others are stubs until named and defined.
+
+### Phase 3.5 — Replace Nagatha's harness: sdk_claude → codex_cli
+
+Nagatha's backend is replaced with a Codex CLI subprocess — the same pattern Ada uses with
+`cli_claude`. No API key required; auth via OpenAI Pro account (same mechanism as Claude CLI).
+
+**Config** (`minds/nagatha/config.yaml`):
+```yaml
+backend: codex_cli
+model: codex
+```
+
+**Invocation**:
+```
+codex exec --json --dangerously-bypass-approvals-and-sandbox -
+```
+Prompt piped via stdin. JSONL events streamed to stdout.
+
+**`minds/nagatha/implementation.py`** — same three-function contract as Ada:
+
+| Function | Behaviour |
+|---|---|
+| `spawn(...)` | Start `codex exec --json ...` subprocess. Same lifecycle as Ada. |
+| `send(...)` | Write stamped message to stdin. Read JSONL from stdout. Map to `assistant`/`result` events. |
+| `kill(...)` | Terminate subprocess. Identical to Ada. |
+
+**JSONL event mapping**:
+
+| Codex event | Internal event |
+|---|---|
+| item type `message` (agent output) | `assistant` |
+| `turn.completed` | `result` |
+| `turn.failed` | error |
+
+**What does NOT change**: Nagatha's soul node, session history, MCP tool access, `mind_id`.
+
+**Remove**: all `sdk_claude` implementation code from `minds/nagatha/implementation.py`.
 
 ---
 
@@ -164,6 +209,7 @@ The orchestrator (a skill, not a daemon) handles delegation: it sends a message 
 3. MCP tool permissions are per-mind. A mind only has access to the tools its config grants.
 4. `mind_id` is set at session creation and never changes mid-session.
 5. The Session Manager is backend-agnostic — it dispatches, it does not reason about identity.
+6. [codex] Changing Nagatha's harness must not change her identity, soul file, or stored session history.
 
 ---
 
@@ -209,6 +255,12 @@ This separation means:
 - MCP tool implementations — shared tools work for any mind
 - The `Event → Specification → Tools` architecture pattern
 - Deployment — all minds run in the same container unless explicitly split out later
+
+[codex] OpenAI docs note: Codex-capable models are currently exposed through the API/SDK, and
+OpenAI recommends the Responses API for streaming semantics. Sources:
+
+- https://platform.openai.com/docs/guides/streaming-responses
+- https://developers.openai.com/api/docs/models/gpt-5.2-codex
 
 ---
 


### PR DESCRIPTION
## Summary
- Fixes intermittent `(No response)` bug where CLI stdout contained stale events from Stop hooks (soul_nudge/self-reflect) or interrupted streams
- Adds `_drain_stale_stdout()` helper that consumes leftover stdout before sending a new message
- Moves result bookkeeping before `yield` to handle generator suspend on client disconnect
- Updates `specs/multi-mind.md` with Codex backend details for Nagatha

## Test plan
- [x] Reproduced and fixed: abandon stream → next msg gets wrong response
- [x] Reproduced and fixed: soul_nudge fires → next msg gets (No response)
- [x] 7-turn test passes with correct responses, 1.7-3.7s per turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)