### PR TITLE
fix: predict soul_nudge to prevent stale self-reflect results

### DIFF
--- a/core/sessions.py
+++ b/core/sessions.py
@@ -566,7 +566,11 @@ class SessionManager:
                                     )
                                 await self._db.commit()
                                 cli_completed = True
-                                self._cli_clean[session_id] = True
+                                # Check if the Stop hook will trigger a
+                                # self-reflect turn AFTER this result.  If
+                                # so, mark dirty so the next message drains
+                                # the stale result before writing.
+                                self._cli_clean[session_id] = not self._stop_hook_will_nudge()
 
                             yield event
 
@@ -676,6 +680,25 @@ class SessionManager:
             "uptime_seconds": uptime,
             "status": "closed",
         }
+
+    # ------------------------------------------------------------------
+    # Stop hook prediction
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _stop_hook_will_nudge() -> bool:
+        """Check if the Stop hook (soul_nudge.sh) will trigger self-reflect.
+
+        The hook increments a counter on each turn and fires on every 5th.
+        We read the counter to predict whether a stale self-reflect result
+        will appear in stdout after this result event.
+        """
+        try:
+            with open("/tmp/claude_soul_turn_counter") as f:
+                count = int(f.read().strip())
+            # Hook already ran and incremented. Nudge fires when count % 5 == 0.
+            return count % 5 == 0
+        except Exception:
+            return False
 
     # ------------------------------------------------------------------
     # Stdout drain helper


### PR DESCRIPTION
## Summary
- Reads the soul_nudge counter file after each CLI result to predict whether the Stop hook will trigger self-reflect
- If yes, marks session dirty so the next message drains with 30s timeout (catches the stale result)
- Without this, the 0.1s fast drain misses self-reflect events that are still being produced
- 12-turn test passes: all responses correct, no latency regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)