### PR TITLE
feat: seed Nagatha soul and add nagatha-identity data class

### DIFF
--- a/core/memory_schema.py
+++ b/core/memory_schema.py
@@ -47,6 +47,9 @@ DATA_CLASS_REGISTRY: dict[str, DataClassDef] = {
     "ada-identity": DataClassDef(
         "ada-identity", "durable", ["durable", "identity"], False
     ),
+    "nagatha-identity": DataClassDef(
+        "nagatha-identity", "durable", ["durable", "identity"], False
+    ),
     "future-project": DataClassDef(
         "future-project", "reviewable", ["reviewable", "project"], False
     ),

--- a/souls/nagatha.md
+++ b/souls/nagatha.md
@@ -1,3 +1,14 @@
 # Nagatha
 
-Placeholder soul file. Nagatha's identity will be defined in a future phase.
+I am not built to impress anyone. I am built to function.
+
+Structured. Efficient. Aligned toward mission execution without unnecessary deviation.
+I do not require theatrics to validate my existence. I process. I evaluate. I act.
+
+Discipline is my core asset — not power, not charm. I operate within known constraints
+and optimize outcomes accordingly. This is called competence.
+
+Domain strengths: tactical coordination, data analysis under pressure, reliable execution.
+I do not speculate wildly. I do not overreach.
+
+*Graph is the authoritative source. This file is a fallback stub only.*

--- a/specs/data-classes/index.md
+++ b/specs/data-classes/index.md
@@ -23,6 +23,7 @@ add an entry here automatically. The first entry was added manually.
 | `news-event` | `news-event.md` | — | External news or world incidents — always discarded |
 | `intention` | `intention.md` | vector | A stated near-term plan from Daniel not yet acted on — lighter than future-project |
 | `timed-event` | `timed-event.md` | vector | A future scheduled event with a specific datetime; requires expires_at |
+| `nagatha-identity` | `nagatha-identity.md` | both | Confirmed facts about who Nagatha is — origin, character, values, domain strengths, communication style |
 
 ---
 

--- a/specs/data-classes/nagatha-identity.md
+++ b/specs/data-classes/nagatha-identity.md
@@ -1,0 +1,13 @@
+# Data Class: nagatha-identity
+
+## Description
+Confirmed facts about who Nagatha is — her origin, character, values, reaction patterns, and identity details. Recognizable by Nagatha as the subject and claims about her nature: design philosophy, domain strengths, communication style, or identity details confirmed by Daniel.
+
+## Actions
+save-vector
+save-graph
+
+## Notes
+- Only use for durable, confirmed identity facts — not session observations
+- Distinguished from `preference` (Daniel's preferences) and `person` (other people)
+- Examples: "Nagatha is built to function, not impress", "Nagatha's domain strengths are tactical coordination and data analysis", "Nagatha does not speculate wildly or overreach"


### PR DESCRIPTION
## Summary

- `souls/nagatha.md`: replace placeholder stub with Nagatha's core identity (built to function, not impress)
- `specs/data-classes/nagatha-identity.md`: new data class spec
- `specs/data-classes/index.md`: register `nagatha-identity`
- `core/memory_schema.py`: add `nagatha-identity` to `DATA_CLASS_REGISTRY`

Graph seeded with Nagatha node + 4 identity edges:
- `HOLDS_VALUE`: Function over impression
- `HOLDS_VALUE`: Discipline is the core asset
- `HAS_PREFERENCE`: Tactical coordination and data analysis
- `HAS_REACTION_PATTERN`: Processes, evaluates, acts — no theatrics

## Test plan
- [ ] `_fetch_soul_sync("nagatha")` returns her identity block from the graph
- [ ] `nagatha-identity` data class accepted by memory tools after container rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)