### PR TITLE
feat: implement HiveMind Telegram group chat bot

### DIFF
--- a/clients/hivemind_bot.py
+++ b/clients/hivemind_bot.py
@@ -1,17 +1,24 @@
 """
-Hive Mind Group Chat Discord Bot (skeleton).
+Hive Mind Group Chat Telegram Bot.
 
 Routes messages through group sessions for multi-mind conversations.
-Token not yet provisioned -- this is a structural skeleton only.
+Each mind's response is attributed by name in the chat.
 """
 
 import json
 import logging
 import os
-from typing import Optional
 
 import aiohttp
-import discord
+import keyring
+from telegram import Update
+from telegram.ext import (
+    ApplicationBuilder,
+    CommandHandler,
+    ContextTypes,
+    MessageHandler,
+    filters,
+)
 
 from config import config
 
@@ -19,138 +26,155 @@ logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
 )
-log = logging.getLogger("hive-mind-group-bot")
+log = logging.getLogger("hive-mind-hivemind-bot")
 
-# ---------------------------------------------------------------------------
-# Constants
-# ---------------------------------------------------------------------------
-DISCORD_MSG_LIMIT = 2000
-SERVER_URL = os.environ.get(
-    "HIVE_MIND_SERVER_URL", f"http://localhost:{config.server_port}"
-)
+SERVER_URL = os.environ.get("HIVE_MIND_SERVER_URL", f"http://localhost:{config.server_port}")
 
-# Group session state: channel_id -> group_session_id
+# chat_id -> group_session_id
 _active_group_sessions: dict[int, str] = {}
 
+http: aiohttp.ClientSession | None = None
 
-# ---------------------------------------------------------------------------
-# Auth helpers
-# ---------------------------------------------------------------------------
-def _get_bot_token() -> Optional[str]:
-    """Get bot token -- keyring first, env fallback."""
+
+def _get_bot_token() -> str | None:
     try:
-        import keyring
-        token = keyring.get_password("hive-mind", "HIVEMIND_DISCORD_TOKEN")
+        token = keyring.get_password("hive-mind", "HIVEMIND_TELEGRAM_BOT_TOKEN")
         if token:
             return token
     except Exception:
         pass
-    return os.getenv("HIVEMIND_DISCORD_TOKEN")
+    return os.getenv("HIVEMIND_TELEGRAM_BOT_TOKEN")
 
 
 def _is_allowed_user(user_id: int) -> bool:
-    """Fail-closed: empty allowlist = no access."""
-    return user_id in config.discord_allowed_users
+    return user_id in config.telegram_allowed_users
+
+
+async def _ensure_http() -> aiohttp.ClientSession:
+    global http
+    if http is None or http.closed:
+        http = aiohttp.ClientSession()
+    return http
+
+
+async def _get_or_create_group_session(chat_id: int) -> str:
+    if chat_id in _active_group_sessions:
+        return _active_group_sessions[chat_id]
+    session = await _ensure_http()
+    async with session.post(
+        f"{SERVER_URL}/group-sessions",
+        json={"moderator_mind_id": "ada"},
+    ) as resp:
+        data = await resp.json()
+        group_session_id = data["id"]
+        _active_group_sessions[chat_id] = group_session_id
+        log.info("Created group session %s for chat %d", group_session_id, chat_id)
+        return group_session_id
+
+
+async def _send_group_message(chat_id: int, content: str) -> list[tuple[str, str]]:
+    """Send message to group session. Returns list of (mind_id, text) tuples."""
+    group_session_id = await _get_or_create_group_session(chat_id)
+    session = await _ensure_http()
+    responses: list[tuple[str, str]] = []
+
+    timeout = aiohttp.ClientTimeout(total=0, sock_read=0)
+    async with session.post(
+        f"{SERVER_URL}/group-sessions/{group_session_id}/message",
+        json={"content": content},
+        timeout=timeout,
+    ) as resp:
+        buf = ""
+        async for chunk in resp.content.iter_any():
+            buf += chunk.decode()
+            while "\n" in buf:
+                raw_line, buf = buf.split("\n", 1)
+                raw_line = raw_line.strip()
+                if not raw_line or not raw_line.startswith("data: "):
+                    continue
+                try:
+                    event = json.loads(raw_line.removeprefix("data: "))
+                except json.JSONDecodeError:
+                    continue
+                if event.get("type") == "assistant":
+                    mind_id = event.get("mind_id", "unknown")
+                    msg = event.get("message", {})
+                    content_blocks = msg.get("content", [])
+                    if isinstance(content_blocks, list):
+                        text = " ".join(
+                            b.get("text", "") for b in content_blocks if b.get("type") == "text"
+                        ).strip()
+                    else:
+                        text = str(content_blocks)
+                    if text:
+                        responses.append((mind_id, text))
+
+    return responses
 
 
 # ---------------------------------------------------------------------------
-# Group session management
+# Handlers
 # ---------------------------------------------------------------------------
-class HiveMindGroupBot:
-    """Bot skeleton for multi-mind group conversations."""
 
-    def __init__(self) -> None:
-        self.http: Optional[aiohttp.ClientSession] = None
+async def cmd_start(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    if not _is_allowed_user(update.effective_user.id):
+        return
+    await update.message.reply_text("Hive Mind group chat. Send a message to hear from the collective.")
 
-    async def _ensure_http(self) -> aiohttp.ClientSession:
-        if self.http is None or self.http.closed:
-            self.http = aiohttp.ClientSession()
-        return self.http
 
-    async def create_group_session(
-        self, channel_id: int, moderator: str = "ada"
-    ) -> str:
-        """Create a new group session via the gateway."""
-        http = await self._ensure_http()
-        async with http.post(
-            f"{SERVER_URL}/group-sessions",
-            json={"moderator_mind_id": moderator},
-        ) as resp:
-            data = await resp.json()
-            group_session_id = data["id"]
-            _active_group_sessions[channel_id] = group_session_id
-            log.info(
-                "Created group session %s for channel %d",
-                group_session_id, channel_id,
-            )
-            return group_session_id
+async def cmd_new(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    if not _is_allowed_user(update.effective_user.id):
+        return
+    chat_id = update.effective_chat.id
+    _active_group_sessions.pop(chat_id, None)
+    group_session_id = await _get_or_create_group_session(chat_id)
+    await update.message.reply_text(f"New group session started: {group_session_id[:8]}…")
 
-    async def send_group_message(
-        self, channel_id: int, content: str
-    ) -> list[str]:
-        """Send a message to the group session for this channel.
 
-        Returns a list of response text chunks with mind attribution.
-        """
-        group_session_id = _active_group_sessions.get(channel_id)
-        if not group_session_id:
-            group_session_id = await self.create_group_session(channel_id)
+async def handle_message(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    if not update.message or not update.message.text:
+        return
+    if not _is_allowed_user(update.effective_user.id):
+        return
 
-        http = await self._ensure_http()
-        chunks: list[str] = []
+    chat_id = update.effective_chat.id
+    content = update.message.text
 
-        sse_timeout = aiohttp.ClientTimeout(total=0, sock_read=0)
-        async with http.post(
-            f"{SERVER_URL}/group-sessions/{group_session_id}/message",
-            json={"content": content},
-            timeout=sse_timeout,
-        ) as resp:
-            buf = ""
-            async for chunk in resp.content.iter_any():
-                buf += chunk.decode()
-                while "\n" in buf:
-                    raw_line, buf = buf.split("\n", 1)
-                    raw_line = raw_line.strip()
-                    if not raw_line or not raw_line.startswith("data: "):
-                        continue
-                    try:
-                        event = json.loads(raw_line.removeprefix("data: "))
-                    except json.JSONDecodeError:
-                        continue
-                    if event.get("type") == "assistant":
-                        for block in event.get("message", {}).get("content", []):
-                            if block.get("type") == "text" and block.get("text"):
-                                chunks.append(block["text"])
-
-        return chunks
-
-    async def handle_new_command(self, channel_id: int) -> str:
-        """Handle /new -- create fresh group session."""
-        group_session_id = await self.create_group_session(channel_id)
-        return f"New group session created: {group_session_id}"
-
-    async def close(self) -> None:
-        """Clean up HTTP session."""
-        if self.http and not self.http.closed:
-            await self.http.close()
+    try:
+        responses = await _send_group_message(chat_id, content)
+        if not responses:
+            await update.message.reply_text("(no response from the hive)")
+            return
+        for mind_id, text in responses:
+            label = mind_id.capitalize()
+            await update.message.reply_text(f"**{label}:** {text}")
+    except Exception as exc:
+        log.exception("Error sending group message")
+        await update.message.reply_text(f"Error: {exc}")
 
 
 # ---------------------------------------------------------------------------
-# Discord bot setup (skeleton -- token not yet provisioned)
+# Entry point
 # ---------------------------------------------------------------------------
-def _build_bot() -> discord.Client:
-    """Build the Discord client. Token binding deferred."""
-    intents = discord.Intents.default()
-    intents.message_content = True
-    client = discord.Client(intents=intents)
-    return client
 
-
-# Entry point (will be wired when token is provisioned)
-if __name__ == "__main__":
+def main() -> None:
     token = _get_bot_token()
     if not token:
-        log.error("HIVEMIND_DISCORD_TOKEN not configured -- cannot start bot")
-    else:
-        bot = _build_bot()
-        bot.run(token)
+        log.error("HIVEMIND_TELEGRAM_BOT_TOKEN not configured — cannot start bot")
+        return
+
+    app = (
+        ApplicationBuilder()
+        .token(token)
+        .build()
+    )
+    app.add_handler(CommandHandler("start", cmd_start))
+    app.add_handler(CommandHandler("new", cmd_new))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+
+    log.info("HiveMind Telegram bot starting…")
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,6 +116,32 @@ services:
       - XDG_DATA_HOME=/home/hivemind/.claude/data
     command: ["/opt/venv/bin/python3", "-m", "clients.telegram_bot"]
 
+  hivemind-bot:
+    build: .
+    container_name: hive-mind-hivemind
+    working_dir: /usr/src/app
+    volumes:
+      - ${HOST_PROJECT_DIR:-.}:/usr/src/app
+      - ${HOST_CLAUDE_DIR:-~/.claude}:/home/hivemind/.claude
+    restart: unless-stopped
+    depends_on:
+      - server
+    networks:
+      - hivemind
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    read_only: true
+    tmpfs:
+      - /tmp
+    environment:
+      - HIVE_MIND_SERVER_URL=http://server:8420
+      - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
+      - PYTHONNOUSERSITE=1
+      - XDG_DATA_HOME=/home/hivemind/.claude/data
+    command: ["/opt/venv/bin/python3", "-m", "clients.hivemind_bot"]
+
   scheduler:
     build: .
     container_name: hive-mind-scheduler

--- a/specs/group-sessions-gateway.md
+++ b/specs/group-sessions-gateway.md
@@ -1,0 +1,66 @@
+# Group Sessions Gateway Endpoints
+
+## User Requirements
+
+The gateway needs three new endpoints to support group chat sessions where multiple minds respond to a single user message. Clients (Telegram HiveMind bot) use these endpoints exclusively — child sessions are managed internally and never addressed directly by clients.
+
+## User Acceptance Criteria
+
+- [ ] `POST /group-sessions` creates a group session and returns a session id
+- [ ] `POST /group-sessions` accepts optional `moderator_mind_id` (defaults to `ada`)
+- [ ] `GET /group-sessions/{id}` returns session metadata and full time-ordered unified transcript with mind attribution
+- [ ] `POST /group-sessions/{id}/message` routes the message to the moderator's child session only
+- [ ] `POST /group-sessions/{id}/message` returns an SSE stream of all mind responses as they complete
+- [ ] Each SSE event includes `mind_id` attribution
+- [ ] Existing `/sessions` endpoints are unchanged
+- [ ] Child sessions are not addressable by clients directly
+
+## Technical Specification
+
+### New SQLite tables
+
+```sql
+CREATE TABLE IF NOT EXISTS group_sessions (
+    id TEXT PRIMARY KEY,
+    moderator_mind_id TEXT NOT NULL DEFAULT 'ada',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    ended_at TIMESTAMP
+);
+
+-- sessions table gains one new column:
+ALTER TABLE sessions ADD COLUMN group_session_id TEXT REFERENCES group_sessions(id);
+```
+
+### Endpoints
+
+#### POST /group-sessions
+- Body: `{ "moderator_mind_id": "ada" }` (optional)
+- Action: Insert into `group_sessions`, spawn a child session for the moderator via existing `_spawn()` logic
+- Returns: `{ "id": "<group_session_id>", "moderator_mind_id": "ada" }`
+
+#### GET /group-sessions/{id}
+- Returns: group session metadata + all messages from child sessions tagged with this `group_session_id`, ordered by timestamp
+
+#### POST /group-sessions/{id}/message
+- Body: `{ "content": "..." }`
+- Routes ONLY to the moderator's child session (Ada runs `/moderate` skill)
+- Streams SSE events as child minds respond
+- Each event shape: `{ "mind_id": "nagatha", "type": "assistant", "message": {...} }`
+
+### Architecture
+
+The gateway routes to the moderator only. The moderator fans out via `forward_to_mind` MCP tool (Phase 4a). The gateway never performs independent fan-out.
+
+## Code References
+
+- `server.py` — add three new route handlers
+- `core/sessions.py` — add group session DB methods (`create_group_session`, `get_group_session`, `get_group_transcript`)
+- `data/sessions.db` — schema migration (new table + column)
+
+## Implementation Order
+
+1. Add `group_sessions` table and `group_session_id` column migration to `sessions.py`
+2. Add `create_group_session()` / `get_group_session()` / `get_group_transcript()` to `SessionManager`
+3. Add `POST /group-sessions` route to `server.py`
+4. Add `GET /group-sessions/{id}` route
+5. Add `POST /group-sessions/{id}/message` route (SSE, routes to moderator child session)


### PR DESCRIPTION
## Summary

- `clients/hivemind_bot.py`: rewrite from Discord skeleton to Telegram bot
  - Uses `HIVEMIND_TELEGRAM_BOT_TOKEN` from keyring (already stored)
  - `/start`, `/new` commands
  - Messages routed through `POST /group-sessions/{id}/message` (SSE)
  - Each mind's response attributed by name in chat
- `docker-compose.yml`: add `hivemind-bot` service (depends on `server` only)
- `specs/group-sessions-gateway.md`: group session gateway spec

## Test plan
- [ ] Merge and rebuild containers
- [ ] Message the bot and verify Ada responds
- [ ] Verify mind attribution shows in replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)