### PR TITLE
fix: remove Unknown prefix from HiveMind bot responses

### DIFF
--- a/clients/hivemind_bot.py
+++ b/clients/hivemind_bot.py
@@ -145,9 +145,8 @@ async def handle_message(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None
         if not responses:
             await update.message.reply_text("(no response from the hive)")
             return
-        for mind_id, text in responses:
-            label = mind_id.capitalize()
-            await update.message.reply_text(f"**{label}:** {text}")
+        for _mind_id, text in responses:
+            await update.message.reply_text(text)
     except Exception as exc:
         log.exception("Error sending group message")
         await update.message.reply_text(f"Error: {exc}")

--- a/server.py
+++ b/server.py
@@ -251,6 +251,7 @@ async def send_group_message(group_session_id: str, body: GroupSessionMessageReq
 
     async def event_stream():
         async for event in session_mgr.send_message(child_session_id, body.content):
+            event.setdefault("mind_id", moderator_mind_id)
             yield f"data: {json.dumps(event)}\n\n"
 
     return StreamingResponse(event_stream(), media_type="text/event-stream")


### PR DESCRIPTION
- `server.py`: stamp `mind_id` on group session SSE events\n- `hivemind_bot.py`: drop redundant label prefix — text already attributed by /moderate skill