### PR TITLE
fix: persist Codex auth across container restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - ${HOST_PROJECT_DIR:-.}:/usr/src/app
       - ${HOST_CLAUDE_DIR:-~/.claude}:/home/hivemind/.claude
+      - ${HOST_CODEX_DIR:-~/.codex}:/home/hivemind/.codex
       - sessions-db:/usr/src/app/data
       - ${HOST_MCP_DIR:-/home/daniel/Storage/Dev/hive_mind_mcp}:/home/daniel/Storage/Dev/hive_mind_mcp
       - ${HOST_SPARK_DIR:-/home/daniel/Storage/Dev/spark_to_bloom}:/home/daniel/Storage/Dev/spark_to_bloom


### PR DESCRIPTION
Mounts `~/.codex` into the server container so Nagatha's OpenAI Pro auth token survives rebuilds.\n\nSame pattern as `~/.claude` for Claude CLI auth.