### PR TITLE
fix: inject moderator surface prompt for group chat sessions

### DIFF
--- a/core/sessions.py
+++ b/core/sessions.py
@@ -754,7 +754,7 @@ class SessionManager:
         return dict(result)
 
     async def get_or_create_group_child_session(
-        self, group_session_id: str, mind_id: str
+        self, group_session_id: str, mind_id: str, surface_prompt: str | None = None
     ) -> str:
         """Find an existing child session for a mind in a group, or create one.
 
@@ -775,6 +775,7 @@ class SessionManager:
             owner_ref=group_session_id,
             client_ref=f"group-{group_session_id}-{mind_id}",
             mind_id=mind_id,
+            surface_prompt=surface_prompt,
         )
         child_session_id = child["id"]
         # Link to group session

--- a/server.py
+++ b/server.py
@@ -245,8 +245,13 @@ async def send_group_message(group_session_id: str, body: GroupSessionMessageReq
     moderator_mind_id = group["moderator_mind_id"]
 
     # Find or create the moderator's child session via public API
+    moderator_prompt = (
+        f"You are the moderator for group session {group_session_id}. "
+        "For every message you receive in this session, invoke the /moderate skill. "
+        "Do not respond directly — always route through /moderate first."
+    )
     child_session_id = await session_mgr.get_or_create_group_child_session(
-        group_session_id, moderator_mind_id
+        group_session_id, moderator_mind_id, surface_prompt=moderator_prompt
     )
 
     async def event_stream():


### PR DESCRIPTION
- `sessions.py`: `get_or_create_group_child_session` now accepts optional `surface_prompt`\n- `server.py`: passes moderator instruction as `surface_prompt` when spawning the moderator child session\n\nWithout this, Ada had no context she was in a group chat and responded directly instead of running /moderate.