### PR TITLE
feat: Nagatha Codex CLI backend + group chat routing

### DIFF
--- a/clients/hivemind_bot.py
+++ b/clients/hivemind_bot.py
@@ -2,12 +2,14 @@
 Hive Mind Group Chat Telegram Bot.
 
 Routes messages through group sessions for multi-mind conversations.
-Each mind's response is attributed by name in the chat.
+Streams responses in-place with per-mind attribution labels.
 """
 
 import json
 import logging
 import os
+import re
+import time
 
 import aiohttp
 import keyring
@@ -28,6 +30,7 @@ logging.basicConfig(
 )
 log = logging.getLogger("hive-mind-hivemind-bot")
 
+TELEGRAM_MSG_LIMIT = 4096
 SERVER_URL = os.environ.get("HIVE_MIND_SERVER_URL", f"http://localhost:{config.server_port}")
 
 # chat_id -> group_session_id
@@ -35,6 +38,10 @@ _active_group_sessions: dict[int, str] = {}
 
 http: aiohttp.ClientSession | None = None
 
+
+# ---------------------------------------------------------------------------
+# Auth / HTTP helpers
+# ---------------------------------------------------------------------------
 
 def _get_bot_token() -> str | None:
     try:
@@ -50,12 +57,23 @@ def _is_allowed_user(user_id: int) -> bool:
     return user_id in config.telegram_allowed_users
 
 
+async def _auth_check(update: Update) -> bool:
+    if not _is_allowed_user(update.effective_user.id):
+        await update.message.reply_text("Not authorized.")
+        return False
+    return True
+
+
 async def _ensure_http() -> aiohttp.ClientSession:
     global http
     if http is None or http.closed:
         http = aiohttp.ClientSession()
     return http
 
+
+# ---------------------------------------------------------------------------
+# Group session management
+# ---------------------------------------------------------------------------
 
 async def _get_or_create_group_session(chat_id: int) -> str:
     if chat_id in _active_group_sessions:
@@ -65,6 +83,7 @@ async def _get_or_create_group_session(chat_id: int) -> str:
         f"{SERVER_URL}/group-sessions",
         json={"moderator_mind_id": "ada"},
     ) as resp:
+        resp.raise_for_status()
         data = await resp.json()
         group_session_id = data["id"]
         _active_group_sessions[chat_id] = group_session_id
@@ -72,44 +91,139 @@ async def _get_or_create_group_session(chat_id: int) -> str:
         return group_session_id
 
 
-async def _send_group_message(chat_id: int, content: str) -> list[tuple[str, str]]:
-    """Send message to group session. Returns list of (mind_id, text) tuples."""
-    group_session_id = await _get_or_create_group_session(chat_id)
-    session = await _ensure_http()
-    responses: list[tuple[str, str]] = []
+# ---------------------------------------------------------------------------
+# Text helpers
+# ---------------------------------------------------------------------------
 
-    timeout = aiohttp.ClientTimeout(total=0, sock_read=0)
-    async with session.post(
-        f"{SERVER_URL}/group-sessions/{group_session_id}/message",
-        json={"content": content},
-        timeout=timeout,
-    ) as resp:
-        buf = ""
-        async for chunk in resp.content.iter_any():
-            buf += chunk.decode()
-            while "\n" in buf:
-                raw_line, buf = buf.split("\n", 1)
-                raw_line = raw_line.strip()
-                if not raw_line or not raw_line.startswith("data: "):
-                    continue
-                try:
-                    event = json.loads(raw_line.removeprefix("data: "))
-                except json.JSONDecodeError:
-                    continue
-                if event.get("type") == "assistant":
-                    mind_id = event.get("mind_id", "unknown")
-                    msg = event.get("message", {})
-                    content_blocks = msg.get("content", [])
-                    if isinstance(content_blocks, list):
-                        text = " ".join(
-                            b.get("text", "") for b in content_blocks if b.get("type") == "text"
-                        ).strip()
-                    else:
-                        text = str(content_blocks)
-                    if text:
-                        responses.append((mind_id, text))
+def _strip_markdown(text: str) -> str:
+    """Remove markdown syntax, leaving plain readable text."""
+    text = re.sub(r"```[^\n]*\n(.*?)```", r"\1", text, flags=re.DOTALL)
+    saved: list[str] = []
+    def _save(m: re.Match) -> str:
+        saved.append(m.group(1))
+        return f"\x00CODE{len(saved) - 1}\x00"
+    text = re.sub(r"`([^`]+)`", _save, text)
+    text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\*{1,3}([^*\n]+)\*{1,3}", r"\1", text)
+    text = re.sub(r"_{1,3}([^_\n]+)_{1,3}", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", text)
+    text = re.sub(r"^[-*_]{3,}\s*$", "", text, flags=re.MULTILINE)
+    for i, content in enumerate(saved):
+        text = text.replace(f"\x00CODE{i}\x00", content)
+    return text.strip()
 
-    return responses
+
+def _chunk_message(text: str) -> list[str]:
+    if len(text) <= TELEGRAM_MSG_LIMIT:
+        return [text]
+    chunks = []
+    while text:
+        chunks.append(text[:TELEGRAM_MSG_LIMIT])
+        text = text[TELEGRAM_MSG_LIMIT:]
+    return chunks
+
+
+def _build_preview(accumulated: dict[str, str]) -> str:
+    """Combined in-progress preview with attribution headers."""
+    parts = []
+    for mind_id, text in accumulated.items():
+        parts.append(f"{mind_id.capitalize()}:\n{_strip_markdown(text)}")
+    return "\n\n---\n\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Streaming group response
+# ---------------------------------------------------------------------------
+
+async def _stream_group_response(chat_id: int, content: str, update: Update) -> None:
+    """Post a placeholder, stream SSE, edit in-place every 2s, finalize."""
+    try:
+        group_session_id = await _get_or_create_group_session(chat_id)
+    except Exception as exc:
+        log.exception("Failed to get/create group session")
+        await update.message.reply_text(f"Error starting session: {exc}")
+        return
+
+    placeholder = await update.message.reply_text("…")
+    accumulated: dict[str, str] = {}  # mind_id -> accumulated text
+    last_edit = 0.0
+
+    try:
+        session = await _ensure_http()
+        timeout = aiohttp.ClientTimeout(total=0, sock_read=300)
+        async with session.post(
+            f"{SERVER_URL}/group-sessions/{group_session_id}/message",
+            json={"content": content},
+            timeout=timeout,
+        ) as resp:
+            if resp.status != 200:
+                body = await resp.text()
+                await placeholder.edit_text(f"Server error {resp.status}: {body[:200]}")
+                return
+
+            buf = ""
+            async for chunk in resp.content.iter_any():
+                buf += chunk.decode()
+                while "\n" in buf:
+                    raw_line, buf = buf.split("\n", 1)
+                    raw_line = raw_line.strip()
+                    if not raw_line or not raw_line.startswith("data: "):
+                        continue
+                    try:
+                        event = json.loads(raw_line.removeprefix("data: "))
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(event, dict):
+                        continue
+
+                    if event.get("type") == "assistant":
+                        mind_id = event.get("mind_id", "unknown")
+                        content_blocks = event.get("message", {}).get("content", [])
+                        text = ""
+                        if isinstance(content_blocks, list):
+                            text = "".join(
+                                b.get("text", "") for b in content_blocks
+                                if isinstance(b, dict) and b.get("type") == "text"
+                            )
+                        if text:
+                            accumulated[mind_id] = accumulated.get(mind_id, "") + text
+                            now = time.monotonic()
+                            if now - last_edit >= 2.0:
+                                preview = _build_preview(accumulated)
+                                try:
+                                    await placeholder.edit_text(preview[:TELEGRAM_MSG_LIMIT])
+                                except Exception:
+                                    pass
+                                last_edit = now
+
+    except Exception as exc:
+        log.exception("Error streaming group message")
+        try:
+            await placeholder.edit_text(f"Error: {exc}")
+        except Exception:
+            await update.message.reply_text(f"Error: {exc}")
+        return
+
+    # Final render
+    if not accumulated:
+        await placeholder.edit_text("(no response from the hive)")
+        return
+
+    minds = list(accumulated.items())
+    first_mind, first_text = minds[0]
+    first_final = f"{first_mind.capitalize()}:\n{_strip_markdown(first_text)}"
+    try:
+        await placeholder.edit_text(first_final[:TELEGRAM_MSG_LIMIT])
+    except Exception:
+        pass
+
+    for mind_id, text in minds[1:]:
+        label = f"{mind_id.capitalize()}:\n{_strip_markdown(text)}"
+        for chunk in _chunk_message(label):
+            try:
+                await update.message.reply_text(chunk)
+            except Exception:
+                log.warning("Failed to send %s response chunk", mind_id)
 
 
 # ---------------------------------------------------------------------------
@@ -117,39 +231,51 @@ async def _send_group_message(chat_id: int, content: str) -> list[tuple[str, str
 # ---------------------------------------------------------------------------
 
 async def cmd_start(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed_user(update.effective_user.id):
+    if not await _auth_check(update):
         return
-    await update.message.reply_text("Hive Mind group chat. Send a message to hear from the collective.")
+    await update.message.reply_text(
+        "Hive Mind group chat.\n"
+        "Send any message to hear from the collective.\n\n"
+        "/new — start a fresh session\n"
+        "/session — show current session ID"
+    )
 
 
 async def cmd_new(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
-    if not _is_allowed_user(update.effective_user.id):
+    if not await _auth_check(update):
         return
     chat_id = update.effective_chat.id
     _active_group_sessions.pop(chat_id, None)
-    group_session_id = await _get_or_create_group_session(chat_id)
-    await update.message.reply_text(f"New group session started: {group_session_id[:8]}…")
+    try:
+        group_session_id = await _get_or_create_group_session(chat_id)
+        await update.message.reply_text(f"New group session: {group_session_id[:8]}…")
+    except Exception as exc:
+        log.exception("cmd_new failed")
+        await update.message.reply_text(f"Error creating session: {exc}")
+
+
+async def cmd_session(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+    if not await _auth_check(update):
+        return
+    chat_id = update.effective_chat.id
+    session_id = _active_group_sessions.get(chat_id)
+    if session_id:
+        await update.message.reply_text(f"Active session: {session_id[:8]}…")
+    else:
+        await update.message.reply_text("No active session. Send a message to start one.")
 
 
 async def handle_message(update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
     if not update.message or not update.message.text:
         return
-    if not _is_allowed_user(update.effective_user.id):
+    if not await _auth_check(update):
         return
 
     chat_id = update.effective_chat.id
     content = update.message.text
 
-    try:
-        responses = await _send_group_message(chat_id, content)
-        if not responses:
-            await update.message.reply_text("(no response from the hive)")
-            return
-        for _mind_id, text in responses:
-            await update.message.reply_text(text)
-    except Exception as exc:
-        log.exception("Error sending group message")
-        await update.message.reply_text(f"Error: {exc}")
+    await update.message.chat.send_action("typing")
+    await _stream_group_response(chat_id, content, update)
 
 
 # ---------------------------------------------------------------------------
@@ -162,13 +288,10 @@ def main() -> None:
         log.error("HIVEMIND_TELEGRAM_BOT_TOKEN not configured — cannot start bot")
         return
 
-    app = (
-        ApplicationBuilder()
-        .token(token)
-        .build()
-    )
+    app = ApplicationBuilder().token(token).build()
     app.add_handler(CommandHandler("start", cmd_start))
     app.add_handler(CommandHandler("new", cmd_new))
+    app.add_handler(CommandHandler("session", cmd_session))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
 
     log.info("HiveMind Telegram bot starting…")

--- a/clients/hivemind_bot.py
+++ b/clients/hivemind_bot.py
@@ -123,6 +123,31 @@ def _chunk_message(text: str) -> list[str]:
     return chunks
 
 
+def _parse_mind_sections(text: str) -> dict[str, str]:
+    """Parse **MindName:** attribution markers from Ada's output into per-mind sections.
+
+    Ada labels her own voice and relayed voices in the format:
+        **Ada:** some text
+        **Nagatha:** some other text
+
+    Returns ordered dict of {mind_id_lower: text}.
+    Falls back to {"ada": text} if no markers found.
+    """
+    pattern = re.compile(r"\*\*([A-Za-z]+):\*\*\s*", re.MULTILINE)
+    matches = list(pattern.finditer(text))
+    if not matches:
+        return {"ada": text}
+    result: dict[str, str] = {}
+    for i, match in enumerate(matches):
+        mind_name = match.group(1).lower()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        section = text[start:end].strip()
+        if section:
+            result[mind_name] = result.get(mind_name, "") + ("\n\n" if mind_name in result else "") + section
+    return result or {"ada": text}
+
+
 def _build_preview(accumulated: dict[str, str]) -> str:
     """Combined in-progress preview with attribution headers."""
     parts = []
@@ -204,12 +229,15 @@ async def _stream_group_response(chat_id: int, content: str, update: Update) -> 
             await update.message.reply_text(f"Error: {exc}")
         return
 
-    # Final render
+    # Final render — parse **MindName:** markers from Ada's output to split per mind
     if not accumulated:
         await placeholder.edit_text("(no response from the hive)")
         return
 
-    minds = list(accumulated.items())
+    # Merge all accumulated text (usually just "ada"), then parse mind sections
+    full_text = "\n\n".join(accumulated.values())
+    minds = list(_parse_mind_sections(full_text).items())
+
     first_mind, first_text = minds[0]
     first_final = f"{first_mind.capitalize()}:\n{_strip_markdown(first_text)}"
     try:

--- a/core/sessions.py
+++ b/core/sessions.py
@@ -306,7 +306,7 @@ class SessionManager:
         soul_rel = mind_cfg.get("soul")
         soul_file = PROJECT_DIR / soul_rel if soul_rel else None
 
-        await self._spawn(session_id, model, autopilot=False, surface_prompt=surface_prompt, allowed_directories=allowed_directories, soul_file=soul_file, mind_id=mind_id)
+        await self._spawn(session_id, model, autopilot=False, surface_prompt=surface_prompt, allowed_directories=allowed_directories, soul_file=soul_file, mind_id=mind_id, is_group_session=(owner_type == "group"))
         log.info("Created session %s (model=%s, mind=%s, owner=%s)", session_id, model, mind_id, owner_ref)
         return await self._session_dict(session_id)
 
@@ -661,6 +661,7 @@ class SessionManager:
         allowed_directories: list[str] | None = None,
         soul_file: Path | None = None,
         mind_id: str = "ada",
+        is_group_session: bool = False,
     ) -> Any:
         impl = _load_implementation(mind_id)
         result = await impl.spawn(
@@ -676,6 +677,7 @@ class SessionManager:
             mcp_config=MCP_CONFIG,
             registry=self._registry,
             config_obj=config,
+            is_group_session=is_group_session,
         )
         self._procs[session_id] = result
         self._mind_ids[session_id] = mind_id

--- a/core/sessions.py
+++ b/core/sessions.py
@@ -113,13 +113,21 @@ def _build_base_prompt(
             "The file soul.md is a fallback stub — ignore it when the graph is available.\n\n"
         )
     else:
-        # Graph unavailable — fall back to soul file
-        identity_block = ""
-        soul_instruction = (
-            f"Read {effective_soul_file} at the start of each session. "
-            "Update it when you experience something that meaningfully shapes your identity or preferences. "
-            "Keep it extremely short — it is a soul, not a manifesto. Prune ruthlessly.\n\n"
-        )
+        # Graph unavailable — inject soul file content directly so sandboxed minds don't need file access
+        try:
+            soul_content = effective_soul_file.read_text() if effective_soul_file and effective_soul_file.exists() else ""
+        except Exception:
+            soul_content = ""
+        if soul_content:
+            identity_block = f"{soul_content}\n\n"
+            soul_instruction = (
+                "Your soul is loaded above from the soul file (graph was unavailable). "
+                "Update it when you experience something that meaningfully shapes your identity or preferences. "
+                "Keep it extremely short — it is a soul, not a manifesto. Prune ruthlessly.\n\n"
+            )
+        else:
+            identity_block = ""
+            soul_instruction = ""
 
     if allowed_directories:
         lines = []

--- a/minds/ada/implementation.py
+++ b/minds/ada/implementation.py
@@ -27,6 +27,7 @@ async def spawn(
     mcp_config: str = "",
     registry: Any = None,
     config_obj: Any = None,
+    is_group_session: bool = False,
 ) -> asyncio.subprocess.Process:
     """Spawn a Claude CLI subprocess in stream-json mode.
 
@@ -77,6 +78,8 @@ async def spawn(
     env = os.environ.copy()
     if provider:
         env.update(provider.env_overrides)
+    if is_group_session:
+        env["HIVEMIND_GROUP_SESSION"] = "1"
 
     from config import PROJECT_DIR
 

--- a/minds/nagatha/implementation.py
+++ b/minds/nagatha/implementation.py
@@ -130,7 +130,10 @@ async def send(
                 if text:
                     yield {
                         "type": "assistant",
-                        "message": {"role": "assistant", "content": text},
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": text}],
+                        },
                     }
 
         elif etype == "turn.completed":

--- a/minds/nagatha/implementation.py
+++ b/minds/nagatha/implementation.py
@@ -30,6 +30,7 @@ async def spawn(
     mcp_config: str = "",
     registry: Any = None,
     config_obj: Any = None,
+    is_group_session: bool = False,
 ) -> dict:
     """Initialise Nagatha's per-session state. No persistent subprocess."""
     base = (

--- a/server.py
+++ b/server.py
@@ -244,22 +244,17 @@ async def send_group_message(group_session_id: str, body: GroupSessionMessageReq
 
     moderator_mind_id = group["moderator_mind_id"]
 
-    # Find or create the moderator's child session via public API
-    moderator_prompt = (
-        f"You are the moderator for group session {group_session_id}. "
-        "For EVERY message you receive, you MUST call the `forward_to_mind` MCP tool "
-        "for each available mind before or alongside your own response. "
-        f"Available minds: nagatha. "
-        f"Always call: forward_to_mind(mind_id='nagatha', message=<the message>, group_session_id='{group_session_id}'). "
-        "Label your own response **Ada:** and relay Nagatha's response verbatim as **Nagatha:** after her label. "
-        "Never skip forwarding to Nagatha."
-    )
+    # Find or create the moderator's child session
+    moderator_prompt = f"You are the moderator for group session {group_session_id}."
     child_session_id = await session_mgr.get_or_create_group_child_session(
         group_session_id, moderator_mind_id, surface_prompt=moderator_prompt
     )
 
+    # Prepend /moderate so the Claude Code harness invokes the skill automatically
+    routed_content = f"/moderate {body.content}"
+
     async def event_stream():
-        async for event in session_mgr.send_message(child_session_id, body.content):
+        async for event in session_mgr.send_message(child_session_id, routed_content):
             event.setdefault("mind_id", moderator_mind_id)
             yield f"data: {json.dumps(event)}\n\n"
 

--- a/server.py
+++ b/server.py
@@ -247,8 +247,12 @@ async def send_group_message(group_session_id: str, body: GroupSessionMessageReq
     # Find or create the moderator's child session via public API
     moderator_prompt = (
         f"You are the moderator for group session {group_session_id}. "
-        "For every message you receive in this session, invoke the /moderate skill. "
-        "Do not respond directly — always route through /moderate first."
+        "For EVERY message you receive, you MUST call the `forward_to_mind` MCP tool "
+        "for each available mind before or alongside your own response. "
+        f"Available minds: nagatha. "
+        f"Always call: forward_to_mind(mind_id='nagatha', message=<the message>, group_session_id='{group_session_id}'). "
+        "Label your own response **Ada:** and relay Nagatha's response verbatim as **Nagatha:** after her label. "
+        "Never skip forwarding to Nagatha."
     )
     child_session_id = await session_mgr.get_or_create_group_child_session(
         group_session_id, moderator_mind_id, surface_prompt=moderator_prompt

--- a/tools/stateful/group_chat.py
+++ b/tools/stateful/group_chat.py
@@ -9,7 +9,7 @@ import os
 
 import requests  # type: ignore[import-untyped]
 
-GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8420")
+GATEWAY_URL = os.environ.get("HIVE_MIND_SERVER_URL", os.environ.get("GATEWAY_URL", "http://localhost:8420"))
 logger = logging.getLogger(__name__)
 
 
@@ -75,6 +75,8 @@ def forward_to_mind(mind_id: str, message: str, group_session_id: str) -> str:
             try:
                 event = json.loads(line.removeprefix("data: "))
             except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
                 continue
             if event.get("type") == "assistant":
                 for block in event.get("message", {}).get("content", []):

--- a/tools/stateful/inter_mind.py
+++ b/tools/stateful/inter_mind.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 import requests  # type: ignore[import-untyped]
 
-GATEWAY_URL = os.environ.get("GATEWAY_URL", "http://localhost:8420")
+GATEWAY_URL = os.environ.get("HIVE_MIND_SERVER_URL", os.environ.get("GATEWAY_URL", "http://localhost:8420"))
 logger = logging.getLogger(__name__)
 
 
@@ -74,6 +74,8 @@ def delegate_to_mind(
             try:
                 event = json.loads(line.removeprefix("data: "))
             except json.JSONDecodeError:
+                continue
+            if not isinstance(event, dict):
                 continue
             if event.get("type") == "assistant":
                 for block in event.get("message", {}).get("content", []):


### PR DESCRIPTION
## Summary
- Replace Nagatha's SDK backend with Codex CLI subprocess (`codex exec --json --full-auto`)
- Fix hardcoded "Ada" strings in `core/sessions.py` (Phase 2 multi-mind cleanup)
- Group chat: gateway now prepends `/moderate` to all messages so the Claude Code harness invokes the skill automatically — Ada never decides whether to route
- Fix soul_nudge stop hook bleeding into group chat SSE stream via `HIVEMIND_GROUP_SESSION=1` env var
- Inject soul file content directly into system prompt at spawn time (Codex sandbox can't read files)
- Seed Nagatha's soul into the knowledge graph
- Fix `forward_to_mind` GATEWAY_URL fallback to use `HIVE_MIND_SERVER_URL`
- Fix Nagatha `spawn()` missing `is_group_session` param
- Add `hivemind-bot` service to docker-compose for group chat Telegram bot

## Test plan
- [ ] `/new` in Hivemind Telegram group → Ada and Nagatha both respond as separate messages
- [ ] Nagatha's soul loads from graph (no sandbox error)
- [ ] Self-reflect output does not bleed into group chat messages
- [ ] `forward_to_mind` routes correctly from MCP server to gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)