### PR TITLE
fix: remove per-mind db fields — database infrastructure is shared

### DIFF
--- a/specs/bob-ollama-mind.md
+++ b/specs/bob-ollama-mind.md
@@ -49,7 +49,6 @@ bob:
   backend: cli_ollama
   model: gpt-oss:20b-32k
   soul: souls/bob.md
-  db: data/bob.db
 ```
 
 Add `bob` to `group_chat.available_minds`.

--- a/specs/multi-mind.md
+++ b/specs/multi-mind.md
@@ -39,8 +39,9 @@ Session Manager (sessions.py)  ← reads mind_id, looks up config
   │  Ada         Nagatha     Skippy  │
   │  CLI Claude  Codex       Ollama  │
   │  own soul    own soul    own soul│
-  │  own db      own db      own db  │
   └──────────────────────────────────┘
+        ↓
+   Shared DB (SQLite, Neo4j, vector)
         ↓
    Shared MCP Tools
 ```
@@ -63,9 +64,9 @@ graph TD
 
     subgraph Pods ["🧠 Isolated Mind Pods"]
         direction LR
-        ADA["Ada\n· own soul.md\n· own SQLite\n· own MCP config\n· CLI Claude"]
-        NAG["Nagatha\n· own soul.md\n· own SQLite\n· own MCP config\n· Codex harness [codex]"]
-        SKIP["Skippy\n· own soul.md\n· own SQLite\n· own MCP config\n· Ollama"]
+        ADA["Ada\n· own soul.md\n· own MCP config\n· CLI Claude"]
+        NAG["Nagatha\n· own soul.md\n· own MCP config\n· Codex harness [codex]"]
+        SKIP["Skippy\n· own soul.md\n· own MCP config\n· Ollama"]
     end
 
     TOOLS["🔧 Shared Tools (MCP)"]
@@ -91,19 +92,16 @@ minds:
     backend: cli_claude
     model: sonnet
     soul: souls/ada.md
-    db: data/ada.db
     mcp_config: .mcp.ada.json
   nagatha:
     backend: codex_cli
     model: codex
     soul: souls/nagatha.md
-    db: data/nagatha.db
     mcp_config: .mcp.nagatha.json
   skippy:
     backend: ollama
     model: llama3
     soul: souls/skippy.md
-    db: data/skippy.db
     mcp_config: .mcp.skippy.json
 ```
 
@@ -128,7 +126,6 @@ The Gateway passes `mind_id` to the Session Manager. The Session Manager does a 
 ```python
 mind_cfg = config["minds"].get(mind_id, config["minds"]["ada"])  # default to Ada
 soul_path = mind_cfg["soul"]
-db_path   = mind_cfg["db"]
 mcp_cfg   = mind_cfg["mcp_config"]
 backend   = mind_cfg["backend"]
 ```
@@ -146,8 +143,9 @@ and preserve the existing `spawn(...)`, `send(...)`, and `kill(...)` contract us
 
 Each mind gets:
 - `souls/<name>.md` — its own system prompt / identity file
-- `data/<name>.db` — its own SQLite session history (no cross-contamination)
 - `.mcp.<name>.json` — its own MCP tool permissions (optional: restrict what each mind can see)
+
+Database infrastructure (SQLite session history, Neo4j knowledge graph, vector store) is **shared** across all minds. Session rows are partitioned by `mind_id`. No per-mind database files.
 
 Ada's soul is already written. The others are stubs until named and defined.
 

--- a/tests/unit/test_config_minds.py
+++ b/tests/unit/test_config_minds.py
@@ -21,9 +21,9 @@ class TestConfigMindsAttribute:
 
         fake_yaml = {
             "minds": {
-                "ada": {"backend": "cli_claude", "model": "sonnet", "soul": "souls/ada.md", "db": "data/ada.db"},
-                "nagatha": {"backend": "sdk_claude", "model": "sonnet", "soul": "souls/nagatha.md", "db": "data/nagatha.db"},
-                "skippy": {"backend": "ollama", "model": "llama3", "soul": "souls/skippy.md", "db": "data/skippy.db"},
+                "ada": {"backend": "cli_claude", "model": "sonnet", "soul": "souls/ada.md"},
+                "nagatha": {"backend": "sdk_claude", "model": "sonnet", "soul": "souls/nagatha.md"},
+                "skippy": {"backend": "ollama", "model": "llama3", "soul": "souls/skippy.md"},
             }
         }
         with patch("config._yaml_config", fake_yaml):
@@ -60,7 +60,7 @@ class TestConfigYamlMindsBlock:
 
     def test_each_mind_has_required_fields(self):
         data = self._load_config_yaml()
-        required = {"backend", "model", "soul", "db"}
+        required = {"backend", "model", "soul"}
         for name, mind in data["minds"].items():
             assert required.issubset(mind.keys()), f"Mind '{name}' missing fields: {required - set(mind.keys())}"
 
@@ -70,7 +70,6 @@ class TestConfigYamlMindsBlock:
         assert ada["backend"] == "cli_claude"
         assert ada["model"] == "sonnet"
         assert ada["soul"] == "souls/ada.md"
-        assert ada["db"] == "data/ada.db"
 
     def test_nagatha_mind_config_values(self):
         data = self._load_config_yaml()
@@ -78,7 +77,6 @@ class TestConfigYamlMindsBlock:
         assert nagatha["backend"] == "sdk_claude"
         assert nagatha["model"] == "sonnet"
         assert nagatha["soul"] == "souls/nagatha.md"
-        assert nagatha["db"] == "data/nagatha.db"
 
     def test_skippy_mind_config_values(self):
         data = self._load_config_yaml()
@@ -86,7 +84,6 @@ class TestConfigYamlMindsBlock:
         assert skippy["backend"] == "ollama"
         assert skippy["model"] == "llama3"
         assert skippy["soul"] == "souls/skippy.md"
-        assert skippy["db"] == "data/skippy.db"
 
     def test_bob_mind_config_values(self):
         data = self._load_config_yaml()
@@ -95,4 +92,3 @@ class TestConfigYamlMindsBlock:
         assert bob["backend"] == "cli_ollama"
         assert bob["model"] == "gpt-oss:20b-32k"
         assert bob["soul"] == "souls/bob.md"
-        assert bob["db"] == "data/bob.db"


### PR DESCRIPTION
## Summary

- Removes all `db:` entries from mind config specs, tests, and story files
- `specs/multi-mind.md`: removes "own SQLite" from architecture diagram and Phase 3, adds explicit shared-DB statement
- `specs/bob-ollama-mind.md`: removes `db` from config example  
- `tests/unit/test_config_minds.py`: removes `db` from required fields set and all per-mind value assertions (9/9 tests pass)

`config.yaml` is gitignored — `db:` fields removed there locally as well.

**This is the contract:** SQLite session history, Neo4j knowledge graph, and vector store are shared infrastructure. No mind has its own database file.

## Test plan

- [x] `pytest tests/unit/test_config_minds.py` — 9/9 passed before this PR was opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)