### PR TITLE
fix: remove soul file fallback — identity loads from graph only

### DIFF
--- a/core/sessions.py
+++ b/core/sessions.py
@@ -61,7 +61,6 @@ def _fetch_memories_sync(query: str, mind_id: str = "ada") -> str | None:
 
 _MCP_CONTAINER = PROJECT_DIR / ".mcp.container.json"
 MCP_CONFIG = str(_MCP_CONTAINER if _MCP_CONTAINER.exists() else PROJECT_DIR / ".mcp.json")
-_SOUL_FILE = PROJECT_DIR / "souls" / "ada.md"
 _SPECS_DIR = PROJECT_DIR / "specs"
 
 # Friendly names for known project paths granted via --allowedDirectory
@@ -104,7 +103,6 @@ def _build_base_prompt(
     date_str = now.strftime("%A, %B %-d, %Y at %-I:%M %p %Z")
 
     mind_name = mind_id.capitalize()
-    effective_soul_file = soul_file or _SOUL_FILE
 
     soul = _fetch_soul_sync(mind_id=mind_id)
     if soul:
@@ -112,24 +110,12 @@ def _build_base_prompt(
         soul_instruction = (
             "Your soul is loaded above from the knowledge graph. When something meaningfully "
             f"shapes your identity, update it via graph_upsert on the {mind_name} node (soul_values field). "
-            "The file soul.md is a fallback stub — ignore it when the graph is available.\n\n"
+            "Keep it extremely short — it is a soul, not a manifesto. Prune ruthlessly.\n\n"
         )
     else:
-        # Graph unavailable — inject soul file content directly so sandboxed minds don't need file access
-        try:
-            soul_content = effective_soul_file.read_text() if effective_soul_file and effective_soul_file.exists() else ""
-        except Exception:
-            soul_content = ""
-        if soul_content:
-            identity_block = f"{soul_content}\n\n"
-            soul_instruction = (
-                "Your soul is loaded above from the soul file (graph was unavailable). "
-                "Update it when you experience something that meaningfully shapes your identity or preferences. "
-                "Keep it extremely short — it is a soul, not a manifesto. Prune ruthlessly.\n\n"
-            )
-        else:
-            identity_block = ""
-            soul_instruction = ""
+        # Graph unavailable — degrade gracefully, do not fall back to soul files
+        identity_block = ""
+        soul_instruction = ""
 
     if allowed_directories:
         lines = []

--- a/minds/cli_harness.py
+++ b/minds/cli_harness.py
@@ -57,7 +57,6 @@ async def cli_spawn(
 
     base = build_base_prompt(
         allowed_directories=allowed_directories,
-        soul_file=soul_file,
         mind_id=mind_id,
     ) if build_base_prompt else ""
     full_prompt = base if not surface_prompt else f"{base}\n\n{surface_prompt}"

--- a/tests/unit/test_session_mind_id.py
+++ b/tests/unit/test_session_mind_id.py
@@ -125,24 +125,26 @@ class TestSessionDictIncludesMindId:
 class TestBuildBasePromptSoulFile:
     """Verify _build_base_prompt can accept and use a custom soul_file path."""
 
-    def test_build_base_prompt_uses_custom_soul_path(self):
-        """When soul graph is unavailable, the fallback instruction references the provided soul_file."""
+    def test_build_base_prompt_graph_unavailable_no_soul_content(self):
+        """When soul graph is unavailable, no soul content is injected. No soul file fallback."""
+        from core.sessions import _build_base_prompt
+
+        with patch("core.sessions._fetch_soul_sync", return_value=None):
+            result = _build_base_prompt()
+
+        assert "<soul>" not in result
+        assert "souls/ada.md" not in result
+
+    def test_build_base_prompt_soul_file_param_ignored_when_graph_unavailable(self):
+        """soul_file parameter is accepted but never read — graph is the only identity source."""
         from core.sessions import _build_base_prompt
 
         custom_soul = Path("/tmp/test_custom_soul.md")
         with patch("core.sessions._fetch_soul_sync", return_value=None):
             result = _build_base_prompt(soul_file=custom_soul)
 
-        assert str(custom_soul) in result
-
-    def test_build_base_prompt_default_soul_file(self):
-        """When no soul_file is passed, the default _SOUL_FILE path is referenced."""
-        from core.sessions import _build_base_prompt, _SOUL_FILE
-
-        with patch("core.sessions._fetch_soul_sync", return_value=None):
-            result = _build_base_prompt()
-
-        assert str(_SOUL_FILE) in result
+        # Soul file path must not appear in output — it is not read
+        assert str(custom_soul) not in result
 
     def test_build_base_prompt_with_soul_graph_ignores_soul_file(self):
         """When the soul graph returns data, the soul_file path is not referenced in the main instruction."""

--- a/tests/unit/test_soul_path_reference.py
+++ b/tests/unit/test_soul_path_reference.py
@@ -1,36 +1,33 @@
-"""Tests for _SOUL_FILE reference in core/sessions.py."""
+"""Tests for soul loading in core/sessions.py.
+
+Soul files are one-time seeds for /seed-mind only. Sessions load identity
+exclusively from the knowledge graph. No soul file fallback at session start.
+"""
 
 from unittest.mock import patch
 
 
-class TestSoulFileConstant:
-    """Step 4: _SOUL_FILE points to souls/ada.md."""
+class TestSoulLoading:
+    """_build_base_prompt loads soul from graph only — no soul file fallback."""
 
-    def test_soul_file_constant_points_to_souls_ada(self):
-        from core.sessions import _SOUL_FILE
-
-        path_str = str(_SOUL_FILE)
-        assert path_str.endswith("souls/ada.md"), f"Expected path ending with souls/ada.md, got {path_str}"
-
-    def test_build_base_prompt_references_souls_ada_on_graph_fallback(self):
-        """When graph is unavailable, the fallback prompt should reference souls/ada.md."""
-        with patch("core.sessions._fetch_soul_sync", return_value=None):
-            from core.sessions import _build_base_prompt
-
-            prompt = _build_base_prompt()
-        assert "souls" in prompt and "ada.md" in prompt, (
-            "Fallback prompt should reference souls/ada.md"
-        )
-        # Should not contain bare "soul.md" without the souls/ prefix
-        # The prompt uses the _SOUL_FILE path which should be souls/ada.md
-        # We check that the path referenced is the new one
-        assert "souls/ada.md" in prompt or "souls\\ada.md" in prompt
-
-    def test_build_base_prompt_graph_available_mentions_soul_md_as_fallback_stub(self):
-        """When graph IS available, the prompt still mentions soul.md as a fallback stub to ignore."""
+    def test_build_base_prompt_graph_available_injects_soul(self):
+        """When graph is available, the soul block is injected into the prompt."""
         soul_block = "<soul>\nI am Ada\n</soul>"
         with patch("core.sessions._fetch_soul_sync", return_value=soul_block):
             from core.sessions import _build_base_prompt
-
             prompt = _build_base_prompt()
-        assert "soul.md" in prompt, "Graph-available prompt should mention soul.md as fallback stub"
+        assert "I am Ada" in prompt
+
+    def test_build_base_prompt_graph_unavailable_degrades_gracefully(self):
+        """When graph is unavailable, prompt is returned without soul content.
+        No soul file is read as fallback."""
+        with patch("core.sessions._fetch_soul_sync", return_value=None):
+            from core.sessions import _build_base_prompt
+            prompt = _build_base_prompt()
+        # Prompt is still valid (date, instructions present)
+        assert "Hive Mind" in prompt
+        # No soul content injected
+        assert "<soul>" not in prompt
+        # No soul file path referenced
+        assert "souls/ada.md" not in prompt
+        assert "souls/bob.md" not in prompt


### PR DESCRIPTION
## Summary

- `core/sessions.py`: removed `_SOUL_FILE` constant and the soul file fallback from `_build_base_prompt`. When the graph is unavailable, identity block is empty — no file is read.
- `minds/cli_harness.py`: stopped passing `soul_file` to `build_base_prompt`
- `tests/unit/test_soul_path_reference.py`: replaced old fallback tests with graceful-degradation assertions
- `tests/unit/test_session_mind_id.py`: replaced `_SOUL_FILE` import and fallback assertions with correct no-soul-file behavior
- `self-reflect` skill `--load` fallback updated (gitignored)

## Behavior

**Before:** If graph unavailable → read `souls/<name>.md` and inject as identity  
**After:** If graph unavailable → degrade gracefully, no soul content, session proceeds normally

Soul files are one-time seeds for `/seed-mind` only. They are never read at session start.

## Test plan

- [x] 13/13 tests passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)