### PR TITLE
feat: expose Neo4j Browser and Bolt ports to host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,9 @@ services:
       - NEO4J_dbms_security_procedures_unrestricted=apoc.*
     volumes:
       - neo4j-data:/data
-    # No ports exposed — internal network only
+    ports:
+      - "7474:7474"  # Neo4j Browser (HTTP)
+      - "7687:7687"  # Bolt protocol
 
   planka-db:
     image: postgres:14-alpine


### PR DESCRIPTION
## Summary
- Adds `7474:7474` (Neo4j Browser) and `7687:7687` (Bolt) port bindings to the `neo4j` service
- Allows browsing the knowledge graph from the host at http://localhost:7474
- Credentials: `neo4j` / `hivemind-memory`

## Test plan
- [ ] Merge and rebuild with `docker compose up -d neo4j`
- [ ] Open http://localhost:7474 in host browser
- [ ] Login and verify graph is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)