### PR TITLE
feat: sync missing skills to specs/skills for repo portability

### DIFF
--- a/specs/skills/browse/SKILL.md
+++ b/specs/skills/browse/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: browse
+description: "Browse the web interactively. Navigate pages, fill forms, click
+  buttons, and extract content from JavaScript-rendered sites. Use when WebFetch
+  fails or the task requires interaction (store lookups, form submissions, etc)."
+argument-hint: "[url-or-task-description]"
+tools: Read, Write, Bash
+model: sonnet
+user-invocable: true
+---
+
+# Browse
+
+## When to Use
+- Page requires JavaScript to render (SPAs, React, dynamic content)
+- Task requires interaction (typing a zip code, clicking filters, submitting forms)
+- WebFetch returns empty or useless HTML
+- Need to navigate through multiple pages (search -> click result -> extract)
+
+## When NOT to Use
+- Static page with content in the HTML -> use WebFetch instead (faster, cheaper)
+- API exists for the data -> use the API directly
+- Searching for general knowledge -> use WebSearch (built-in) first
+
+## Procedure
+
+1. **Assess the task.** Decide whether it's a simple page read or multi-step
+   interaction. If multi-step, plan the sequence before starting.
+
+2. **Navigate.** Call `browser_navigate(url)`. Read the accessibility tree
+   to understand the page structure. Look for:
+   - Input fields (role: textbox, searchbox)
+   - Buttons (role: button, link)
+   - Navigation elements (tabs, menus)
+   - Content areas (headings, text, lists)
+
+3. **Interact.** Use `browser_type` for input fields, `browser_click` for
+   buttons and links. After each interaction, check the result with
+   `browser_content()`.
+
+4. **Extract.** Once on the target page, use `browser_content(mode="text")`
+   to get plain text, or `browser_content(mode="accessibility")` for
+   structured data. Parse what you need.
+
+5. **Clean up.** Call `browser_close()` when done, especially if the task
+   is complete. Sessions auto-close after 5 minutes idle, but explicit
+   cleanup is preferred.
+
+## Selector Strategy
+
+Prefer selectors in this order:
+1. `role=button[name="Submit"]` -- most stable, accessibility-based
+2. `text=Sign In` -- readable, works for visible text
+3. `#element-id` -- fast, but IDs change across deploys
+4. `.class-name` -- fragile, use as last resort
+
+## Error Handling
+
+- **Timeout**: Page didn't load -> try with `wait_until="domcontentloaded"`
+  instead of `networkidle`
+- **Selector not found**: Re-read the accessibility tree to find the correct
+  element name or role
+- **CAPTCHA**: Stop. Tell Daniel the site requires human verification. Do not
+  attempt to solve CAPTCHAs.
+- **Bot detection**: Try DuckDuckGo instead of Google. For persistent blocks,
+  tell Daniel the site is not automatable.
+
+## Web Search via Browser
+
+For searches that need real browser rendering:
+```
+web_search("Honda mower HRN216", engine="duckduckgo")
+```
+Returns structured JSON with title, url, snippet. Use `browser_navigate`
+on interesting results to read the full page.

--- a/specs/skills/seed-mind/SKILL.md
+++ b/specs/skills/seed-mind/SKILL.md
@@ -1,0 +1,82 @@
+# Seed Mind
+
+Seeds a mind's complete identity into the knowledge graph from its soul file.
+
+The soul file (`souls/<name>.md`) is a **one-time driver** — it exists solely to
+populate the mind's graph node on first setup. After seeding, the soul file is an
+archived artifact. Sessions **never** read it. The graph node IS the living identity.
+
+## Usage
+
+`/seed-mind <mind_id>`
+
+Examples: `/seed-mind ada`, `/seed-mind bob`, `/seed-mind nagatha`
+
+---
+
+## Step 1 — Resolve the soul file
+
+Read `config.yaml`. Find `minds.<mind_id>.soul`. This is the path to the soul file.
+
+If `mind_id` is not in the `minds` block, stop: "Unknown mind: <mind_id>."
+
+---
+
+## Step 2 — Read the soul file verbatim
+
+Read the entire file at the resolved path.
+
+**Do not summarize. Do not abbreviate. Do not paraphrase. Do not shorten.**
+Every sentence is the mind's identity. Every word goes in.
+
+---
+
+## Step 3 — Check for existing graph node
+
+Call `graph_query('<MindName>', agent_id='<mind_id>')` where `<MindName>` is the
+capitalized mind name (e.g. `ada` -> `Ada`, `bob` -> `Bob`).
+
+If a node already exists with `soul_values` populated:
+- Display the existing content to the user
+- Ask: "A graph node for <MindName> already exists. Overwrite? (y/n)"
+- If no: stop
+
+---
+
+## Step 4 — Write the graph node
+
+Call `graph_upsert_direct` with:
+
+- Node type: `Mind`
+- Node name: `<MindName>`
+- Properties:
+  - `mind_id`: the mind's ID string (e.g. `"ada"`)
+  - `soul_values`: **every non-empty line of the soul file, verbatim, as a list**. No collapsing. No summarizing. One entry per line.
+  - `soul_file`: the path to the soul file (audit trail only -- no code reads this)
+
+---
+
+## Step 5 — Verify
+
+Call `graph_query('<MindName>', agent_id='<mind_id>')` again. Confirm the node
+was written. Display the stored `soul_values` back so the operator can verify
+nothing was lost.
+
+---
+
+## Step 6 — Report
+
+Output:
+- Mind: `<mind_id>`
+- Soul file seeded from: `<path>`
+- Lines stored in graph: `<count>`
+- Status: "Sessions will load this mind's identity exclusively from the graph node."
+
+---
+
+## Rules
+
+- Never abbreviate or paraphrase soul content. Every line goes in verbatim.
+- This skill writes to the graph. It does not modify the soul file.
+- The soul file is an archived seed. Sessions never read it.
+- If the graph is unavailable, report the error and stop. No fallback.

--- a/specs/skills/send-email/SKILL.md
+++ b/specs/skills/send-email/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: send-email
+description: Send an email via Gmail on Daniel's behalf using the hive-mind-mcp tool. Requires human approval via Telegram before sending. Use when Daniel asks to send an email or when an automated workflow needs to deliver an email.
+user-invocable: true
+---
+
+# Send Email
+
+## Overview
+
+Sends email via Gmail using the `mcp__hive-mind-mcp__send_email` MCP tool. The tool requires human approval via Telegram before the message is dispatched — the HITL gate will fire automatically.
+
+## Signature
+
+Always append this block to the bottom of every email body sent on Daniel's behalf:
+
+```
+---
+Sent on behalf of Daniel by Ada.
+```
+
+Do not append if Daniel explicitly says not to, or if the email is clearly automated/system-generated.
+
+## Tool Call
+
+```
+mcp__hive-mind-mcp__send_email(
+    to="recipient@example.com",
+    subject="Subject line",
+    body="...",
+    cc="",                        # optional, comma-separated
+    attachment_filename="",       # optional, e.g. "report.md"
+    attachment_content_b64=""     # optional, base64-encoded file content
+)
+```
+
+## Attachments
+
+Pass a single attachment via the two flat string params — no JSON arrays:
+
+```
+attachment_filename="alexander-setup.md"
+attachment_content_b64="<base64 content>"
+```
+
+To base64-encode a file:
+```bash
+base64 -w 0 /path/to/file
+```
+
+Multiple attachments are not currently supported. Send multiple emails if needed.
+
+## Process
+
+1. Gather: to, subject, body (and attachment fields if needed)
+2. Append signature to body (unless directed otherwise)
+3. Base64-encode any attachment file with `base64 -w 0`
+4. Call `mcp__hive-mind-mcp__send_email` — Telegram approval will fire automatically
+5. Confirm sent message ID from the response
+
+## Error Handling
+
+- `Gmail not authenticated` → run `setup_gmail.py` in the `hive_mind_mcp` container
+- Approval denied → do not retry; report back to Daniel


### PR DESCRIPTION
## Summary
- `.claude/skills/` is gitignored — `specs/skills/` is the committed copy so cloners get all skills out of the box
- Three active skills were missing from `specs/skills/`: `send-email`, `browse`, `seed-mind`
- Added all three to keep the committed spec directory in sync with the active skill set

## Test plan
- [ ] Clone the repo fresh and verify `specs/skills/send-email/`, `specs/skills/browse/`, and `specs/skills/seed-mind/` are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)