### PR TITLE
fix: prevent notify test from sending real Telegram messages

### DIFF
--- a/tests/unit/test_stateless_notify.py
+++ b/tests/unit/test_stateless_notify.py
@@ -57,9 +57,11 @@ class TestStatelessNotify:
         """Asserts graceful error when credentials missing (not test mode)."""
         # Provide minimal env that still allows Python to import modules
         env = os.environ.copy()
-        # Clear credential-related vars
+        # Clear credential-related vars AND force null keyring so get_credential()
+        # cannot fall back to keyring and accidentally send a real Telegram message.
         env.pop("TELEGRAM_BOT_TOKEN", None)
         env.pop("TELEGRAM_OWNER_CHAT_ID", None)
+        env["PYTHON_KEYRING_BACKEND"] = "keyring.backends.null.Keyring"
         result = subprocess.run(
             [sys.executable, SCRIPT_PATH, "send",
              "--message", "No creds test",


### PR DESCRIPTION
## Summary

- `test_notify_missing_credentials` was clearing `TELEGRAM_BOT_TOKEN`/`TELEGRAM_OWNER_CHAT_ID` from the subprocess env, but `get_credential()` falls back to keyring — which has live credentials inside the container
- Result: the message `"No creds test"` was sent to Daniel's Telegram on **every test run** (4 times in a row during the structured-logging pipeline)
- Fix: add `PYTHON_KEYRING_BACKEND=keyring.backends.null.Keyring` to the subprocess env so keyring returns nothing and the missing-credentials path is actually exercised

## Test plan

- [x] All 6 notify tests pass (6/6)
- [x] `test_notify_missing_credentials` now correctly asserts `telegram.success is False`
- [x] No real Telegram message sent during test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)