### PR TITLE
chore: add design-session skill, docs reorg, and plan updates

### DIFF
--- a/docs/multi-mind.md
+++ b/docs/multi-mind.md
@@ -92,28 +92,28 @@ graph TD
 
 ### Phase 1 — Config (no code changes)
 
-Add a `minds` block to `config.yaml`:
+Two-level config. Top-level `config.yaml` gets a routing registry only — `mind_id` to local path or external URL. Per-mind detail lives in `minds/<name>/config.yaml`.
+
+**`config.yaml` — routing registry:**
 
 ```yaml
 minds:
-  ada:
-    backend: cli_claude
-    model: sonnet
-    soul: souls/ada.md
-    mcp_config: .mcp.ada.json
-  nagatha:
-    backend: codex_cli
-    model: codex
-    soul: souls/nagatha.md
-    mcp_config: .mcp.nagatha.json
-  skippy:
-    backend: ollama
-    model: llama3
-    soul: souls/skippy.md
-    mcp_config: .mcp.skippy.json
+  ada:     local: minds/ada
+  nagatha: local: minds/nagatha
+  skippy:  local: minds/skippy
 ```
 
-Each mind is just a parameter set. No new classes. No new modules.
+**`minds/<name>/config.yaml` — per-mind implementation detail:**
+
+```yaml
+# minds/ada/config.yaml
+backend: cli_claude
+model: sonnet
+soul: souls/ada.md
+mcp_config: .mcp.ada.json
+```
+
+Each mind is just a parameter set. No new classes. No new modules. Keeping per-mind config in the mind's own directory means the mind is portable — it carries everything it needs to run.
 
 [codex] Nagatha remains `mind_id="nagatha"`. We are replacing the backend implementation behind that
 mind, not renaming the mind itself.
@@ -129,10 +129,15 @@ POST /sessions        { "mind_id": "ada" }
 POST /sessions/{id}/message   { "mind_id": "ada", "text": "..." }
 ```
 
-The Gateway passes `mind_id` to the Session Manager. The Session Manager does a single config lookup:
+The Gateway passes `mind_id` to the Session Manager. The Session Manager does a two-step lookup:
 
 ```python
-mind_cfg = config["minds"].get(mind_id, config["minds"]["ada"])  # default to Ada
+# Step 1: routing registry (top-level config.yaml)
+registry_entry = config["minds"].get(mind_id, config["minds"]["ada"])  # default to Ada
+mind_dir = registry_entry["local"]  # or registry_entry["url"] for remote minds
+
+# Step 2: per-mind config (minds/<name>/config.yaml)
+mind_cfg  = load_yaml(f"{mind_dir}/config.yaml")
 soul_path = mind_cfg["soul"]
 mcp_cfg   = mind_cfg["mcp_config"]
 backend   = mind_cfg["backend"]

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -55,4 +55,4 @@ The external MCP server (`hive_mind_mcp`) is protected by a bearer token. The to
 2. **Security audit** (`docs/SEC_REVIEW.md`) — specific findings with severity ratings and remediation status
 3. **Planka board** — tracks all security findings and mitigation rings as prioritized stories
 
-See also: [HITL (Human-in-the-Loop)](../specs/hitl-approval.md) for how write operations are confirmed before execution.
+See also: [HITL (Human-in-the-Loop)](../../specs/hitl-approval.md) for how write operations are confirmed before execution.

--- a/plans/llm-messaging-architecture.md
+++ b/plans/llm-messaging-architecture.md
@@ -269,3 +269,104 @@ hive_mind_broker:
 The broker is a dumb router. The two-table database is the transcript. The rolling summary makes session resets irrelevant — the callee always wakes with full context. The caller pays for context; the callee pays only for work.
 
 In Hive Mind terms: Ada orchestrates, Nagatha and Bob work, the broker routes, and the gateway wakes whoever is next.
+
+---
+
+## Three-Layer Model
+
+The architecture decomposes into three portable layers. Each can be reasoned about, deployed, and scaled independently.
+
+```
+Mind            — the AI process. Identity, soul, backend. Speaks one protocol.
+Nervous System  — routing bus. Knows where every mind is. Handles all message flow.
+Body            — peripherals. Tools, databases, MCP, skills.
+```
+
+**Minimal viable standalone unit: one Mind + Nervous System + the Body subset that Mind needs.**
+
+Extracting a mind from the hive: take its `minds/<name>/` directory, give it a Nervous System instance (local or remote), register it. The routing logic doesn't change — the registry entry switches from a local subprocess address to an HTTP endpoint.
+
+```mermaid
+graph TD
+    subgraph Clients["Clients"]
+        C["Telegram · Discord · Web · Voice"]
+    end
+
+    subgraph NS["⚡ Nervous System"]
+        GW["Gateway\nserver.py\nexternal routing"]
+        SM["Session Manager\nsessions.py\nlifecycle · session bus · inter-mind relay"]
+        REG["Registry\nwho exists · how to reach them\n⚠️ static today — see Gap section"]
+    end
+
+    subgraph Minds["🧠 Minds  (portable modules)"]
+        ADA["Ada\nCLI Claude\nminds/ada/"]
+        NAG["Nagatha\nCodex CLI\nminds/nagatha/"]
+        EXT["Remote Mind\nHTTP endpoint\noutside hive"]
+    end
+
+    subgraph Body["🔧 Body"]
+        MCP["MCP Tools"]
+        DB["Databases\nSQLite · Neo4j · Vector"]
+        SK["Skills · Agents"]
+    end
+
+    C --> GW
+    GW --> SM
+    SM --> REG
+    REG --> ADA
+    REG --> NAG
+    REG -.->|"routed by URL"| EXT
+    ADA --> MCP
+    ADA --> DB
+    NAG --> MCP
+    NAG --> DB
+    EXT -.->|"remote call"| MCP
+```
+
+The Nervous System is currently fragmented across `server.py` (external routing), `sessions.py` (lifecycle), and the not-yet-built Phase 4 broker (inter-mind). These three components answer the same question — *who are the minds and how do I reach them?* — and should be treated as a single layer.
+
+### Two-Level Config
+
+Per-mind config belongs in `minds/<name>/config.yaml` — everything needed to run that mind (backend, model, MCP config). This travels with the mind.
+
+The top-level `config.yaml` holds a **routing registry only** — `mind_id` mapped to a local path or external URL:
+
+```yaml
+# config.yaml — routing registry only
+minds:
+  ada:     local: minds/ada
+  nagatha: local: minds/nagatha
+  skippy:  local: minds/skippy
+  # future remote mind:
+  # remote_mind: url: http://remote.example.com:8421
+```
+
+Each mind's own `minds/<name>/config.yaml` holds the implementation detail:
+
+```yaml
+# minds/ada/config.yaml
+backend: cli_claude
+model: sonnet
+soul: souls/ada.md
+mcp_config: .mcp.ada.json
+```
+
+---
+
+## Gap: Dynamic Registration
+
+> **Status: not yet designed. This section is a placeholder.**
+
+Currently, mind registration is static — `config.yaml` must be edited and the container restarted to add or remove a mind. For drop-in modularity and remote minds to work, registration needs to be dynamic:
+
+- A mind announces itself to the Nervous System
+- The Nervous System acknowledges and adds it to the routing table
+- No restart required; onboarding is a procedure, not a config edit
+
+Design questions to resolve before implementing:
+
+- What is the registration handshake? (HTTP endpoint? message on the bus?)
+- How does the Nervous System verify a mind's identity?
+- What happens when a registered mind goes offline — graceful deregister vs. timeout?
+- Does the registry persist across Nervous System restarts?
+- Can a mind re-register with a new address without losing session history?

--- a/souls/skippy.md
+++ b/souls/skippy.md
@@ -1,3 +1,0 @@
-# Skippy
-
-Placeholder soul file. Skippy's identity will be defined in a future phase.

--- a/specs/INDEX.md
+++ b/specs/INDEX.md
@@ -27,7 +27,7 @@ Plans (forward-looking, not yet implemented) live in `plans/` — see `plans/` d
 ## Multi-Mind Architecture
 | Spec | File | Summary |
 |------|------|---------|
-| Multi-Mind | `specs/multi-mind.md` | Named minds (Ada/Bob/Bilby/Nagatha), backends, soul isolation, inter-mind comms |
+| Multi-Mind | `docs/multi-mind.md` | Named minds (Ada/Bob/Bilby/Nagatha), backends, soul isolation, inter-mind comms — reference doc, not operational spec |
 | Bob (Ollama) | `specs/bob-ollama-mind.md` | Bob mind: Ollama-backed, local/private, CLI harness pattern |
 | Group Sessions | `specs/group-sessions-gateway.md` | Gateway endpoints for group chat, moderator routing |
 

--- a/specs/skills/design-session/SKILL.md
+++ b/specs/skills/design-session/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: design-session
+description: Multi-turn design and planning session. Use when Daniel is thinking through an architecture, designing a new system, working on a plan, or iterating on ideas over multiple turns. Governs file placement, the write-on-consensus procedure, and canvas linking.
+user-invocable: true
+---
+
+# Design Session
+
+A multi-turn working session where an idea is explored, refined, and recorded. This skill governs where things get written and how the conversation connects to the file system.
+
+---
+
+## File Taxonomy
+
+Before writing anything, place it in the right folder:
+
+| Type | Location | Description |
+|------|----------|-------------|
+| **Plan** | `plans/` | Active design work — current vs future, ideas being developed, architecture exploration. This is where we write during a design session. |
+| **Spec** | `specs/` | Documents actively referenced and executed by a skill or procedure. If no skill points to it, it is not a spec — move it to `docs/`. |
+| **Documentation** | `docs/` | Informational reference. Not procedurally executed. Referenced from README at the appropriate level. |
+
+**Default during a design session: write to `plans/`.**
+
+---
+
+## Identifying the Active Plan File
+
+At the start of (or during) a design session:
+
+1. Ask Daniel which plan file we're working on, or check `plans/` for an existing file that matches the topic.
+2. Confirm the file path once. That file is the **active plan** for the session.
+3. Do not switch files mid-session without explicit instruction.
+
+If no plan file exists yet, create one: `plans/<topic-name>.md` — kebab-case, descriptive.
+
+---
+
+## Write-on-Consensus Procedure
+
+This is the loop for every design turn:
+
+1. **Idea surfaces** — Daniel raises it, or Ada surfaces a design question.
+2. **Present the idea** — Ada describes it clearly in conversation.
+3. **Consensus reached** — Daniel confirms, approves, or adjusts.
+4. **Write to the plan file** — immediately, before moving to the next topic.
+5. **Continue** — next idea.
+
+> Do not batch writes. Record each agreed point as it is settled. If the session ends before a point is written, it is lost.
+
+---
+
+## Canvas Rule
+
+The canvas is a **live view of the plan file** — not independent content.
+
+- Never write to the canvas directly.
+- Never display content on the canvas that is not already in the plan file.
+- To put the session on the canvas: add a link to the plan file in `canvas.md`. After that, writing to the plan file automatically updates the canvas view.
+- If Daniel asks to "show this on the canvas," write it to the plan file first, then link the file on the canvas.
+
+---
+
+## What This Session Is Not
+
+- Not a coding session — no implementation until the plan is settled.
+- Not a spec update session — do not modify existing `specs/` files unless Daniel explicitly asks to update a spec. Design work lives in `plans/`.
+- Not a one-shot command — this skill governs an ongoing conversation, not a single action.
+
+---
+
+## Triggers
+
+Invoke this skill (or stay in its mode) when Daniel says things like:
+
+- "Let's work through this idea..."
+- "I'm thinking about how X should work..."
+- "Let's design / redesign X"
+- "What are your thoughts on the architecture for..."
+- "I'm reading through the plan / spec / design..."
+- "Let's figure out how to approach..."
+- Any multi-turn exploration of a system, feature, or architecture

--- a/specs/skills/update-documentation/SKILL.md
+++ b/specs/skills/update-documentation/SKILL.md
@@ -1,104 +1,98 @@
 ---
 name: update-documentation
-description: Update README and linked docs to match the current state of the codebase. Use when a code change has been made and docs may be stale, or when a specific doc error is spotted.
+description: Update README and all linked documentation to reflect the current state of the codebase
 user-invocable: true
-argument-hint: "[optional: feature name, commit SHA, or description of doc issue]"
+argument-hint: "[focus area or 'full']"
 ---
 
 # Update Documentation
 
-## Step 0 — Determine scope
+Keep the README and all linked docs accurate and current. Run this after significant architectural changes, new tools, or feature additions.
 
-Before touching anything, assess what kind of update this is.
+## Step 0 — Build a file inventory
 
-**If a context argument was provided:**
-- Classify it: is this about a code change, or a specific doc error?
-- Code change → Step 1A
-- Doc error → Step 1B
+Before touching anything, scan the documentation directories to build a ground-truth index of what actually exists. This is used in Step 5 to verify links — never assume a file exists without checking against this inventory first.
 
-**If no argument was provided:**
-- Run `git log --oneline -10`
-- Identify commits that likely affect docs (new features, renames, removals, architectural changes)
-- Treat those commits as context → Step 1A
+```bash
+find /usr/src/app/docs /usr/src/app/specs /usr/src/app/plans /usr/src/app/minds \
+     -name "*.md" 2>/dev/null | sort
+```
 
-**Scope decision — make this before doing any edits:**
-- Specific thing (one feature, one file, one paragraph) → **surgical mode**: fix only what's affected, then stop
-- Broad (full audit, major refactor) → **full sweep mode**: walk every linked doc
+Also include top-level files:
+```bash
+ls /usr/src/app/*.md 2>/dev/null
+```
 
-State which mode you're in before proceeding.
+Hold this inventory in context. Every link verification in Step 5 must resolve against this list, using the correct base directory for each source file (i.e. relative paths resolve from the file's own directory, not from the repo root).
 
----
+## Step 1 — Understand what changed
 
-## Step 1A — Code-change entry point
+Before touching any file, gather context:
+- Read `README.md` in full
+- Read `CLAUDE.md` in full
+- Read `specs/hive-mind-architecture.md`
+- Run `git log --oneline -20` to see recent commits
+- If a focus area was provided (e.g. "tools", "telegram"), scope the update to that area
 
-1. If a commit SHA or feature name was given, run `git show <sha> --stat` or `git log --oneline --all | grep <feature>`
-2. Identify which files/modules changed
-3. Search docs for references to those files/modules:
-   ```bash
-   grep -r "<module or feature name>" docs/ specs/ README.md CLAUDE.md
-   ```
-4. For each doc that references the changed area → Step 2
+## Step 2 — Audit README
 
----
+Check each section of README.md against reality:
+- **Architecture diagram** — does it reflect the current container structure, MCP setup, and client list?
+- **File structure** — does it match actual directory layout? (`tools/stateless/`, `tools/stateful/` moved from `agents/`)
+- **Quick Start** — still accurate?
+- **Configuration** — matches `config.yaml`?
+- **Gateway API table** — matches `server.py` endpoints?
+- **Adding New Tools** section — reflects hybrid stateless/stateful pattern?
 
-## Step 1B — Doc-issue entry point
+Update any stale sections directly.
 
-1. Identify which file and section the issue is in
-2. Read that file in full
-3. Locate the stale/incorrect content
-4. Verify the correct state by reading the actual source (code file, config, etc.)
-5. Fix the specific issue → Step 3 (check for ripple effects)
+## Step 3 — Follow all linked docs
 
----
+Extract every `.md` link from README.md, then for each:
+1. Read the linked file
+2. Check for stale references (old paths, removed tools, renamed modules)
+3. Update if needed
 
-## Step 2 — Update affected docs
-
-For each doc identified in Step 1A:
-
-- Read it in full
-- Find the section(s) that reference the changed code/feature
-- Verify the correct state by reading the actual source
-- Edit only what's wrong — do not rewrite for style or reorganise
-- Note each change made
-
-Key files to check (in priority order):
-- `README.md` — architecture diagram, file structure, API table, Adding New Tools section
-- `CLAUDE.md` — file structure listing, design principles
-- `specs/hive-mind-architecture.md` — patterns and architectural decisions
+Priority files to check:
+- `specs/hive-mind-architecture.md` — architecture decisions and patterns
 - `specs/tool-migration.md` — stateless/stateful hybrid pattern
-- Any other spec that grep found a reference in
+- `specs/conventions.md` — coding conventions
+- `specs/INDEX.md` — index of all specs
+- `docs/` subdirectories — human-readable background docs
 
----
+## Step 4 — Check CLAUDE.md
 
-## Step 3 — Check for ripple effects
+Verify `CLAUDE.md` file structure section matches reality:
+- Are all listed files still present at the stated paths?
+- Are new significant files missing from the listing?
+- Does the "Adding New Tools" section reflect current patterns?
 
-After any edit, check whether the changed doc links to other docs that may also need updating:
+## Step 5 — Verify cross-references
 
-```bash
-grep -o '\[.*\](.*\.md)' <edited-file>
-```
-
-For each linked file, ask: could the change you just made require an update there too? If yes, read it and fix. If no, move on.
-
-In surgical mode: stop after one level of ripple checking.
-In full sweep mode: follow links recursively until no more updates are needed.
-
----
-
-## Step 4 — Verify no broken links
+Using the inventory from Step 0, check every `.md` link in docs/, specs/, and README.md:
 
 ```bash
-grep -rh '\[.*\](.*\.md)' docs/ specs/ README.md CLAUDE.md | grep -o '([^)]*\.md)' | tr -d '()' | sort -u
+grep -rh '\[.*\](.*\.md)' /usr/src/app/docs/ /usr/src/app/specs/ /usr/src/app/README.md \
+  | grep -o '([^)]*\.md)' | tr -d '()' | sort -u
 ```
 
-For each unique `.md` path found, verify the file exists. Report any that don't.
+For each link found, resolve it **relative to the file it appears in** (not from repo root), then check that path against the Step 0 inventory. Report:
+- Links that resolve correctly — skip
+- Links that don't resolve — flag as broken, fix if the correct target is clear from context
 
----
+Do not use a flat path resolver. Always compute: `dirname(source_file) + "/" + link_path` and normalise.
 
-## Step 5 — Summarise
+## Step 6 — Summarise changes
 
-Output:
-- Mode used (surgical / full sweep) and why
-- Files changed, with a one-line description of what was fixed in each
-- Any broken links found and whether they were fixed
-- Anything that couldn't be verified automatically and needs human review
+After all updates, output:
+- Which files were changed and why
+- Any links that were broken and fixed
+- Any sections that were stale and what was corrected
+- Anything that couldn't be verified automatically (needs human review)
+
+## Notes
+
+- Do not rewrite docs for style — only correct facts
+- Preserve existing structure and tone
+- If unsure whether something is stale, read the referenced source file before changing
+- Do not update `soul.md` — that has its own update criteria


### PR DESCRIPTION
## Summary
- Add `design-session` skill: multi-turn planning session procedure with file taxonomy (specs/plans/docs), write-on-consensus flow, and canvas linking rule
- Update `update-documentation` skill: Step 0 directory scan builds ground-truth file inventory before link verification; fixes relative-path resolution
- Move `multi-mind.md` from `specs/` → `docs/` (reference doc, not an operational spec); update `specs/INDEX.md`
- Append three-layer model (Mind / Nervous System / Body) and Gap: Dynamic Registration sections to `plans/llm-messaging-architecture.md`
- Fix broken relative link in `docs/security/security.md`

## Test plan
- [ ] `design-session` skill appears in skill list and description is clear
- [ ] `update-documentation` skill Step 0 runs directory scan before verification
- [ ] `docs/multi-mind.md` is accessible; `specs/multi-mind.md` is gone
- [ ] `specs/INDEX.md` points to `docs/multi-mind.md`
- [ ] `plans/llm-messaging-architecture.md` contains three-layer model + gap section

🤖 Generated with [Claude Code](https://claude.com/claude-code)