### PR TITLE
chore: full documentation audit — sync README and CLAUDE.md to codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,30 +9,37 @@ This file provides guidance to Claude Code when working with this repository.
 ### Architecture
 
 ```
-┌─────────────┐  ┌─────────────┐  ┌─────────────┐
-│ Discord Bot │  │ Terminal UI │  │   Web UI    │
-│  (thin)     │  │  (thin)     │  │  (thin)     │
-└──────┬──────┘  └──────┬──────┘  └──────┬──────┘
-       │                │                │
-       └────────────────┼────────────────┘
+┌─────────────┐  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
+│ Discord Bot │  │ Telegram Bot│  │ Group Chat  │  │  Scheduler  │
+│  (thin)     │  │  (thin)     │  │  Bot (thin) │  │  (cron)     │
+└──────┬──────┘  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘
+       │                │                │                 │
+       └────────────────┼────────────────┴─────────────────┘
                         │  HTTP / WebSocket
                  ┌──────▼──────┐
                  │   FastAPI   │
                  │   Gateway   │  ← server.py
                  └──────┬──────┘
                         │
-              ┌─────────▼─────────┐
-              │  Session Manager  │  ← core/sessions.py
-              │  (process pool +  │
-              │   SQLite DB)      │
-              └─────────┬─────────┘
-                        │  stdin/stdout (NDJSON)
-              ┌─────────▼─────────┐
-              │  claude -p        │
-              │  --stream-json    │
-              │  + MCP tools      │
-              │  (one per session)│
-              └───────────────────┘
+              ┌──────────▼──────────┐
+              │   Session Manager   │  ← core/sessions.py
+              │   (process pool +   │
+              │    SQLite DB)       │
+              └──────────┬──────────┘
+                         │  mind_id routing
+         ┌───────────────┼───────────────┬──────────────┐
+  ┌──────▼───────┐ ┌─────▼──────┐ ┌─────▼──────┐ ┌────▼─────────┐
+  │ Ada          │ │   Bob      │ │   Bilby    │ │  Nagatha     │
+  │ (CLI Claude) │ │(CLI Ollama)│ │ (SDK Code) │ │ (SDK Claude) │
+  └──────┬───────┘ └─────┬──────┘ └─────┬──────┘ └────┬─────────┘
+         └───────────────┴───────────────┴──────────────┘
+                         │  MCP (stdio / SSE)
+          ┌──────────────┴──────────────┐
+   ┌──────▼──────┐               ┌──────▼──────┐
+   │ hive-mind-  │               │ hive-mind-  │
+   │ tools (int) │               │ mcp (ext +  │
+   │             │               │   HITL)     │
+   └─────────────┘               └─────────────┘
 ```
 
 ### Self-Improvement
@@ -73,13 +80,24 @@ hive_mind/
 │   ├── secrets.py                # Shared get_credential() utility
 │   ├── models.py                 # Model registry (static aliases + Ollama)
 │   ├── gateway_client.py         # Shared HTTP client for bots
-│   └── hitl.py                   # Human-in-the-loop approval
+│   ├── hitl.py                   # Human-in-the-loop approval
+│   ├── audit.py                  # MCP tool invocation audit logging (JSON + rotation)
+│   ├── dep_scan.py               # pip-audit wrapper for dependency vulnerability scanning
+│   ├── epilogue.py               # Session epilogue processor (post-session memory extraction)
+│   ├── kg_guards.py              # Knowledge graph write guards (disambiguation + orphan)
+│   ├── memory_expiry.py          # Timed-event expiry sweep for Neo4j
+│   ├── memory_schema.py          # Memory data class registry and validation
+│   ├── notify_utils.py           # Shared Telegram notification utility
+│   ├── path_validation.py        # CWE-22 path traversal protection for skill agents
+│   └── story_pipeline.py         # Post-merge story pipeline (pull, health check, cleanup)
 │
 ├── tools/
 │   ├── stateful/                  # MCP tools (registered in mcp_server.py)
 │   │   ├── browser.py            # Async Playwright browser automation
 │   │   ├── knowledge_graph.py    # Neo4j knowledge graph
-│   │   └── memory.py             # Neo4j vector memory store
+│   │   ├── memory.py             # Neo4j vector memory store
+│   │   ├── group_chat.py         # Group session message forwarding between minds
+│   │   └── inter_mind.py         # Direct mind-to-mind delegation
 │   │
 │   └── stateless/                 # Standalone scripts (invoked via skills)
 │       ├── crypto/crypto.py      # CoinGecko crypto prices
@@ -94,7 +112,8 @@ hive_mind/
 │
 ├── clients/                       # Thin client entry points
 │   ├── discord_bot.py            # Discord bot
-│   ├── telegram_bot.py           # Telegram bot
+│   ├── telegram_bot.py           # Telegram bot (Ada + named minds)
+│   ├── hivemind_bot.py           # Group chat Telegram bot (multi-mind sessions)
 │   └── scheduler.py              # Cron daemon
 │
 ├── voice/                         # Voice infrastructure
@@ -117,6 +136,15 @@ hive_mind/
 │   ├── bob.md                    # Bob's soul seed
 │   ├── nagatha.md                # Nagatha's soul seed
 │   └── skippy.md                 # Skippy placeholder
+│
+├── utilities/                     # Standalone utilities (not invoked via skills)
+│   └── ollama_tools.py           # Direct Ollama API client
+│
+├── vendor/                        # Vendored dependencies
+│   └── claude_code_sdk/          # Vendored Claude Code SDK (used by Bilby)
+│
+├── plans/                         # Forward-looking plans and proposals (not yet implemented)
+│
 ├── soul.md                        # Pointer stub (see souls/ada.md)
 ├── CLAUDE.md                      # This file
 ├── Dockerfile
@@ -169,6 +197,15 @@ A minimal `.env` remains for docker-compose interpolation (Neo4j, Planka only).
 | `POST` | `/command` | Route slash commands |
 | `POST` | `/sessions/{id}/remote-control` | Start remote observation of a session |
 | `DELETE` | `/sessions/{id}/remote-control` | Stop remote observation |
+| `POST` | `/group-sessions` | Create group session (multi-mind) |
+| `GET` | `/group-sessions/{id}` | Get group session detail |
+| `POST` | `/group-sessions/{id}/message` | Send message to group session |
+| `DELETE` | `/group-sessions/{id}` | Kill group session |
+| `POST` | `/memory/expiry-sweep` | Trigger timed-event expiry sweep |
+| `POST` | `/epilogue/sweep` | Trigger session epilogue sweep |
+| `POST` | `/hitl/request` | Submit HITL approval request |
+| `GET` | `/hitl/status/{token}` | Check HITL approval status |
+| `POST` | `/hitl/respond` | Respond to HITL approval request |
 
 ## Adding New Tools
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A self-improving personal assistant powered by Claude Code. The system wraps the
 flowchart TD
     DC[Discord] --> GW[FastAPI Gateway]
     TG[Telegram] --> GW
+    HV[Group Chat Bot] --> GW
     SC[Scheduler] --> GW
     GW --> SM[Session Manager]
     SM -->|mind_id lookup| ADA[Ada · CLI Claude]
@@ -56,7 +57,7 @@ Human-readable guides, background, and reference material — organized by topic
 | [docs/setup/](docs/setup/) | Configuration, providers, and secrets |
 | [docs/memory/](docs/memory/) | Memory lifecycle and storage strategy |
 | [docs/security/](docs/security/) | Security model, hardening, and open tradeoffs |
-| [docs/projects/](docs/projects/) | Future project notes and proposals |
+| [plans/](plans/) | Forward-looking plans and proposals (not yet implemented) |
 
 ## Specs (`specs/`)
 
@@ -104,8 +105,9 @@ All Claude skills, version-controlled. Bootstrap: `cp -rn specs/skills/. ~/.clau
 | [3am](specs/skills/3am/SKILL.md) | Nightly autonomous session |
 | [7am](specs/skills/7am/SKILL.md) | Morning briefing |
 | [agent-logs](specs/skills/agent-logs/SKILL.md) | Scan system log files for critical entries |
+| [browse](specs/skills/browse/SKILL.md) | Browse the web interactively (navigate, fill forms, click, extract) |
 | [check-reminders](specs/skills/check-reminders/SKILL.md) | Check due reminders |
-| [code-genius](specs/skills/code-genius/SKILL.md) | Angular/Dotnet TDD implementation |
+| [code-genius](specs/skills/code-genius/SKILL.md) | Python coding skill: implement features, validate quality, and self-correct |
 | [code-review-genius](specs/skills/code-review-genius/SKILL.md) | Structured code review against story requirements |
 | [commit](specs/skills/commit/SKILL.md) | Stage, commit, push, and open a PR |
 | [convert-to-pdf](specs/skills/convert-to-pdf/SKILL.md) | Convert documents to PDF |
@@ -131,7 +133,9 @@ All Claude skills, version-controlled. Bootstrap: `cp -rn specs/skills/. ~/.clau
 | [reminders](specs/skills/reminders/SKILL.md) | Set, list, delete, and check one-time reminders |
 | [save-session](specs/skills/save-session/SKILL.md) | Save memories from the current session |
 | [secrets](specs/skills/secrets/SKILL.md) | Manage secrets via the system keyring |
+| [seed-mind](specs/skills/seed-mind/SKILL.md) | Seed a mind's complete identity into the knowledge graph |
 | [self-reflect](specs/skills/self-reflect/SKILL.md) | Ada's identity reflection and soul update system |
+| [send-email](specs/skills/send-email/SKILL.md) | Send an email via Gmail on Daniel's behalf (requires HITL approval) |
 | [semantic-memory-save](specs/skills/semantic-memory-save/SKILL.md) | Write a memory chunk to the vector store |
 | [sitrep](specs/skills/sitrep/SKILL.md) | System situation report |
 | [skill-creator-claude](specs/skills/skill-creator-claude/SKILL.md) | Guide for creating Claude skills correctly |


### PR DESCRIPTION
## Summary
- **CLAUDE.md architecture diagram** — replaced non-existent Terminal UI/Web UI clients with actual clients (Discord, Telegram, Group Chat Bot, Scheduler); expanded to show mind-id routing and both MCP servers
- **CLAUDE.md file structure** — added 9 missing `core/` modules, 2 stateful tools (`group_chat.py`, `inter_mind.py`), `hivemind_bot.py` client, and 3 new top-level directories (`utilities/`, `vendor/`, `plans/`)
- **CLAUDE.md Gateway API table** — added 9 missing endpoints (group-sessions ×4, expiry-sweep, epilogue-sweep, HITL ×3)
- **README.md architecture diagram** — added Group Chat Bot node
- **README.md docs table** — removed broken `docs/projects/` link (moved to `plans/`), added `plans/` entry
- **README.md skills table** — fixed `code-genius` description (was Angular/Dotnet, now Python); added 3 missing skills (`browse`, `seed-mind`, `send-email`)

## Test plan
- [ ] Verify all linked `.md` paths in README resolve to real files
- [ ] Confirm architecture diagram renders correctly in GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)