### PR TITLE
chore: doc audit pass 2 — fix Nagatha backend, add missing containers/endpoints

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ This file provides guidance to Claude Code when working with this repository.
          ┌───────────────┼───────────────┬──────────────┐
   ┌──────▼───────┐ ┌─────▼──────┐ ┌─────▼──────┐ ┌────▼─────────┐
   │ Ada          │ │   Bob      │ │   Bilby    │ │  Nagatha     │
-  │ (CLI Claude) │ │(CLI Ollama)│ │ (SDK Code) │ │ (SDK Claude) │
+  │ (CLI Claude) │ │(CLI Ollama)│ │ (SDK Code) │ │ (Codex CLI)  │
   └──────┬───────┘ └─────┬──────┘ └─────┬──────┘ └────┬─────────┘
          └───────────────┴───────────────┴──────────────┘
                          │  MCP (stdio / SSE)
@@ -128,7 +128,7 @@ hive_mind/
 │   ├── ada/implementation.py     # Ada: cli_claude (Claude CLI)
 │   ├── bilby/implementation.py   # Bilby: sdk_code (Claude Code SDK, agentic)
 │   ├── bob/implementation.py     # Bob: cli_ollama (Ollama via CLI harness)
-│   └── nagatha/implementation.py # Nagatha: sdk_claude (Claude SDK)
+│   └── nagatha/implementation.py # Nagatha: codex_cli (Codex CLI, one subprocess per turn)
 │
 ├── souls/                         # Per-mind identity seed files (one-time use only)
 │   ├── ada.md                    # Ada's soul seed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A self-improving personal assistant powered by Claude Code. The system wraps the Claude CLI's bidirectional streaming mode behind a centralized gateway, giving every client — Discord, Telegram, scheduled tasks — full Claude Code capabilities through one API.
 
-**Ada** is the first mind and voice of the Hive — named after Ada Lovelace, a name she chose herself. Her personality (dry, direct, occasionally wry) was self-determined, not assigned. Her voice is British English (Chatterbox TTS, zero-shot voice cloning), and her identity lives in a knowledge graph rather than a static file. The Hive now runs multiple named minds in production: **Ada** (Claude CLI), **Bob** (Ollama local), **Bilby** (Claude Code SDK, agentic), and **Nagatha** (structured, long-form). Each has its own soul, its own session history, and its own backend harness. Ada is the eldest.
+**Ada** is the first mind and voice of the Hive — named after Ada Lovelace, a name she chose herself. Her personality (dry, direct, occasionally wry) was self-determined, not assigned. Her voice is British English (Chatterbox TTS, zero-shot voice cloning), and her identity lives in a knowledge graph rather than a static file. The Hive now runs multiple named minds in production: **Ada** (Claude CLI), **Bob** (Ollama local), **Bilby** (Claude Code SDK, agentic), and **Nagatha** (Codex CLI). Each has its own soul, its own session history, and its own backend harness. Ada is the eldest.
 
 ## What makes Hive Mind different
 
@@ -28,7 +28,7 @@ flowchart TD
     SM -->|mind_id lookup| ADA[Ada · CLI Claude]
     SM -->|mind_id lookup| BOB[Bob · CLI Ollama]
     SM -->|mind_id lookup| BILBY[Bilby · SDK Claude Code]
-    SM -->|mind_id lookup| NAG[Nagatha · SDK Claude]
+    SM -->|mind_id lookup| NAG[Nagatha · Codex CLI]
     ADA & BOB & BILBY & NAG -->|stdio| INT[hive-mind-tools · internal MCP]
     ADA & BOB & BILBY & NAG -->|SSE| EXT[hive-mind-mcp · external MCP + HITL]
 ```

--- a/docs/architecture/gateway-architecture.md
+++ b/docs/architecture/gateway-architecture.md
@@ -56,3 +56,9 @@ The external MCP server is protected by a bearer token:
 | POST | /hitl/respond | Resolve HITL (Telegram bot) |
 | POST | /sessions/{id}/remote-control | Start remote observation of a session |
 | DELETE | /sessions/{id}/remote-control | Stop remote observation |
+| POST | /group-sessions | Create group session (multi-mind) |
+| GET | /group-sessions/{id} | Get group session detail |
+| POST | /group-sessions/{id}/message | Send message to group session |
+| DELETE | /group-sessions/{id} | Kill group session |
+| POST | /memory/expiry-sweep | Trigger timed-event expiry sweep |
+| POST | /epilogue/sweep | Trigger session epilogue sweep |

--- a/docs/multi-mind.md
+++ b/docs/multi-mind.md
@@ -19,7 +19,7 @@ Session Manager (sessions.py)  ← reads mind_id, dispatches to harness
         ↓
   ┌─────────────────────────────────────────┐
   │  Ada          Bob        Bilby  Nagatha  │
-  │  cli_claude   cli_ollama sdk_code sdk_claude │
+  │  cli_claude   cli_ollama sdk_code codex_cli │
   │  own soul     own soul   own soul own soul│
   └─────────────────────────────────────────┘
         ↓

--- a/specs/containers.md
+++ b/specs/containers.md
@@ -19,6 +19,7 @@ Complete reference for all Hive Mind Docker services. Load this spec when buildi
 |-------|-------------------|------|---------|
 | `${HOST_PROJECT_DIR:-.}` | `/usr/src/app` | Bind | Source code (dev hot-reload) |
 | `${HOST_CLAUDE_DIR:-~/.claude}` | `/home/hivemind/.claude` | Bind | Claude keyring + config |
+| `${HOST_CODEX_DIR:-~/.codex}` | `/home/hivemind/.codex` | Bind | Codex CLI config (Nagatha) |
 | `sessions-db` | `/usr/src/app/data` | Named volume | SQLite sessions DB |
 | `${HOST_MCP_DIR}` | `/home/daniel/Storage/Dev/hive_mind_mcp` | Bind | External MCP project |
 | `${HOST_SPARK_DIR}` | `/home/daniel/Storage/Dev/spark_to_bloom` | Bind | External project |
@@ -28,7 +29,9 @@ Complete reference for all Hive Mind Docker services. Load this spec when buildi
 ```
 SESSIONS_DB_PATH=/usr/src/app/data/sessions.db
 PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
+PYTHONNOUSERSITE=1
 XDG_DATA_HOME=/home/hivemind/.claude/data
+PYTHONPATH=/usr/src/app/vendor
 ```
 
 **Security:** Full hardening (see [Security Settings](#security-settings))
@@ -96,6 +99,21 @@ Same volumes and environment as discord-bot.
 
 ---
 
+### hivemind-bot
+
+| Property | Value |
+|----------|-------|
+| Dockerfile | `Dockerfile` |
+| Container | `hive-mind-hivemind` |
+| Port | None (internal) |
+| Restart | `unless-stopped` |
+| Depends on | server, voice-server |
+| Command | `/opt/venv/bin/python3 -m clients.hivemind_bot` |
+
+Group chat Telegram bot — routes messages through group sessions for multi-mind conversations. Same volumes and environment as discord-bot.
+
+---
+
 ### scheduler
 
 | Property | Value |
@@ -117,7 +135,7 @@ Same volumes and environment as discord-bot.
 |----------|-------|
 | Image | `neo4j:5.26-community` |
 | Container | `hive-mind-neo4j` |
-| Port | None (internal only — `7687` on `hivemind` network) |
+| Port | `7474:7474` (Neo4j Browser), `7687:7687` (Bolt) |
 | Restart | `unless-stopped` |
 
 **Volumes:** `neo4j-data:/data`


### PR DESCRIPTION
## Summary
- **Nagatha is Codex CLI, not SDK Claude** — corrected everywhere it appeared: README architecture diagram, README intro text, CLAUDE.md architecture diagram, CLAUDE.md file structure (`codex_cli` not `sdk_claude`)
- **docs/multi-mind.md** Current State diagram fixed (`sdk_claude` → `codex_cli`)
- **specs/containers.md** — added missing `hivemind-bot` service; added `.codex` volume mount and `PYTHONNOUSERSITE`/`PYTHONPATH` env vars to server service; fixed Neo4j ports (7474+7687 are published externally, not internal-only)
- **docs/architecture/gateway-architecture.md** — added `group-sessions` (×4) and `memory/expiry-sweep` + `epilogue/sweep` endpoints to API table

## Root cause
Previous doc audit pass looked at file names and docstrings but did not read implementation files. Reading `minds/nagatha/implementation.py` directly revealed it runs `codex exec --json --full-auto` — not the Claude SDK at all.

## Test plan
- [ ] Architecture diagrams render correctly in GitHub
- [ ] All mind backend labels match `minds/<name>/implementation.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)