### PR TITLE
chore: document message broker in README, CLAUDE.md, and gateway-architecture

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ hive_mind/
 │
 ├── core/                          # Internal libraries (not entry points)
 │   ├── sessions.py               # Session manager (process pool + SQLite)
+│   ├── broker.py                 # Message broker — async inter-mind messaging (SQLite + background wakeup)
 │   ├── secrets.py                # Shared get_credential() utility
 │   ├── models.py                 # Model registry (static aliases + Ollama)
 │   ├── gateway_client.py         # Shared HTTP client for bots
@@ -108,7 +109,8 @@ hive_mind/
 │       ├── secrets/secrets.py    # Keyring secret management
 │       ├── x_api/x_api.py       # X/Twitter search
 │       ├── agent_logs/agent_logs.py # Log file scanner
-│       └── current_time/current_time.py # Timezone-aware clock
+│       ├── current_time/current_time.py # Timezone-aware clock
+│       └── poll_broker/poll_broker.py # Polls broker for inter-mind task results (stdlib only)
 │
 ├── clients/                       # Thin client entry points
 │   ├── discord_bot.py            # Discord bot
@@ -206,6 +208,9 @@ A minimal `.env` remains for docker-compose interpolation (Neo4j, Planka only).
 | `POST` | `/hitl/request` | Submit HITL approval request |
 | `GET` | `/hitl/status/{token}` | Check HITL approval status |
 | `POST` | `/hitl/respond` | Respond to HITL approval request |
+| `POST` | `/broker/messages` | Send inter-mind message (async, returns immediately, wakes callee in background) |
+| `GET` | `/broker/messages` | Query messages by `conversation_id` (polling) |
+| `GET` | `/broker/conversations/{id}` | Get conversation with all messages |
 
 ## Adding New Tools
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ flowchart TD
     HV[Group Chat Bot] --> GW
     SC[Scheduler] --> GW
     GW --> SM[Session Manager]
+    GW --> BR[Message Broker\ncore/broker.py]
     SM -->|mind_id lookup| ADA[Ada · CLI Claude]
     SM -->|mind_id lookup| BOB[Bob · CLI Ollama]
     SM -->|mind_id lookup| BILBY[Bilby · SDK Claude Code]
     SM -->|mind_id lookup| NAG[Nagatha · Codex CLI]
     ADA & BOB & BILBY & NAG -->|stdio| INT[hive-mind-tools · internal MCP]
     ADA & BOB & BILBY & NAG -->|SSE| EXT[hive-mind-mcp · external MCP + HITL]
+    ADA & BOB & BILBY & NAG -->|POST /broker/messages| BR
+    BR -->|wakeup via session_mgr| SM
 ```
 
 Each client is a thin HTTP wrapper. The gateway routes sessions to a named mind by `mind_id`, spawning the appropriate subprocess. Each mind has its own soul, backend harness, and session history. Claude Code does the heavy lifting; clients just relay messages and render responses.

--- a/docs/architecture/gateway-architecture.md
+++ b/docs/architecture/gateway-architecture.md
@@ -43,6 +43,27 @@ The external MCP server is protected by a bearer token:
 - Bridged into env at gateway startup
 - Referenced in `.mcp.container.json` as `${MCP_AUTH_TOKEN}`
 
+## Message Broker
+
+`core/broker.py` provides asynchronous inter-mind messaging integrated directly into `server.py`. No separate container — it runs in the same process as the gateway and shares the session manager.
+
+**How it works:**
+- A mind POSTs to `POST /broker/messages` with `from`, `to`, `content`, and optional `rolling_summary`
+- The broker writes the message to `data/broker.db` (SQLite, separate from `sessions.db`) and returns immediately: `{ "status": "dispatched", "conversation_id": "...", "message_id": "..." }`
+- An `asyncio` background task wakes the callee: creates a session via `session_mgr`, sends a wakeup prompt, collects the full SSE response, and writes it back as a new message row
+- The caller's polling agent (`tools/stateless/poll_broker/poll_broker.py`) polls `GET /broker/messages?conversation_id=<id>` every 30 seconds until the callee's response appears
+- Callee minds never know about the broker — they just respond normally through their session
+
+**Startup recovery:** On gateway start, messages stranded in `dispatched` status (session died on restart) are marked `failed`. Messages in `pending` are returned for re-dispatch.
+
+**Broker endpoints:**
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| POST | /broker/messages | Send message, write to DB, kick off background wakeup |
+| GET | /broker/messages | Query messages by `conversation_id` |
+| GET | /broker/conversations/{id} | Get conversation with all messages |
+
 ## Key API Endpoints
 
 | Method | Path | Purpose |


### PR DESCRIPTION
## Summary
- **README.md**: added `Message Broker (core/broker.py)` node and inter-mind messaging arrows to the architecture mermaid diagram — minds POST to broker, broker wakes callee via session_mgr
- **CLAUDE.md**: added `core/broker.py` and `tools/stateless/poll_broker/poll_broker.py` to the file structure; added three `/broker/*` endpoints to the Gateway API table
- **docs/architecture/gateway-architecture.md**: added full Message Broker section covering the async background task design, wakeup flow, startup recovery, and all three endpoints

## What the broker does (for reviewers)
Minds send async messages to each other via `POST /broker/messages`. The gateway's background task wakes the callee (creates a session, sends a wakeup prompt, collects the SSE response), then writes the result back to `data/broker.db`. The caller's polling agent (`poll_broker.py`) polls `GET /broker/messages` until the response appears. Callee minds are unaware of the broker — they just respond normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)