### PR TITLE
fix: dynamic secret loading in mind containers

### DIFF
--- a/core/network_identity.py
+++ b/core/network_identity.py
@@ -29,8 +29,11 @@ async def resolve_container_name(ip: str) -> str | None:
         hostname, _aliases, _addrs = await asyncio.to_thread(
             socket.gethostbyaddr, ip
         )
-        # Strip domain suffix -- Docker DNS may return FQDN
+        # Strip domain suffix -- Docker DNS may return FQDN like "hive-mind-ada.hivemind"
         short_name = hostname.split(".")[0]
+        # Strip container name prefix -- Docker names containers as "hive-mind-<mind_id>"
+        if short_name.startswith("hive-mind-"):
+            short_name = short_name[len("hive-mind-"):]
         return short_name
     except (socket.herror, socket.gaierror, OSError) as exc:
         log.debug("Failed to resolve container name for IP %s: %s", ip, exc)

--- a/docs/multi-mind-architecture.md
+++ b/docs/multi-mind-architecture.md
@@ -205,7 +205,13 @@ The NS session manager calls the mind's HTTP endpoints instead of spawning local
 
 ### Secrets Access
 
-Mind containers do not store secrets. When a mind needs a credential (via MCP tools or skill code), it calls `GET http://server:8420/secrets/<key>` on the NS gateway. The NS identifies the caller by Docker network identity and checks the `secret_scopes` table.
+Mind containers do not store secrets locally. At startup, `mind_server.py` queries the NS for its scoped secret list (`GET /secrets/scopes/<mind_id>` — authenticated by network identity), fetches each secret, and injects them into the process environment. Harness subprocesses inherit these env vars.
+
+This means:
+- No hardcoded secret lists in `mind_server.py` — the NS scoping policy is the source of truth
+- New secrets are added by granting scope via `/add-mind` or `/update-mind`, then restarting the mind container
+- Secrets are held in memory only — never on disk inside the container
+- The `_ENV_MAP` in `mind_server.py` translates secret key names to env var names (e.g. `mcp_auth_token` → `MCP_AUTH_TOKEN`)
 
 ### Skills and Tools
 

--- a/mind_server.py
+++ b/mind_server.py
@@ -46,6 +46,68 @@ app = FastAPI(title=f"Mind Server: {MIND_ID}")
 # In-memory session tracking — no database
 _sessions: dict[str, dict] = {}  # session_id -> {"proc": process, "model": str, ...}
 
+# NS gateway URL — for secrets API calls
+_NS_URL = os.environ.get("HIVE_MIND_SERVER_URL", "http://server:8420")
+
+
+async def _fetch_secrets_on_startup():
+    """Fetch all scoped secrets from the NS and inject into environment.
+
+    Queries the NS for which secrets this mind is allowed to access,
+    then fetches each one. No hardcoded secret list — the scoping
+    policy in the NS determines what's available.
+    """
+    import aiohttp
+
+    # Map secret key names to environment variable names
+    _ENV_MAP = {
+        "gh_oauth_token": "GH_TOKEN",
+        "mcp_auth_token": "MCP_AUTH_TOKEN",
+    }
+
+    try:
+        async with aiohttp.ClientSession() as http:
+            # 1. Get the list of secrets this mind is scoped for
+            async with http.get(
+                f"{_NS_URL}/secrets/scopes/{MIND_ID}",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status != 200:
+                    log.debug("Could not fetch secret scopes (status=%d)", resp.status)
+                    return
+                scopes = await resp.json()
+                secret_keys = scopes.get("secret_keys", [])
+
+            if not secret_keys:
+                log.debug("No secrets scoped for mind %s", MIND_ID)
+                return
+
+            # 2. Fetch each scoped secret
+            for key in secret_keys:
+                try:
+                    async with http.get(
+                        f"{_NS_URL}/secrets/{key}",
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    ) as resp:
+                        if resp.status == 200:
+                            data = await resp.json()
+                            value = data.get("value")
+                            if value:
+                                env_name = _ENV_MAP.get(key, key.upper())
+                                os.environ[env_name] = value
+                                log.info("Secret %s loaded into %s", key, env_name)
+                except Exception:
+                    log.debug("Could not fetch secret %s", key)
+
+            log.info("Loaded %d secrets for mind %s", len(secret_keys), MIND_ID)
+    except Exception:
+        log.debug("Could not connect to NS for secrets (NS may not be ready yet)")
+
+
+@app.on_event("startup")
+async def startup_secrets():
+    await _fetch_secrets_on_startup()
+
 
 @app.get("/health")
 async def health():

--- a/server.py
+++ b/server.py
@@ -770,12 +770,31 @@ async def secrets_revoke_scopes(
 @app.get("/secrets/scopes/{mind_name}")
 async def secrets_list_scopes(
     mind_name: str,
+    request: Request,
     x_hitl_internal: str = Header(None),
 ):
-    """List all secret keys a mind is allowed to access. Requires HITL internal token."""
-    if not config.hitl_internal_token:
-        return JSONResponse({"error": "HITL not configured"}, status_code=500)
-    if x_hitl_internal != config.hitl_internal_token:
+    """List all secret keys a mind is allowed to access.
+
+    Two auth paths:
+    - HITL internal token (admin access to any mind's scopes)
+    - Network identity (a mind can list its own scopes)
+    """
+    # Path 1: HITL admin token
+    hitl_ok = (
+        config.hitl_internal_token
+        and x_hitl_internal == config.hitl_internal_token
+    )
+
+    # Path 2: Network identity — mind can list its own scopes
+    identity_ok = False
+    if not hitl_ok:
+        caller_ip = request.client.host if request.client else None
+        if caller_ip:
+            caller_name = await resolve_container_name(caller_ip)
+            if caller_name == mind_name:
+                identity_ok = True
+
+    if not hitl_ok and not identity_ok:
         return JSONResponse({"error": "unauthorized"}, status_code=401)
 
     db = app.state.broker_db


### PR DESCRIPTION
## Summary
- Mind containers now fetch all scoped secrets dynamically from the NS at startup
- No hardcoded secret list — NS scoping policy is the source of truth
- Fixed network identity resolver (hive-mind-ada → ada)
- Minds can now list their own scopes via network identity

## Test plan
- [x] Ada loads 16 secrets at startup
- [x] Calendar/MCP working via injected MCP_AUTH_TOKEN
- [x] gh auth working via injected GH_TOKEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)