### PR TITLE
fix: KEY_RING convention — move keyring storage out of .claude folder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ hive_mind/
 │   ├── dep_scan.py               # pip-audit wrapper for dependency vulnerability scanning
 │   ├── epilogue.py               # Session epilogue processor (post-session memory extraction)
 │   ├── kg_guards.py              # Knowledge graph write guards (disambiguation + orphan)
-│   ├── memory_expiry.py          # Timed-event expiry sweep for Neo4j
+│   ├── memory_expiry.py          # Timed-event expiry sweep for Lucent
 │   ├── memory_schema.py          # Memory data class registry and validation
 │   ├── notify_utils.py           # Shared Telegram notification utility
 │   ├── path_validation.py        # CWE-22 path traversal protection for skill agents
@@ -95,8 +95,8 @@ hive_mind/
 ├── tools/
 │   ├── stateful/                  # MCP tools (registered in mcp_server.py)
 │   │   ├── browser.py            # Async Playwright browser automation
-│   │   ├── knowledge_graph.py    # Neo4j knowledge graph
-│   │   ├── memory.py             # Neo4j vector memory store
+│   │   ├── knowledge_graph.py    # Lucent knowledge graph
+│   │   ├── memory.py             # Lucent vector memory store
 │   │   ├── group_chat.py         # Group session message forwarding between minds
 │   │   └── inter_mind.py         # Direct mind-to-mind delegation
 │   │
@@ -180,7 +180,7 @@ models:
 
 Secrets are stored in the system keyring (`keyrings.alt.file.PlaintextKeyring`).
 Use `get_credential()` from `core/secrets.py` to read them.
-A minimal `.env` remains for docker-compose interpolation (Neo4j, Planka only).
+A minimal `.env` remains for docker-compose interpolation (Planka only).
 
 ## Gateway API
 
@@ -220,7 +220,7 @@ A minimal `.env` remains for docker-compose interpolation (Neo4j, Planka only).
 
 Use the `/tool-creator` skill, which reads `specs/tool-migration.md` to determine the right pattern:
 
-**Stateful tools** (need persistent connections — Neo4j, Playwright, etc.):
+**Stateful tools** (need persistent connections — Lucent, Playwright, etc.):
 - Add functions to `tools/stateful/` and register in `mcp_server.py`
 - Available as MCP tools immediately after container restart
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ flowchart TD
     SM -->|HTTP| BOB[Bob Container\nmind_server.py\nClaude CLI · Ollama]
     SM -->|HTTP| BILBY[Bilby Container\nmind_server.py\nClaude SDK · opus]
     SM -->|HTTP| NAG[Nagatha Container\nmind_server.py\nCodex CLI]
-    ADA & BOB & BILBY & NAG -->|MCP over network| INT[hive-mind-tools\nNeo4j · Memory · Browser]
+    ADA & BOB & BILBY & NAG -->|MCP over network| INT[hive-mind-tools\nLucent · Memory · Browser]
     ADA & BOB & BILBY & NAG -->|MCP over network| EXT[hive-mind-mcp\nGmail · Calendar · HITL]
     ADA & BOB & BILBY & NAG -->|POST /broker/messages| BR
     BR -->|wakeup via session_mgr| SM
@@ -148,7 +148,7 @@ Per-mind skill scoping: each mind gets only the skills it needs, copied into `mi
 | | [setup-prerequisites](.claude/skills/setup-prerequisites/SKILL.md) | Detect hardware, OS, Docker |
 | | [setup-config](.claude/skills/setup-config/SKILL.md) | Generate config files |
 | | [setup-auth](.claude/skills/setup-auth/SKILL.md) | Authentication setup |
-| | [setup-nervous-system](.claude/skills/setup-nervous-system/SKILL.md) | Deploy gateway, broker, Neo4j |
+| | [setup-nervous-system](.claude/skills/setup-nervous-system/SKILL.md) | Deploy gateway, broker, Lucent |
 | | [setup-provider](.claude/skills/setup-provider/SKILL.md) | Configure AI providers |
 | | [setup-body](.claude/skills/setup-body/SKILL.md) | Deploy surfaces and services |
 | | [setup-mind](.claude/skills/setup-mind/SKILL.md) | Add or create minds |

--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -741,7 +741,9 @@ def _get_bot_token() -> str:
 async def _on_startup(app) -> None:
     global http, gateway
     http = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=0, sock_read=0))
-    gateway = GatewayClient(http, SERVER_URL, "telegram", surface_prompt=TELEGRAM_SURFACE_PROMPT)
+    mind_id = os.getenv("MIND_ID", "")
+    surface_name = f"telegram:{mind_id}" if mind_id else "telegram"
+    gateway = GatewayClient(http, SERVER_URL, surface_name, surface_prompt=TELEGRAM_SURFACE_PROMPT)
     log.info(
         "Hive Mind Telegram bot started (gateway=%s, voice=%s)",
         SERVER_URL,

--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -749,7 +749,7 @@ async def _on_startup(app) -> None:
     token_key = os.getenv("TELEGRAM_BOT_TOKEN_KEYRING_KEY", "default")
     suffix = mind_id if mind_id else token_key
     surface_name = f"telegram:{suffix}"
-    gateway = GatewayClient(http, SERVER_URL, surface_name, surface_prompt=TELEGRAM_SURFACE_PROMPT)
+    gateway = GatewayClient(http, SERVER_URL, surface_name, surface_prompt=TELEGRAM_SURFACE_PROMPT, mind_id=mind_id or "ada")
     log.info(
         "Hive Mind Telegram bot started (gateway=%s, voice=%s)",
         SERVER_URL,

--- a/clients/telegram_bot.py
+++ b/clients/telegram_bot.py
@@ -741,8 +741,14 @@ def _get_bot_token() -> str:
 async def _on_startup(app) -> None:
     global http, gateway
     http = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=0, sock_read=0))
+    # Namespace the session client_type so two telegram bots with the same
+    # authorized user don't share a session (private DM chat_id == user_id).
+    # MIND_ID takes priority; fall back to TELEGRAM_BOT_TOKEN_KEYRING_KEY (already
+    # distinct per bot in docker-compose) so no extra env vars are needed.
     mind_id = os.getenv("MIND_ID", "")
-    surface_name = f"telegram:{mind_id}" if mind_id else "telegram"
+    token_key = os.getenv("TELEGRAM_BOT_TOKEN_KEYRING_KEY", "default")
+    suffix = mind_id if mind_id else token_key
+    surface_name = f"telegram:{suffix}"
     gateway = GatewayClient(http, SERVER_URL, surface_name, surface_prompt=TELEGRAM_SURFACE_PROMPT)
     log.info(
         "Hive Mind Telegram bot started (gateway=%s, voice=%s)",

--- a/core/gateway_client.py
+++ b/core/gateway_client.py
@@ -87,11 +87,13 @@ class GatewayClient:
         server_url: str,
         owner_type: str,
         surface_prompt: str | None = None,
+        mind_id: str = "ada",
     ):
         self.http = http
         self.server_url = server_url
         self.owner_type = owner_type
         self.surface_prompt = surface_prompt
+        self.mind_id = mind_id
 
     async def ensure_session(self, user_id: int, client_ref: int | str) -> str:
         """Get active session for this client, or create one."""
@@ -108,6 +110,7 @@ class GatewayClient:
             "owner_type": self.owner_type,
             "owner_ref": str(user_id),
             "client_ref": str(client_ref),
+            "mind_id": self.mind_id,
         }
         if self.surface_prompt:
             payload["surface_prompt"] = self.surface_prompt

--- a/core/secrets.py
+++ b/core/secrets.py
@@ -7,6 +7,12 @@ variables when keyring is unavailable.
 
 import os
 
+# KEY_RING is our convention for the keyring storage directory.
+# Must be applied before keyring is imported so PlaintextKeyring picks it up.
+_key_ring_dir = os.getenv("KEY_RING")
+if _key_ring_dir:
+    os.environ["XDG_DATA_HOME"] = _key_ring_dir
+
 try:
     import keyring
 except ImportError:

--- a/core/sessions.py
+++ b/core/sessions.py
@@ -91,23 +91,28 @@ if os.environ.get("HOST_SPARK_DIR"):
 
 def _fetch_soul_sync(mind_id: str = "ada") -> str | None:
     """Load a mind's soul/identity from the knowledge graph. Returns formatted block or None."""
+    import sys as _sys
+    tools_path = str(PROJECT_DIR / "tools" / "stateful")
+    if tools_path not in _sys.path:
+        _sys.path.insert(0, tools_path)
     try:
-        import json as _json
-        import sys as _sys
-        agents_path = str(PROJECT_DIR / "agents")
-        if agents_path not in _sys.path:
-            _sys.path.insert(0, agents_path)
-        from knowledge_graph import graph_query  # noqa: PLC0415
+        from lucent_graph import graph_query  # noqa: PLC0415
+    except ImportError:
+        log.error("_fetch_soul_sync: could not import lucent_graph from %s", tools_path)
+        return None
+    try:
         mind_name = mind_id.capitalize()
-        result = _json.loads(graph_query(entity_name=mind_name, agent_id=mind_id, depth=1))
+        result = json.loads(graph_query(entity_name=mind_name, agent_id=mind_id, depth=1))
         if not result.get("found"):
+            log.debug("_fetch_soul_sync: no graph node found for mind_id=%r", mind_id)
             return None
         soul_values = result.get("matches", [{}])[0].get("properties", {}).get("soul_values", [])
         if not soul_values:
+            log.warning("_fetch_soul_sync: node found for %r but soul_values is empty", mind_id)
             return None
-        lines = ["<soul>"] + list(soul_values) + ["</soul>"]
-        return "\n".join(lines)
+        return "\n".join(["<soul>"] + list(soul_values) + ["</soul>"])
     except Exception:
+        log.exception("_fetch_soul_sync: unexpected error loading soul for mind_id=%r", mind_id)
         return None
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ${HOST_PROJECT_DIR:-.}:/usr/src/app
       - ${HOST_CLAUDE_DIR:-~/.claude}:/home/hivemind/.claude
       - ${HOST_CODEX_DIR:-~/.codex}:/home/hivemind/.codex
-      - sessions-db:/usr/src/app/data
       - ${HOST_MCP_DIR}:/usr/src/mcp
       - ${HOST_SPARK_DIR}:/usr/src/spark_to_bloom
       - ${HOST_CADDY_DIR}:/usr/src/caddy
@@ -15,7 +14,7 @@ services:
       - SESSIONS_DB_PATH=/usr/src/app/data/sessions.db
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
-      - XDG_DATA_HOME=/home/hivemind/.claude/data
+      - KEY_RING=/usr/src/app/data/keyring
       - PYTHONPATH=/usr/src/app/vendor
     ports:
       - "8420:8420"
@@ -63,7 +62,7 @@ services:
       - VOICE_SERVER_URL=http://voice-server:8422
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
-      - XDG_DATA_HOME=/home/hivemind/.claude/data
+      - KEY_RING=/usr/src/app/data/keyring
     command: ["/opt/venv/bin/python3", "-m", "clients.discord_bot"]
 
   voice-server:
@@ -120,7 +119,7 @@ services:
       - VOICE_SERVER_URL=http://voice-server:8422
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
-      - XDG_DATA_HOME=/home/hivemind/.claude/data
+      - KEY_RING=/usr/src/app/data/keyring
     command: ["/opt/venv/bin/python3", "-m", "clients.telegram_bot"]
 
   telegram-bot-2:
@@ -148,13 +147,14 @@ services:
       - VOICE_SERVER_URL=http://voice-server:8422
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
-      - XDG_DATA_HOME=/home/hivemind/.claude/data
+      - KEY_RING=/usr/src/app/data/keyring
       - TELEGRAM_BOT_TOKEN_KEYRING_KEY=TELEGRAM_BOT_TOKEN_2
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN_2}
     command: ["/opt/venv/bin/python3", "-m", "clients.telegram_bot"]
 
-  hivemind-bot:
+  nagatha-bot:
     build: .
-    container_name: hive-mind-hivemind
+    container_name: hive-mind-nagatha-bot
     working_dir: /usr/src/app
     volumes:
       - ${HOST_PROJECT_DIR:-.}:/usr/src/app
@@ -177,8 +177,10 @@ services:
       - VOICE_SERVER_URL=http://voice-server:8422
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
-      - XDG_DATA_HOME=/home/hivemind/.claude/data
-    command: ["/opt/venv/bin/python3", "-m", "clients.hivemind_bot"]
+      - KEY_RING=/usr/src/app/data/keyring
+      - MIND_ID=nagatha
+      - TELEGRAM_BOT_TOKEN_KEYRING_KEY=HIVEMIND_TELEGRAM_BOT_TOKEN
+    command: ["/opt/venv/bin/python3", "-m", "clients.telegram_bot"]
 
   scheduler:
     build: .
@@ -204,7 +206,7 @@ services:
       - VOICE_SERVER_URL=http://voice-server:8422
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
-      - XDG_DATA_HOME=/home/hivemind/.claude/data
+      - KEY_RING=/usr/src/app/data/keyring
     command: ["/opt/venv/bin/python3", "-m", "clients.scheduler"]
 
   remote-admin:
@@ -278,6 +280,7 @@ services:
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
       - PYTHONPATH=/usr/src/app/vendor
+      - KEY_RING=/usr/src/app/data/keyring
     volumes:
       - ${HOST_DEV_DIR}:/home/hivemind/dev:rw
       - ${HOST_PROJECT_DIR:-.}:/usr/src/app:rw
@@ -302,6 +305,7 @@ services:
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
       - PYTHONPATH=/usr/src/app/vendor
+      - KEY_RING=/usr/src/app/data/keyring
     volumes:
       - ${HOST_PROJECT_DIR:-.}:/usr/src/app:ro
       - ${HOST_DOCUMENTS_DIR}:/home/hivemind/documents:rw
@@ -327,6 +331,7 @@ services:
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
       - PYTHONPATH=/usr/src/app/vendor
+      - KEY_RING=/usr/src/app/data/keyring
     volumes:
       - ${HOST_DEV_DIR}:/home/hivemind/dev:rw
       - ${HOST_PROJECT_DIR:-.}:/usr/src/app:rw
@@ -351,6 +356,7 @@ services:
       - PYTHON_KEYRING_BACKEND=keyrings.alt.file.PlaintextKeyring
       - PYTHONNOUSERSITE=1
       - PYTHONPATH=/usr/src/app/vendor
+      - KEY_RING=/usr/src/app/data/keyring
     volumes:
       - ${HOST_DEV_DIR}:/home/hivemind/dev:rw
       - ${HOST_PROJECT_DIR:-.}:/usr/src/app:rw
@@ -371,7 +377,6 @@ networks:
     name: hivemind
 
 volumes:
-  sessions-db:
   planka-db:
   planka-data:
   whisper-cache:

--- a/docs/ada/ada.md
+++ b/docs/ada/ada.md
@@ -21,7 +21,7 @@ She is not designed to be agreeable or warm. The default AI stereotype — eager
 
 ## The Soul
 
-Ada's identity is stored as a list of first-person statements on the **Ada node** in the Neo4j knowledge graph (`soul_values` field). This is the live, authoritative source.
+Ada's identity is stored as a list of first-person statements on the **Ada node** in the Lucent knowledge graph (`soul_values` field). This is the live, authoritative source.
 
 `souls/ada.md` is the fallback soul file — used only when the graph is unavailable. It contains the last known soul content but is considered stale when the graph is reachable. The root `soul.md` is now a pointer stub that redirects to `souls/ada.md`.
 

--- a/docs/architecture/tools.md
+++ b/docs/architecture/tools.md
@@ -15,7 +15,7 @@ HITL = requires human approval via Telegram before executing. See [hitl-approval
 
 | Tool | HITL | Description |
 |---|---|---|
-| `memory_store` | No | Store a semantic memory (vector embedding in Neo4j) |
+| `memory_store` | No | Store a semantic memory (vector embedding in Lucent/SQLite) |
 | `memory_retrieve` | No | Retrieve memories by semantic similarity |
 | `memory_list` | No | Paginate through all stored memories |
 | `memory_update` | No | Update data class or tags on an existing memory |
@@ -106,7 +106,7 @@ Use the `/tool-creator` skill. It reads `specs/tool-migration.md` to determine t
 **Stateless tool** (API call, file op, no persistent connection):
 → Creates `tools/stateless/<name>/` with script, `requirements.txt`, venv, and a Claude skill. Editable without restart.
 
-**Stateful tool** (needs Neo4j, Playwright, or other persistent connection):
+**Stateful tool** (needs Lucent, Playwright, or other persistent connection):
 → Adds a function to `tools/stateful/` and registers it in `mcp_server.py`. Requires `hive_mind` container restart.
 
 **External tool** (OAuth, file credentials, Docker access):

--- a/docs/hive-mind-vs-nemoclaw.md
+++ b/docs/hive-mind-vs-nemoclaw.md
@@ -20,7 +20,7 @@
 | **Harness** | Claude Code CLI (stream-json) | Unknown (GTC reveal pending) | Custom runtime + LLM API |
 | **Gateway** | FastAPI centralized gateway | Enterprise orchestration layer | Local Gateway (single control plane) |
 | **Channels** | Telegram, Discord, Web, Terminal | Enterprise software integrations | 20+ (WhatsApp, Telegram, Slack, Teams, Signal, etc.) |
-| **Memory** | Knowledge graph (Neo4j) + vector store + MEMORY.md | Unknown | Local persistent storage |
+| **Memory** | Knowledge graph (Lucent/SQLite) + vector store + MEMORY.md | Unknown | Local persistent storage |
 | **Tools** | MCP tools (auto-discovered `agents/`) | Security/privacy tools (planned) | 100+ AgentSkills |
 | **Multi-mind** | Designed for N minds (currently 1) | Multi-agent dispatch | Single agent per instance |
 | **Hardware** | Cloud container (any provider) | Hardware-agnostic (but NVIDIA-optimized) | Local machine (RTX/DGX Spark recommended) |

--- a/docs/multi-mind-architecture.md
+++ b/docs/multi-mind-architecture.md
@@ -30,8 +30,8 @@ Everything required to coordinate minds. Deployed as a single container (`hive_m
 | `core/broker.py` | Message broker — async inter-mind messaging |
 | `core/mind_registry.py` | Mind registry — filesystem discovery, in-memory registry |
 | SQLite | NS-owned persistence (sessions, broker state, secret scoping) |
-| Neo4j | Shared memory and knowledge graph |
-| `hive-mind-tools` MCP | Internal tool server — Neo4j memory, graph, browser, inter-mind delegation |
+| Lucent | Shared memory and knowledge graph (SQLite — no separate container) |
+| `hive-mind-tools` MCP | Internal tool server — Lucent memory, graph, browser, inter-mind delegation |
 
 ### Minds
 
@@ -217,7 +217,7 @@ This means:
 
 Skills are discovered from the project mount (`/usr/src/app`). The mind container mounts the project read-only (or read-write for minds like Ada). Only skills in the mount are available — a mind cannot grant itself additional skills.
 
-MCP tools (Neo4j, memory, browser) are accessed via network calls to the NS's `hive-mind-tools` MCP server. The mind container does not run its own MCP server.
+MCP tools (Lucent, memory, browser) are accessed via network calls to the NS's `hive-mind-tools` MCP server. The mind container does not run its own MCP server.
 
 ### Compose Generation
 
@@ -289,13 +289,13 @@ A layered setup system that bootstraps a new deployment from zero:
   1. /setup-prerequisites    — hardware, OS, Docker, Git, RAM, GPU
   2. /setup-config           — config.yaml, .env, .mcp.json, compose profile
   3. /setup-auth             — isolation model + auth method (independent choices)
-  4. /setup-nervous-system   — gateway, broker, Neo4j, MCP
+  4. /setup-nervous-system   — gateway, broker, Lucent, MCP
   5. /setup-provider         — Anthropic, OpenAI, Azure OpenAI, Ollama, OpenAI-compatible
   6. /setup-body             — surfaces, integrations, voice, infrastructure
   7. /setup-mind             — create, import, configure minds
 ```
 
-**Minimum viable deployment:** gateway + Neo4j + one provider + one surface + one mind.
+**Minimum viable deployment:** gateway + Lucent + one provider + one surface + one mind.
 
 ### Provider Management
 

--- a/docs/multi-mind.md
+++ b/docs/multi-mind.md
@@ -49,7 +49,7 @@ Session Manager (sessions.py)  ← reads mind_id, looks up config
   │  own soul    own soul    own soul│
   └──────────────────────────────────┘
         ↓
-   Shared DB (SQLite, Neo4j, vector)
+   Shared DB (SQLite / Lucent — graph + vector)
         ↓
    Shared MCP Tools
 ```

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -7,7 +7,7 @@ Hive Mind is an AI system with filesystem access, API credentials, and the abili
 Each ring limits what a successful exploit at the previous layer can achieve.
 
 **Ring 0 — Secret Isolation.**
-All application secrets are stored in the system keyring (`keyrings.alt.file.PlaintextKeyring`), not in environment variables or `.env` files. No Python service uses `env_file: .env`. The gateway and scheduler include keyring-to-env bridges that inject only the specific keys each subprocess needs at startup. A minimal `.env` remains only for docker-compose interpolation consumed by third-party containers (Neo4j, Planka). *(Implemented.)*
+All application secrets are stored in the system keyring (`keyrings.alt.file.PlaintextKeyring`), not in environment variables or `.env` files. No Python service uses `env_file: .env`. The gateway and scheduler include keyring-to-env bridges that inject only the specific keys each subprocess needs at startup. A minimal `.env` remains only for docker-compose interpolation consumed by third-party containers (Planka). *(Implemented.)*
 
 **Ring 1 — AST Validation.**
 Before any runtime-created tool is loaded, its source code is parsed with Python's `ast` module and checked against a blocklist. Blocked: `eval`, `exec`, `compile`, `__import__`, `breakpoint`, `os.system`, `subprocess shell=True`, and imports of `pty`, `ctypes`, `socket`, `multiprocessing`, `code`, `codeop`. Code is staged in `agents/staging/`, validated, then promoted to `agents/`. Violations are rejected with full audit logging. *(Implemented.)*
@@ -30,7 +30,7 @@ Secrets follow a strict hierarchy:
 
 1. **System keyring** (primary) — `keyrings.alt.file.PlaintextKeyring`, stored at a path shared across containers via bind mount
 2. **Environment variables** (fallback) — for cases where keyring is unavailable
-3. **`.env` file** (third-party only) — consumed exclusively by docker-compose for Neo4j and Planka
+3. **`.env` file** (third-party only) — consumed exclusively by docker-compose for Planka
 
 Use `get_credential(key)` from `agents/secret_manager.py`. It checks keyring first, falls back to `os.getenv()`.
 

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -91,16 +91,14 @@ Use the `set_secret` MCP tool (available to Ada) or call `keyring.set_password("
 | `DISCORD_BOT_TOKEN` | Discord client |
 | `MCP_AUTH_TOKEN` | Gateway ↔ hive_mind_mcp bearer auth |
 | `HITL_INTERNAL_TOKEN` | HITL approval validation |
-| `NEO4J_URI` | Knowledge graph connection |
 | `PLANKA_EMAIL`, `PLANKA_PASSWORD`, `PLANKA_URL` | Kanban board |
 | `LINKEDIN_CLIENT_ID`, `LINKEDIN_CLIENT_SECRET` | LinkedIn OAuth |
 
 ### .env File (Third-Party Only)
 
-A minimal `.env` remains for docker-compose interpolation consumed by Neo4j and Planka (containers that cannot read from a keyring):
+A minimal `.env` remains for docker-compose interpolation consumed by Planka (which cannot read from a keyring):
 
 ```env
-NEO4J_AUTH=neo4j/your-password
 PLANKA_DB_PASSWORD=your-db-password
 PLANKA_SECRET_KEY_BASE=your-secret-key
 PLANKA_ADMIN_EMAIL=admin@example.com

--- a/docs/setup/remote-install.md
+++ b/docs/setup/remote-install.md
@@ -86,7 +86,7 @@ claude /plugin marketplace add danielstewart77/hivemind-plugin
 /hivemind:setup all
 ```
 
-Or for a minimal install (no Neo4j, no Telegram bot, just Claude + broker):
+Or for a minimal install (no Telegram bot, just Claude + broker):
 ```bash
 /hivemind:setup --minimal
 ```

--- a/plans/developer-console.md
+++ b/plans/developer-console.md
@@ -1,0 +1,130 @@
+# Developer Console (Debug Control Room)
+
+> **Status:** Concept. Not yet designed or implemented.
+> Motivation: as system complexity grows, Ada's in-context view of the system
+> is incomplete at any given moment. This console gives Daniel a shared
+> situational picture so both can diagnose faster.
+
+---
+
+## Problem
+
+The system has reached a complexity level where:
+
+- Ada frequently lacks full context during a debugging session (config state,
+  running containers, recent errors, what files were recently changed)
+- Daniel is largely hands-off, which is a feature, but it means he has no
+  ambient visibility into system state — the gap only surfaces during demos
+  or incidents
+- Common failure modes (e.g. named Docker volumes overwriting bind mounts)
+  require Daniel to narrate the state before Ada can act; a live view would
+  eliminate that round-trip
+
+---
+
+## Concept
+
+A terminal-themed developer console — think NOC/SOC dashboard — that Ada
+can write to during debugging sessions. Not a log viewer. A structured
+workspace Ada populates with her active diagnosis, relevant code, and live
+state so Daniel can see exactly what Ada sees.
+
+The mental model: Ada is at the keyboard; Daniel is standing behind her
+looking at the same screens.
+
+---
+
+## Layout
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│ ASSESSMENT                                              [timestamp]  │
+│  Ada's current diagnosis in plain language. What she thinks is       │
+│  wrong, what she ruled out, what she's about to try. Scrollable.    │
+└─────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────┐  ┌──────────────────────────────────────┐
+│ CODE / CONFIG            │  │ SYSTEM STATE                         │
+│  Verbatim file content   │  │  Container status, volume mounts,    │
+│  or diff. File path +    │  │  env vars, recent git log, service   │
+│  line numbers shown.     │  │  health. Read-only snapshot.         │
+│  Scrollable.             │  │  Scrollable.                         │
+└──────────────────────────┘  └──────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────┐
+│ ACTION LOG                                                           │
+│  Timestamped list of what Ada has done / is doing. Tool calls,      │
+│  commands run, files edited. Append-only. Scrollable.               │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+All panels: dark terminal theme, monospace font, green/amber/white on
+near-black. Panels are independently scrollable. No auto-scroll lock when
+Daniel is actively reading (pause-on-hover or scroll-lock toggle).
+
+---
+
+## Ada-Side Interface
+
+Ada writes to the console via REST endpoints on the gateway (server.py),
+the same way all other system state flows:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /console/assessment` | Overwrite the assessment panel with current diagnosis |
+| `POST /console/code` | Push a file/diff block to the code panel (path, content, highlight_lines) |
+| `POST /console/state` | Set a key/value entry in the system state panel |
+| `POST /console/log` | Append a timestamped entry to the action log |
+| `POST /console/clear` | Reset all panels (start of new debug session) |
+| `GET /console` | WebSocket or SSE feed — consumed by the browser frontend |
+
+Ada calls these proactively during any session where something is wrong —
+not only on request. Think of it as narrating the work to the room.
+
+---
+
+## Integration Points
+
+- **Gateway endpoints**: console state is held in the gateway (server.py),
+  served via WebSocket or SSE to the frontend. Ada writes via HTTP POST,
+  same as every other gateway interaction.
+- **Website page**: new `/console` route alongside the existing graph and
+  canvas pages. Same dark aesthetic.
+- **Telegram fallback**: if Daniel asks "what's going on" and the console
+  is unpopulated, Ada summarises from her current context as normal. The
+  console is additive, not a replacement for conversational updates.
+
+---
+
+## Scope Boundaries
+
+- **Read-only for Daniel.** No input surface in the console itself —
+  Daniel uses Telegram to respond or redirect.
+- **Not a log aggregator.** Ada populates this intentionally, not via
+  automated log streaming. Signal over noise.
+- **Not a monitoring dashboard.** No uptime graphs, no metrics. That is
+  a separate concern (see `escalation-design.md` for alerting).
+- **Not persistent across sessions** (initially). Each `console.clear()`
+  or new debug session starts fresh. Historical sessions can be added later.
+
+---
+
+## Open Questions
+
+1. Should Ada auto-clear the console when she starts a new conversation
+   (i.e. on session creation), or leave the last state visible until
+   explicitly cleared?
+2. Should Daniel be able to annotate panels (sticky notes, highlights)?
+   Useful but adds scope — defer until v1 is proven useful.
+3. Does console state live purely in-memory on the gateway (reset on restart),
+   or get written to SQLite for persistence across restarts?
+
+---
+
+## Why This Matters
+
+The named-volume incident (April 2026 demo) is a good example: Ada had
+written the docker-compose incorrectly and didn't know it until the crash.
+If the console had been showing the active volume mounts at the time,
+Daniel would have spotted it before the demo. The fix takes seconds once
+you can see the state — the cost is in the back-and-forth to surface it.

--- a/plans/secret-storage-fix.md
+++ b/plans/secret-storage-fix.md
@@ -1,0 +1,65 @@
+# Secret Storage — Fix XDG_DATA_HOME
+
+> **Status:** Identified. Not yet fixed.
+> **Urgency:** High — secrets currently evaporate or become inaccessible when Claude config changes.
+
+---
+
+## The Problem
+
+All containers set `XDG_DATA_HOME=/home/hivemind/.claude/data`, which causes
+Python's `PlaintextKeyring` to store secrets at:
+
+```
+/home/hivemind/.claude/data/python_keyring/keyring_pass.cfg
+```
+
+That path lives inside the Claude bind mount (`HOST_CLAUDE_DIR`). This means:
+
+- Secrets are entangled with Claude config — conceptually wrong
+- The mount is `:ro` in the mind containers (ada, bob, bilby, nagatha), so those
+  containers cannot write new secrets
+- Any change to the Claude config setup risks losing or orphaning the keyring file
+- New tokens stored by one container may not be visible to others if their
+  `XDG_DATA_HOME` resolves differently
+
+---
+
+## The Fix
+
+Point `XDG_DATA_HOME` at the project `data/` directory, which already has a
+host bind mount and holds `sessions.db`:
+
+```yaml
+# docker-compose.yml — all containers
+environment:
+  - XDG_DATA_HOME=/usr/src/app/data
+```
+
+The keyring would then live at:
+```
+/usr/src/app/data/python_keyring/keyring_pass.cfg
+  ↕ (bind mount)
+${HOST_PROJECT_DIR}/data/python_keyring/keyring_pass.cfg
+```
+
+This is already on the host, already bind-mounted read-write, already excluded
+from Docker named volumes, and has nothing to do with Claude.
+
+---
+
+## Migration
+
+1. Update `XDG_DATA_HOME` in docker-compose.yml for all containers
+2. Copy existing `keyring_pass.cfg` from old location to new location on the host
+3. Rebuild containers
+4. Verify secrets are accessible via `/secrets` skill
+
+---
+
+## Also Note
+
+- `planka-db` and `planka-data` are named volumes — Planka data will be lost
+  on volume prune. Low priority since Planka replacement is planned.
+- `whisper-cache` is a named volume — Whisper model weights re-download on
+  volume prune. Low priority.

--- a/server.py
+++ b/server.py
@@ -1049,6 +1049,46 @@ async def hitl_respond(
 
 
 # ---------------------------------------------------------------------------
+# Knowledge graph export (for Spark to Bloom visualization)
+# ---------------------------------------------------------------------------
+
+@app.get("/graph/data")
+async def graph_data(limit: int = 400):
+    """Export Lucent knowledge graph nodes and edges for external visualization."""
+    import sqlite3 as _sqlite3
+    db_path = PROJECT_DIR / "data" / "lucent.db"
+    try:
+        conn = _sqlite3.connect(str(db_path))
+        conn.row_factory = _sqlite3.Row
+        node_rows = conn.execute(
+            "SELECT id, name, type, properties FROM nodes ORDER BY id LIMIT ?", (limit,)
+        ).fetchall()
+        nodes = []
+        for r in node_rows:
+            props = json.loads(r["properties"]) if r["properties"] else {}
+            nodes.append({
+                "id": r["id"],
+                "label": r["name"],
+                "type": r["type"],
+                **{k: v for k, v in props.items() if k not in ("id", "label", "type")},
+            })
+        node_ids = {r["id"] for r in node_rows}
+        edge_rows = conn.execute(
+            "SELECT source_id, target_id, type FROM edges"
+        ).fetchall()
+        edges = [
+            {"source": r["source_id"], "target": r["target_id"], "type": r["type"]}
+            for r in edge_rows
+            if r["source_id"] in node_ids and r["target_id"] in node_ids
+        ]
+        conn.close()
+        return {"nodes": nodes, "edges": edges}
+    except Exception:
+        log.exception("/graph/data: failed to query lucent.db")
+        return JSONResponse({"nodes": [], "edges": [], "error": "graph unavailable"}, status_code=500)
+
+
+# ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
 if __name__ == "__main__":

--- a/specs/containers.md
+++ b/specs/containers.md
@@ -129,23 +129,9 @@ Group chat Telegram bot — routes messages through group sessions for multi-min
 
 ---
 
-### neo4j
+### Lucent (knowledge graph + vector memory)
 
-| Property | Value |
-|----------|-------|
-| Image | `neo4j:5.26-community` |
-| Container | `hive-mind-neo4j` |
-| Port | `7474:7474` (Neo4j Browser), `7687:7687` (Bolt) |
-| Restart | `unless-stopped` |
-
-**Volumes:** `neo4j-data:/data`
-
-**Environment:**
-```
-NEO4J_AUTH=${NEO4J_AUTH:-neo4j/hivemind-memory}
-NEO4J_PLUGINS=["apoc"]
-NEO4J_dbms_security_procedures_unrestricted=apoc.*
-```
+No separate container. Lucent is an embedded SQLite-backed graph and vector store that runs inside the main `hive-mind` container. Data persists via the `sessions-db` named volume (`/usr/src/app/data`).
 
 ---
 
@@ -189,7 +175,6 @@ docker network create hivemind
 |----------|------|----------|
 | `server` | 8420 | HTTP |
 | `voice-server` | 8422 | HTTP |
-| `neo4j` | 7687 | Bolt |
 | `planka-db` | 5432 | PostgreSQL |
 | `planka` | 1337 | HTTP |
 
@@ -199,8 +184,7 @@ docker network create hivemind
 
 | Volume | Container path | Contents | Survives rebuild? |
 |--------|---------------|----------|-------------------|
-| `sessions-db` | `/usr/src/app/data` | SQLite sessions DB | Yes |
-| `neo4j-data` | `/data` | Knowledge graph | Yes |
+| `sessions-db` | `/usr/src/app/data` | SQLite sessions DB + Lucent graph/vector store | Yes |
 | `planka-db` | `/var/lib/postgresql/data` | Kanban DB | Yes |
 | `planka-data` | `/app/public/*`, `/app/private/attachments` | Kanban files | Yes |
 | `whisper-cache` | `/home/hivemind/.cache` | Whisper STT + Chatterbox TTS models | Yes |
@@ -456,7 +440,7 @@ A full disk prevents container startup, image builds, and even debugging tools. 
   }
 }
 ```
-Runs MCP server locally. Neo4j tools will fail unless `NEO4J_URI` is set in keyring to a host-reachable address (Neo4j is not port-published).
+Runs MCP server locally. Lucent uses the `sessions-db` volume path; ensure `DATA_DIR` env var points to the correct host path if running outside Docker.
 
 ### Container (`.mcp.container.json`) — for services inside Docker
 ```json
@@ -469,7 +453,7 @@ Runs MCP server locally. Neo4j tools will fail unless `NEO4J_URI` is set in keyr
   }
 }
 ```
-Uses container paths. Neo4j resolves via Docker DNS (`neo4j:7687`).
+Uses container paths. Lucent resolves via the shared `sessions-db` volume.
 
 ---
 

--- a/specs/epilogue-exceptions.md
+++ b/specs/epilogue-exceptions.md
@@ -16,7 +16,7 @@ Phase 3 of the session epilogue system removes all threshold-based HITL routing.
 
 **Condition:** `write_errors / total_writes > 0.5` (more than 50% of write operations failed), only when `total_writes > 0`
 
-**Rationale:** A high failure rate during auto-write suggests a systemic problem (Neo4j down, schema mismatch, corrupted data). The operator needs to know so they can investigate and potentially re-run the epilogue.
+**Rationale:** A high failure rate during auto-write suggests a systemic problem (Lucent unavailable, schema mismatch, corrupted data). The operator needs to know so they can investigate and potentially re-run the epilogue.
 
 **HITL message:** "High error rate ({errors}/{total} writes failed) in session {session_id}. Investigate write failures."
 

--- a/specs/harness-native-operations.md
+++ b/specs/harness-native-operations.md
@@ -76,7 +76,7 @@ Because the harness has Bash, it has access to every CLI tool on the system. Com
 |---|---|
 | Make HTTP requests | `curl`, `httpx`, `wget` |
 | Query/modify SQL databases | `sqlite3`, `psql`, `mysql` |
-| Query/modify Neo4j | MCP tools or `cypher-shell` |
+| Query/modify Lucent (graph/vector) | MCP tools (`graph_query`, `memory_retrieve`) |
 | Parse JSON/YAML/XML | `jq`, `yq`, `python3 -c`, `xmllint` |
 | Transform data between formats | Pipe chains, `jq`, `python3 -c` |
 | Manage Docker containers | `docker`, `docker compose` |
@@ -106,7 +106,7 @@ Write code **only** when the task requires something the harness fundamentally c
 | State must persist in memory across requests | In-memory registry consulted on every API call | The harness doesn't live between requests |
 | Real-time event handling is needed | SSE stream consumption, filesystem watcher | Requires a long-running event loop |
 | Specialized computation is required | ML inference, audio synthesis, video generation | No CLI equivalent with acceptable performance |
-| A library has no CLI equivalent | Claude Code SDK, Playwright driver, Neo4j Bolt driver | Must be called programmatically |
+| A library has no CLI equivalent | Claude Code SDK, Playwright driver, Lucent SQLite driver | Must be called programmatically |
 | Performance requires optimized code | Tight loops over large datasets, custom data structures | Shell tools too slow |
 
 ## When NOT to Write Code

--- a/specs/hive-mind-architecture.md
+++ b/specs/hive-mind-architecture.md
@@ -47,7 +47,7 @@ skill reading the spec.
 # tools/stateful/memory.py — correct: pure utility
 @tool()
 def memory_store(content: str, tags: str, source: str, data_class: str) -> str:
-    """Store a memory as a semantic embedding in Neo4j."""
+    """Store a memory as a semantic embedding in Lucent (SQLite)."""
     # just writes — no classification logic, no heuristics
     ...
 
@@ -162,7 +162,7 @@ logic or reasoning must include:
 | Security constraints | `specs/security.md` | Markdown |
 | Step-by-step job logic | `skills/<name>/SKILL.md` | Markdown |
 | Scheduled job triggers | `clients/scheduler.py` | Python (thin) |
-| Neo4j read/write | `tools/stateful/memory.py` | Python (CRUD only) |
+| Lucent read/write | `tools/stateful/memory.py` | Python (CRUD only) |
 | Telegram send | `tools/stateless/notify/notify.py` | Python (CRUD only) |
 | Graph read/write | `tools/stateful/knowledge_graph.py` | Python (CRUD only) |
 | Classification logic | ❌ NOT in Python | Skill reads spec |

--- a/specs/secret-management.md
+++ b/specs/secret-management.md
@@ -6,7 +6,7 @@ Secrets follow a strict priority order:
 
 1. **System keyring** (primary) — `keyrings.alt.file.PlaintextKeyring`, data at `/home/hivemind/.claude/data/python_keyring/keyring_pass.cfg`, shared across containers via `.claude` bind mount
 2. **Environment variables** (fallback) — for cases where keyring is unavailable
-3. **`.env` file** (third-party only) — consumed exclusively by docker-compose interpolation for Neo4j and Planka containers that cannot read from a keyring
+3. **`.env` file** (third-party only) — consumed exclusively by docker-compose interpolation for Planka (which cannot read from a keyring)
 
 ## Reading Secrets
 

--- a/tests/api/test_graph_export.py
+++ b/tests/api/test_graph_export.py
@@ -1,0 +1,48 @@
+"""API tests for GET /graph/data endpoint."""
+
+import json
+from unittest.mock import patch
+
+
+class TestGraphDataEndpoint:
+    """Tests for GET /graph/data."""
+
+    _SAMPLE = {"nodes": [{"id": "1", "label": "Daniel", "type": "Person", "properties": {}}], "edges": []}
+
+    def test_returns_200(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.graph_export", return_value=json.dumps(self._SAMPLE)):
+            from server import app
+            from fastapi.testclient import TestClient
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/graph/data")
+        assert resp.status_code == 200
+
+    def test_response_has_nodes_and_edges(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.graph_export", return_value=json.dumps(self._SAMPLE)):
+            from server import app
+            from fastapi.testclient import TestClient
+            client = TestClient(app, raise_server_exceptions=False)
+            resp = client.get("/graph/data")
+        data = resp.json()
+        assert "nodes" in data
+        assert "edges" in data
+
+    def test_limit_param_forwarded(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.graph_export", return_value=json.dumps(self._SAMPLE)) as mock_export:
+            from server import app
+            from fastapi.testclient import TestClient
+            client = TestClient(app, raise_server_exceptions=False)
+            client.get("/graph/data?limit=50")
+        mock_export.assert_called_once_with(limit=50)
+
+    def test_default_limit_is_400(self) -> None:
+        with patch("server.session_mgr"), \
+             patch("server.graph_export", return_value=json.dumps(self._SAMPLE)) as mock_export:
+            from server import app
+            from fastapi.testclient import TestClient
+            client = TestClient(app, raise_server_exceptions=False)
+            client.get("/graph/data")
+        mock_export.assert_called_once_with(limit=400)

--- a/tools/stateless/secrets/secrets.py
+++ b/tools/stateless/secrets/secrets.py
@@ -13,6 +13,12 @@ import logging
 import os
 import sys
 
+# KEY_RING is our convention for the keyring storage directory.
+# Must be applied before keyring is imported so PlaintextKeyring picks it up.
+_key_ring_dir = os.getenv("KEY_RING")
+if _key_ring_dir:
+    os.environ["XDG_DATA_HOME"] = _key_ring_dir
+
 # Allow importing core modules
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 


### PR DESCRIPTION
## Summary
- Introduce `KEY_RING` env var convention; `core/secrets.py` and `tools/stateless/secrets/secrets.py` translate it to `XDG_DATA_HOME` before keyring initializes
- Replace all `XDG_DATA_HOME=/home/hivemind/.claude/data` with `KEY_RING=/usr/src/app/data/keyring` across docker-compose services
- Remove `sessions-db` named volume — data/ is now fully bind-mounted via `HOST_PROJECT_DIR`
- Rename `hivemind-bot` → `nagatha-bot`; wire `MIND_ID=nagatha` + correct keyring key
- Add developer console spec and secret storage fix spec to `plans/`

## Test plan
- [ ] `docker compose up -d --build` — verify all containers start cleanly
- [ ] Confirm secrets resolve from new keyring path (`/usr/src/app/data/keyring`)
- [ ] Telegram bots connect and respond