### PR TITLE
feat: Hive Mind Live Console — passive SSE stream + interrupt improvements

### DIFF
--- a/core/gateway_client.py
+++ b/core/gateway_client.py
@@ -15,7 +15,6 @@ from typing import AsyncGenerator
 
 import aiohttp
 
-_SKILLS_DIR = os.path.expanduser("~/.claude/skills")
 _locks: dict[int, asyncio.Lock] = {}
 _chat_queues: dict[int, asyncio.Queue] = {}
 
@@ -24,10 +23,28 @@ _chat_queues: dict[int, asyncio.Queue] = {}
 # Shared utilities
 # ---------------------------------------------------------------------------
 
+def _resolve_skills_dir() -> str:
+    """Return the active skills directory for the current harness."""
+    codex_home = os.environ.get("CODEX_HOME")
+    if codex_home:
+        return os.path.join(os.path.expanduser(codex_home), "skills")
+
+    claude_config_dir = os.environ.get("CLAUDE_CONFIG_DIR")
+    if claude_config_dir:
+        return os.path.join(os.path.expanduser(claude_config_dir), "skills")
+
+    default_codex_dir = os.path.expanduser("~/.codex/skills")
+    if os.path.isdir(default_codex_dir):
+        return default_codex_dir
+
+    return os.path.expanduser("~/.claude/skills")
+
+
 def get_skills() -> list[dict]:
     """Read all user-invocable skills from SKILL.md files."""
     skills = []
-    for path in sorted(glob.glob(os.path.join(_SKILLS_DIR, "*/SKILL.md"))):
+    skills_dir = _resolve_skills_dir()
+    for path in sorted(glob.glob(os.path.join(skills_dir, "*/SKILL.md"))):
         try:
             with open(path) as f:
                 content = f.read()
@@ -184,6 +201,20 @@ class GatewayClient:
             json=payload,
             timeout=sse_timeout,
         ) as resp:
+            if resp.status != 200:
+                error_text = ""
+                try:
+                    data = await resp.json()
+                    if isinstance(data, dict):
+                        error_text = str(data.get("error", ""))
+                    else:
+                        error_text = str(data)
+                except Exception:
+                    error_text = await resp.text()
+                error_text = error_text or f"HTTP {resp.status}"
+                raise RuntimeError(
+                    f"Gateway message request failed for session {session_id}: {error_text}"
+                )
             buf = ""
             async for chunk in resp.content.iter_any():
                 buf += chunk.decode()

--- a/core/sessions.py
+++ b/core/sessions.py
@@ -227,6 +227,7 @@ class SessionManager:
         self._mind_ids: dict[str, str] = {}  # session_id -> mind_id
         self._rc_procs: dict[str, asyncio.subprocess.Process] = {}  # RC subprocesses
         self._locks: dict[str, asyncio.Lock] = {}
+        self._observer_queues: dict[str, set[asyncio.Queue]] = {}
         self._reaper_task: asyncio.Task | None = None
         self._guard_task: asyncio.Task | None = None
         self.mind_registry = None  # Set by server.py after scan
@@ -379,6 +380,46 @@ class SessionManager:
         if not result:
             return None
         return await self._session_dict(result["session_id"])
+
+    async def stream_session_events(self, session_id: str):
+        """Yield live session events to passive observers."""
+        session = await self._get_row(session_id)
+        if not session:
+            raise ValueError(f"Session not found: {session_id}")
+
+        if session.get("status") == "closed":
+            yield {"type": "session_closed", "session_id": session_id}
+            return
+
+        queue: asyncio.Queue = asyncio.Queue(maxsize=200)
+        self._observer_queues.setdefault(session_id, set()).add(queue)
+
+        try:
+            while True:
+                event = await queue.get()
+                yield event
+                if event.get("type") == "session_closed":
+                    return
+        finally:
+            watchers = self._observer_queues.get(session_id)
+            if watchers is not None:
+                watchers.discard(queue)
+                if not watchers:
+                    self._observer_queues.pop(session_id, None)
+
+    async def _publish_session_event(self, session_id: str, event: dict[str, Any]) -> None:
+        """Fan out a session event to all passive observers."""
+        watchers = list(self._observer_queues.get(session_id, ()))
+        for queue in watchers:
+            if queue.full():
+                try:
+                    queue.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                continue
 
     async def activate_session(
         self, session_id: str, client_type: str, client_ref: str
@@ -542,6 +583,7 @@ class SessionManager:
                                     )
                                     break
 
+                                await self._publish_session_event(session_id, event)
                                 yield event
 
                                 now = time.time()
@@ -635,20 +677,30 @@ class SessionManager:
     # Interrupt (SIGINT without killing)
     # ------------------------------------------------------------------
     async def interrupt_session(self, session_id: str) -> dict:
-        """Forward an interrupt request to the mind container.
+        """Interrupt the current run and recycle the live process.
 
-        Sends SIGINT to the running subprocess without killing the session.
-        The session stays alive and ready for the next message.
+        This approximates an interactive escape keypress: stop the current
+        request, discard the stale subprocess, but keep the logical session
+        active so the next message can respawn with ``claude_sid``.
 
         Raises:
-            LookupError: If session_id is not in _procs.
-            ValueError: If the session has no mind container URL.
+            LookupError: If session_id does not exist in the database.
+            ValueError: If the live session has no mind container URL.
             RuntimeError: If the mind container is unreachable.
         """
-        if session_id not in self._procs:
+        session = await self._get_row(session_id)
+        if not session:
             raise LookupError(f"Session not found: {session_id}")
 
-        proc_info = self._procs[session_id]
+        proc_info = self._procs.get(session_id)
+        if not proc_info:
+            return {
+                "ok": True,
+                "session_id": session_id,
+                "message": "nothing_running",
+                "resume_ready": bool(session.get("claude_sid")),
+            }
+
         mind_url = proc_info.get("_mind_url")
         if not mind_url:
             raise ValueError(f"No mind container URL for session {session_id}")
@@ -660,11 +712,21 @@ class SessionManager:
                     f"{mind_url}/sessions/{session_id}/interrupt",
                     timeout=aiohttp.ClientTimeout(total=5),
                 ) as resp:
-                    return await resp.json()
+                    result = await resp.json()
         except aiohttp.ClientError as exc:
             raise RuntimeError(
                 f"Mind container unreachable for session {session_id}: {exc}"
             ) from exc
+
+        # The interrupted subprocess is no longer trustworthy. Remove the live
+        # process so the next message respawns cleanly against the saved thread.
+        await self._kill_process(session_id)
+
+        if not isinstance(result, dict):
+            result = {"ok": True}
+        result.setdefault("session_id", session_id)
+        result["resume_ready"] = bool(session.get("claude_sid"))
+        return result
 
     # ------------------------------------------------------------------
     # Kill / close
@@ -683,6 +745,10 @@ class SessionManager:
             "DELETE FROM active_sessions WHERE session_id = ?", (session_id,)
         )
         await self._db.commit()
+        await self._publish_session_event(
+            session_id,
+            {"type": "session_closed", "session_id": session_id},
+        )
 
         uptime = time.time() - session["created_at"]
         return {
@@ -1012,6 +1078,10 @@ class SessionManager:
                 for row in await rows.fetchall():
                     sid = row["id"]
                     await self._kill_process(sid)
+                    await self._publish_session_event(
+                        sid, {"type": "session_closed", "session_id": sid}
+                    )
+                    self._observer_queues.pop(sid, None)
                     await self._db.execute(
                         "UPDATE sessions SET status = 'idle' WHERE id = ?", (sid,)
                     )

--- a/server.py
+++ b/server.py
@@ -288,6 +288,20 @@ async def send_message(session_id: str, body: MessageRequest):
     return StreamingResponse(event_stream(), media_type="text/event-stream")
 
 
+@app.get("/sessions/{session_id}/events")
+async def stream_session_events(session_id: str):
+    """Read-only SSE stream for passive session observers."""
+    session = await session_mgr.get_session(session_id)
+    if not session:
+        return JSONResponse({"error": "Session not found"}, status_code=404)
+
+    async def event_stream():
+        async for event in session_mgr.stream_session_events(session_id):
+            yield f"data: {json.dumps(event)}\n\n"
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+
+
 # ---------------------------------------------------------------------------
 # Session management endpoints
 # ---------------------------------------------------------------------------

--- a/tests/api/test_session_events_endpoint.py
+++ b/tests/api/test_session_events_endpoint.py
@@ -1,0 +1,47 @@
+"""API tests for GET /sessions/{id}/events."""
+
+import json
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+
+async def _sample_stream(session_id: str):
+    assert session_id == "sess-1"
+    yield {"type": "assistant", "content": "hello"}
+    yield {"type": "session_closed", "session_id": session_id}
+
+
+class TestSessionEventsEndpoint:
+    """Passive observer endpoint tests."""
+
+    def test_events_returns_sse_stream(self):
+        with patch("server.session_mgr") as mock_mgr:
+            mock_mgr.get_session = AsyncMock(
+                return_value={"id": "sess-1", "status": "running"}
+            )
+            mock_mgr.stream_session_events = _sample_stream
+
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.get("/sessions/sess-1/events")
+
+            assert response.status_code == 200
+            assert "text/event-stream" in response.headers["content-type"]
+            assert (
+                f"data: {json.dumps({'type': 'assistant', 'content': 'hello'})}"
+                in response.text
+            )
+
+    def test_events_returns_404_for_missing_session(self):
+        with patch("server.session_mgr") as mock_mgr:
+            mock_mgr.get_session = AsyncMock(return_value=None)
+
+            from server import app
+
+            client = TestClient(app, raise_server_exceptions=False)
+            response = client.get("/sessions/missing/events")
+
+            assert response.status_code == 404
+            assert response.json()["error"] == "Session not found"

--- a/tests/integration/test_stop_interrupt_flow.py
+++ b/tests/integration/test_stop_interrupt_flow.py
@@ -1,7 +1,7 @@
 """Integration tests for the /stop interrupt signal chain.
 
-Covers: gateway session manager forwarding to mind container,
-and verifying session status is not changed by interrupt.
+Covers: gateway session manager forwarding to the mind container,
+recycling the live process, and reusing the saved thread on the next message.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -33,6 +33,8 @@ class TestInterruptSignalChain:
         """Gateway session manager forwards POST to the correct mind container URL."""
         mind_url = "http://mind-ada:8420"
         session_mgr._procs["sess-chain"] = {"_mind_url": mind_url}
+        session_mgr._get_row = AsyncMock(return_value={"id": "sess-chain", "claude_sid": "conv-1"})
+        session_mgr._kill_process = AsyncMock()
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -56,16 +58,50 @@ class TestInterruptSignalChain:
         # Verify the response is passed through
         assert result["ok"] is True
         assert result["session_id"] == "sess-chain"
+        assert result["resume_ready"] is True
+        session_mgr._kill_process.assert_awaited_once_with("sess-chain")
 
     @pytest.mark.asyncio
-    async def test_interrupt_does_not_change_session_status(self, session_mgr):
-        """After interrupt_session(), the session remains in _procs (not removed)."""
-        mind_url = "http://mind-ada:8420"
-        session_mgr._procs["sess-alive"] = {"_mind_url": mind_url}
+    async def test_send_message_respawns_with_saved_thread_after_recycle(self, session_mgr):
+        """If the live proc is gone but claude_sid exists, the next message respawns with resume."""
+        from core.sessions import SessionManager
+
+        class _AsyncBytesIter:
+            def __init__(self, items):
+                self._iter = iter(items)
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                try:
+                    return next(self._iter)
+                except StopIteration as exc:
+                    raise StopAsyncIteration from exc
+
+        session_mgr._db = AsyncMock()
+        session_mgr._locks = {}
+        session_mgr._procs = {}
+        session_mgr._mind_ids = {}
+        session_mgr._get_row = AsyncMock(return_value={
+            "id": "sess-resume",
+            "mind_id": "ada",
+            "model": "sonnet",
+            "autopilot": 0,
+            "claude_sid": "conv-1",
+            "summary": "Existing session",
+        })
+
+        async def fake_spawn(*args, **kwargs):
+            session_mgr._procs["sess-resume"] = {"_mind_url": "http://mind-ada:8420"}
+
+        session_mgr._spawn = AsyncMock(side_effect=fake_spawn)
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
-        mock_resp.json = AsyncMock(return_value={"ok": True, "session_id": "sess-alive"})
+        mock_resp.content = _AsyncBytesIter([
+            b'data: {"type":"result","result":"ok","session_id":"conv-1"}\n'
+        ])
 
         mock_session_ctx = AsyncMock()
         mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_ctx)
@@ -76,9 +112,8 @@ class TestInterruptSignalChain:
         ))
 
         with patch("aiohttp.ClientSession", return_value=mock_session_ctx):
-            await session_mgr.interrupt_session("sess-alive")
+            events = [event async for event in SessionManager.send_message(session_mgr, "sess-resume", "hello")]
 
-        # Session is still tracked (not removed from _procs)
-        assert "sess-alive" in session_mgr._procs
-        # The proc info is unchanged
-        assert session_mgr._procs["sess-alive"]["_mind_url"] == mind_url
+        session_mgr._spawn.assert_awaited_once()
+        assert session_mgr._spawn.await_args.kwargs["resume_sid"] == "conv-1"
+        assert events[-1]["type"] == "result"

--- a/tests/unit/test_gateway_client_interrupt.py
+++ b/tests/unit/test_gateway_client_interrupt.py
@@ -1,13 +1,14 @@
-"""Unit tests for GatewayClient.interrupt_session().
+"""Unit tests for GatewayClient helpers and interrupt_session().
 
 Covers: correct endpoint call and handling of error responses.
 """
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from core.gateway_client import GatewayClient
+from core.gateway_client import GatewayClient, _resolve_skills_dir, get_skills
 
 
 @pytest.fixture()
@@ -116,3 +117,73 @@ class TestGatewayClientFindActiveSession:
         result = await gateway.find_active_session(123, 456)
 
         assert result is None
+
+
+class TestGatewayClientQueryStream:
+    """GatewayClient.query_stream() error-path tests."""
+
+    @pytest.mark.asyncio
+    async def test_query_stream_raises_on_non_200_message_response(self, gateway):
+        """A non-200 /message response should surface an explicit error."""
+        gateway.ensure_session = AsyncMock(return_value="sess-1")
+
+        mock_resp = AsyncMock()
+        mock_resp.status = 500
+        mock_resp.json = AsyncMock(return_value={"error": "Process not running"})
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        gateway.http.post = MagicMock(return_value=mock_ctx)
+
+        with pytest.raises(RuntimeError, match="Process not running"):
+            async for _ in gateway.query_stream(123, 456, "hello"):
+                pass
+
+
+class TestGatewayClientSkillDiscovery:
+    """Skill directory resolution and parsing tests."""
+
+    def test_resolve_skills_dir_prefers_codex_home(self, monkeypatch, tmp_path: Path):
+        codex_home = tmp_path / "nagatha-codex"
+        claude_dir = tmp_path / "nagatha-claude"
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_dir))
+
+        assert _resolve_skills_dir() == str(codex_home / "skills")
+
+    def test_resolve_skills_dir_uses_claude_config_when_codex_missing(
+        self, monkeypatch, tmp_path: Path
+    ):
+        claude_dir = tmp_path / "ada-claude"
+        monkeypatch.delenv("CODEX_HOME", raising=False)
+        monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(claude_dir))
+
+        assert _resolve_skills_dir() == str(claude_dir / "skills")
+
+    def test_get_skills_reads_active_codex_home(self, monkeypatch, tmp_path: Path):
+        skills_dir = tmp_path / ".codex" / "skills" / "demo"
+        skills_dir.mkdir(parents=True)
+        skill_path = skills_dir / "SKILL.md"
+        skill_path.write_text(
+            "---\n"
+            "name: demo\n"
+            "description: Demo skill\n"
+            "user-invocable: true\n"
+            "argument-hint: <arg>\n"
+            "---\n"
+            "\n"
+            "# Demo\n"
+        )
+        monkeypatch.setenv("CODEX_HOME", str(tmp_path / ".codex"))
+        monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+        skills = get_skills()
+
+        assert skills == [
+            {
+                "name": "demo",
+                "description": "Demo skill",
+                "argument_hint": "<arg>",
+            }
+        ]

--- a/tests/unit/test_session_interrupt.py
+++ b/tests/unit/test_session_interrupt.py
@@ -1,7 +1,7 @@
 """Unit tests for SessionManager.interrupt_session().
 
-Covers: forwarding interrupt to mind container, session not found,
-missing mind_url, and mind container unreachable.
+Covers: forwarding interrupt, recycling the live process, missing sessions,
+missing mind_url, and unreachable mind containers.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -29,9 +29,11 @@ class TestInterruptSession:
     """SessionManager.interrupt_session() tests."""
 
     @pytest.mark.asyncio
-    async def test_interrupt_session_forwards_to_mind_container(self, session_mgr):
-        """interrupt_session() POSTs to {mind_url}/sessions/{id}/interrupt and returns the response."""
+    async def test_interrupt_session_recycles_live_process(self, session_mgr):
+        """interrupt_session() POSTs interrupt, then clears the stale live process."""
         session_mgr._procs["sess-1"] = {"_mind_url": "http://mind-ada:8420"}
+        session_mgr._get_row = AsyncMock(return_value={"id": "sess-1", "claude_sid": "conv-1"})
+        session_mgr._kill_process = AsyncMock()
 
         mock_resp = AsyncMock()
         mock_resp.status = 200
@@ -48,21 +50,24 @@ class TestInterruptSession:
         with patch("aiohttp.ClientSession", return_value=mock_session_ctx):
             result = await session_mgr.interrupt_session("sess-1")
 
-        assert result == {"ok": True, "session_id": "sess-1"}
+        assert result == {"ok": True, "session_id": "sess-1", "resume_ready": True}
         mock_session_ctx.post.assert_called_once()
         call_url = mock_session_ctx.post.call_args[0][0]
         assert call_url == "http://mind-ada:8420/sessions/sess-1/interrupt"
+        session_mgr._kill_process.assert_awaited_once_with("sess-1")
 
     @pytest.mark.asyncio
     async def test_interrupt_session_not_found_raises_lookup_error(self, session_mgr):
-        """interrupt_session() raises LookupError when session_id not in _procs."""
+        """interrupt_session() raises LookupError when session is not in the database."""
+        session_mgr._get_row = AsyncMock(return_value=None)
         with pytest.raises(LookupError, match="Session not found"):
             await session_mgr.interrupt_session("nonexistent")
 
     @pytest.mark.asyncio
     async def test_interrupt_session_no_mind_url_raises_value_error(self, session_mgr):
         """interrupt_session() raises ValueError when _procs entry has no _mind_url."""
-        session_mgr._procs["sess-no-url"] = {}
+        session_mgr._procs["sess-no-url"] = {"_placeholder": True}
+        session_mgr._get_row = AsyncMock(return_value={"id": "sess-no-url", "claude_sid": None})
 
         with pytest.raises(ValueError, match="No mind container URL"):
             await session_mgr.interrupt_session("sess-no-url")
@@ -72,6 +77,7 @@ class TestInterruptSession:
         """interrupt_session() raises RuntimeError when the mind container HTTP call fails."""
         import aiohttp
         session_mgr._procs["sess-down"] = {"_mind_url": "http://mind-ada:8420"}
+        session_mgr._get_row = AsyncMock(return_value={"id": "sess-down", "claude_sid": None})
 
         mock_session_ctx = AsyncMock()
         mock_session_ctx.__aenter__ = AsyncMock(return_value=mock_session_ctx)
@@ -81,3 +87,17 @@ class TestInterruptSession:
         with patch("aiohttp.ClientSession", return_value=mock_session_ctx):
             with pytest.raises(RuntimeError, match="Mind container unreachable"):
                 await session_mgr.interrupt_session("sess-down")
+
+    @pytest.mark.asyncio
+    async def test_interrupt_session_returns_nothing_running_when_proc_missing(self, session_mgr):
+        """interrupt_session() preserves the logical session even if no live proc exists."""
+        session_mgr._get_row = AsyncMock(return_value={"id": "sess-idle", "claude_sid": "conv-1"})
+
+        result = await session_mgr.interrupt_session("sess-idle")
+
+        assert result == {
+            "ok": True,
+            "session_id": "sess-idle",
+            "message": "nothing_running",
+            "resume_ready": True,
+        }

--- a/tests/unit/test_session_observer_events.py
+++ b/tests/unit/test_session_observer_events.py
@@ -1,0 +1,45 @@
+"""Unit tests for passive session observer fan-out."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class TestSessionObserverEvents:
+    """Verify SessionManager observer subscriptions receive live events."""
+
+    @pytest.mark.asyncio
+    async def test_stream_session_events_yields_published_event(self):
+        from core.models import ModelRegistry
+        from core.sessions import SessionManager
+
+        registry = MagicMock(spec=ModelRegistry)
+        mgr = SessionManager(registry)
+        mgr._get_row = AsyncMock(return_value={"id": "sess-1", "status": "running"})
+
+        async def consume_one():
+            async for event in mgr.stream_session_events("sess-1"):
+                return event
+
+        task = asyncio.create_task(consume_one())
+        await asyncio.sleep(0)
+        await mgr._publish_session_event("sess-1", {"type": "assistant", "content": "hello"})
+
+        event = await asyncio.wait_for(task, timeout=1)
+        assert event == {"type": "assistant", "content": "hello"}
+
+    @pytest.mark.asyncio
+    async def test_stream_session_events_returns_closed_event_for_closed_session(self):
+        from core.models import ModelRegistry
+        from core.sessions import SessionManager
+
+        registry = MagicMock(spec=ModelRegistry)
+        mgr = SessionManager(registry)
+        mgr._get_row = AsyncMock(return_value={"id": "sess-2", "status": "closed"})
+
+        events = []
+        async for event in mgr.stream_session_events("sess-2"):
+            events.append(event)
+
+        assert events == [{"type": "session_closed", "session_id": "sess-2"}]


### PR DESCRIPTION
## Summary

- **Passive observer SSE stream** — `GET /sessions/{id}/events` endpoint exposes a read-only fan-out stream so Spark to Bloom (or any client) can watch session events without injecting prompts
- **Observer cleanup on idle reap** — idle sessions now publish `session_closed` to all watching queues and remove the queue set
- **Interrupt improvements** — `interrupt_session()` now recycles the live process after SIGINT so the next message respawns cleanly against the saved `claude_sid` thread; adds `resume_ready` field to response
- **Skills dir resolution** — `_resolve_skills_dir()` makes gateway_client.py compatible with both Claude and Codex harnesses via env vars
- **Gateway error clarity** — `query()` now surfaces structured error messages instead of a bare status code

Note: Spark to Bloom auth layer (SQLite bcrypt auth, `/console`, `/login`, proxy routes) is implemented in the spark_to_bloom repo — companion PR merged separately.

## Test plan

- [x] `tests/unit/test_session_observer_events.py` — fan-out queue logic
- [x] `tests/api/test_session_events_endpoint.py` — SSE endpoint 404 and stream
- [x] `tests/unit/test_session_interrupt.py` — updated for recycle + resume_ready
- [x] `tests/unit/test_gateway_client_interrupt.py` — skills dir + error handling
- [x] `tests/integration/test_stop_interrupt_flow.py` — end-to-end interrupt + recycle

All 20 targeted tests pass. mypy + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)