### PR TITLE
Fix SSE truncation: drop total timeout cap on mind-bound requests

### DIFF
--- a/core/sessions.py
+++ b/core/sessions.py
@@ -554,7 +554,11 @@ class SessionManager:
                         async with http.post(
                             f"{mind_url}/sessions/{session_id}/message",
                             json={"content": stamped_content, "images": images},
-                            timeout=aiohttp.ClientTimeout(total=600),
+                            # Long Claude/Codex turns (heavy thinking + tool use) can exceed
+                            # 10 min. Cap on no-data-received instead of total elapsed so we
+                            # don't truncate legitimate long turns (which the bot then sees
+                            # as ClientPayloadError / TransferEncodingError mid-stream).
+                            timeout=aiohttp.ClientTimeout(total=None, sock_read=600),
                         ) as resp:
                             if resp.status == 404:
                                 # Session doesn't exist on mind container — respawn


### PR DESCRIPTION
## Summary

The gateway's request to each mind container had a hard 10-min total timeout (\`ClientTimeout(total=600)\`). Long turns exceeded it; aiohttp aborted the upstream connection mid-response; clients (Telegram bot, Discord bot, anything consuming the SSE stream) saw the truncation as:

\`\`\`
aiohttp.client_exceptions.ClientPayloadError: Response payload is not completed:
  <TransferEncodingError: 400, message='Not enough data to satisfy transfer length header.'>
\`\`\`

This was the symptom Daniel was seeing periodically through the Telegram path — and the same pattern that left Nagatha broker turns silently dropping their final result (see \`memory-system-fixes\` backlog item *nagatha-broker-codex-repair-loose-end*).

## Change

\`core/sessions.py:557\`:

\`\`\`diff
-timeout=aiohttp.ClientTimeout(total=600),
+timeout=aiohttp.ClientTimeout(total=None, sock_read=600),
\`\`\`

Fail only on no-data-received-for-10-min, not on absolute elapsed. Mirrors the pattern already used in \`core/gateway_client.py: query_stream\` for the bot side.

## Test plan

- [ ] Drive a long turn through one of the minds (Ada, Bob, Bilby, Nagatha) that previously hit 10+ min and would have raised \`ClientPayloadError\` in the bot logs
- [ ] Confirm the response completes naturally
- [ ] Confirm the bot still detects a true silent stall (kill the mind container mid-turn — should fail after ~10 min of silence)