### PR TITLE
fix: pass mind voice_id from Discord bot to voice server

### DIFF
--- a/clients/discord_bot.py
+++ b/clients/discord_bot.py
@@ -60,9 +60,16 @@ def _is_allowed_channel(channel_id: int) -> bool:
 # Voice / TTS helpers
 # ---------------------------------------------------------------------------
 
-async def _tts(text: str) -> bytes:
-    """POST text to voice-server /tts, return OGG audio bytes."""
-    async with http.post(f"{VOICE_SERVER_URL}/tts", json={"text": text}) as resp:
+async def _tts(text: str, voice_id: str) -> bytes:
+    """POST text to voice-server /tts, return OGG audio bytes.
+
+    `voice_id` selects the per-mind reference clip on the voice server
+    (resolves to `minds/<voice_id>/voice_ref.wav`). Without it the voice
+    server falls back to chatterbox's built-in default voice.
+    """
+    async with http.post(
+        f"{VOICE_SERVER_URL}/tts", json={"text": text, "voice_id": voice_id}
+    ) as resp:
         if resp.status != 200:
             raise RuntimeError(f"TTS error {resp.status}: {await resp.text()}")
         return await resp.read()
@@ -90,7 +97,7 @@ async def _play_tts_for_member(member: discord.Member | discord.User, text: str)
         return
 
     try:
-        ogg_bytes = await _tts(text)
+        ogg_bytes = await _tts(text, voice_id=gateway.mind_id)
     except Exception:
         log.exception("TTS synthesis failed")
         return


### PR DESCRIPTION
## Summary
Every mind on Discord was speaking with chatterbox's generic default voice instead of its own per-mind reference. Telegram and the hivemind group bot were already wired correctly; only Discord was dropping the \`voice_id\`.

## Root cause
\`clients/discord_bot.py:_tts\` posted only \`{"text": text}\` to \`/tts\`. The voice server's \`TTSRequest\` defaults \`voice_id\` to \`"default"\`, then \`_resolve_voice_ref("default")\` returned \`None\` (no \`minds/default/voice_ref.wav\`), so chatterbox synthesized with no \`audio_prompt_path\` — i.e., its built-in default voice.

## Fix
- \`_tts\` now requires \`voice_id\` and forwards it in the request body.
- The single call site (\`_play_tts_for_member\`) passes \`gateway.mind_id\`. Discord's \`GatewayClient\` is constructed without an explicit \`mind_id\` so it defaults to \`"ada"\` — same as before, just reaching the voice server now.

If a future surface points the Discord gateway at a different mind (or splits into one bot per mind), \`gateway.mind_id\` will follow that automatically.

## Test plan
- [ ] Restart \`hive-mind-discord\` container and DM the bot from voice — confirm Ada's voice plays, not the generic default
- [ ] If you also hear the default voice on Telegram for any mind, that's a separate issue — likely \`MIND_ID\` not set in that bot's container env, or the voice container can't see \`/usr/src/app/minds/<mind>/voice_ref.wav\`. Worth a quick \`docker exec hive-mind-voice ls /usr/src/app/minds/*/voice_ref.wav\` to rule out the mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)