### PR TITLE
feat(scheduler): also discover scheduled skills under .codex/skills

### DIFF
--- a/bots/scheduler.py
+++ b/bots/scheduler.py
@@ -1,8 +1,9 @@
 """Hive Mind Scheduler — cron-driven proactive tasks.
 
 Discovers scheduled skills from each mind's `.claude/skills/*/SKILL.md`
-(via frontmatter `schedule:` field), runs them on their cron, and delivers
-the result as a voice note (with text fallback) via Telegram.
+or `.codex/skills/*/SKILL.md` (via frontmatter `schedule:` field), runs
+them on their cron, and delivers the result as a voice note (with text
+fallback) via Telegram.
 
 Each fire creates a fresh session, sends the skill invocation, reads the
 response, and kills the session. Sessions are not resumed across fires —

--- a/core/scheduled_skills.py
+++ b/core/scheduled_skills.py
@@ -1,8 +1,8 @@
 """Scheduled skill discovery.
 
-Walks every mind's `.claude/skills/*/SKILL.md`, extracts skills that declare
-a `schedule:` cron expression in frontmatter, and returns them as a flat
-list the scheduler can register with APScheduler.
+Walks every mind's `.claude/skills/*/SKILL.md` and `.codex/skills/*/SKILL.md`,
+extracts skills that declare a `schedule:` cron expression in frontmatter,
+and returns them as a flat list the scheduler can register with APScheduler.
 
 Schedule lives on the skill, not in `config.yaml`. Adding or removing a
 scheduled task is the same operation as adding or removing a skill.
@@ -79,8 +79,12 @@ def discover_scheduled_skills(minds_root: Path) -> list[ScheduledSkill]:
     if not minds_root.is_dir():
         return found
 
-    for skill_md in sorted(minds_root.glob("*/.claude/skills/*/SKILL.md")):
-        # minds_root/<mind_name>/.claude/skills/<skill_name>/SKILL.md
+    skill_files = sorted(
+        list(minds_root.glob("*/.claude/skills/*/SKILL.md"))
+        + list(minds_root.glob("*/.codex/skills/*/SKILL.md"))
+    )
+    for skill_md in skill_files:
+        # minds_root/<mind_name>/(.claude|.codex)/skills/<skill_name>/SKILL.md
         try:
             mind_name = skill_md.relative_to(minds_root).parts[0]
             skill_name = skill_md.parent.name

--- a/tests/unit/test_scheduled_skills.py
+++ b/tests/unit/test_scheduled_skills.py
@@ -25,12 +25,13 @@ def _write_skill(
     skill_name: str,
     frontmatter: str,
     body: str = "skill body",
+    harness: str = ".claude",
 ) -> Path:
     mind_dir = minds_root / mind_name
     mind_dir.mkdir(parents=True, exist_ok=True)
     uuid_ = _TEST_UUIDS.get(mind_name, f"00000000-0000-0000-0000-{mind_name:>012s}")
     (mind_dir / "runtime.yaml").write_text(f"name: {mind_name}\nmind_id: {uuid_}\n")
-    skill_dir = mind_dir / ".claude" / "skills" / skill_name
+    skill_dir = mind_dir / harness / "skills" / skill_name
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_md = skill_dir / "SKILL.md"
     skill_md.write_text(f"---\n{frontmatter}\n---\n\n{body}\n")
@@ -115,6 +116,27 @@ def test_skips_when_runtime_yaml_missing(tmp_path: Path, caplog: pytest.LogCaptu
     )
     assert discover_scheduled_skills(tmp_path) == []
     assert any("no mind_id" in r.message.lower() for r in caplog.records)
+
+
+def test_discovers_codex_harness_skills(tmp_path: Path):
+    """Codex-harness minds keep their skills under `.codex/skills/` instead
+    of `.claude/skills/`, but the SKILL.md schema is identical and the
+    scheduler must walk both."""
+    _write_skill(
+        tmp_path, "ada", "morning",
+        "name: morning\nschedule: \"0 7 * * *\"",
+        harness=".claude",
+    )
+    _write_skill(
+        tmp_path, "bob", "evening",
+        "name: evening\nschedule: \"0 19 * * *\"",
+        harness=".codex",
+    )
+    found = discover_scheduled_skills(tmp_path)
+    by_skill = {(s.mind_name, s.skill_name): s for s in found}
+    assert set(by_skill) == {("ada", "morning"), ("bob", "evening")}
+    assert by_skill[("bob", "evening")].mind_id == _TEST_UUIDS["bob"]
+    assert by_skill[("bob", "evening")].cron == "0 19 * * *"
 
 
 def test_quoted_and_unquoted_cron_values_both_accepted(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Scheduler discovery previously globbed only `minds/*/.claude/skills/*/SKILL.md`, so codex-harness minds (Bilby, Nagatha) could not register cron jobs even with a `schedule:` line in frontmatter.
- Adds a parallel `.codex/skills/*/SKILL.md` glob and concatenates results. Same frontmatter parser, same mind-name extraction.
- Updates module + scheduler docstrings to document both harness paths.
- Adds a unit test that exercises a `.codex`-rooted skill alongside a `.claude`-rooted one.

## Test plan
- [x] `venv/bin/python -m pytest tests/unit/test_scheduled_skills.py -q` → 11 passed