### PR TITLE
docs: per-mind hooks, persona anchor, voice-id resolution

### DIFF
--- a/docs/ada/VOICE_IDENTITY.md
+++ b/docs/ada/VOICE_IDENTITY.md
@@ -27,19 +27,23 @@ clip means Chatterbox falls back to its default untrained voice.
 
 ### Voice Reference Resolution
 
-The voice server resolves a `voice_id` to a file path via `_resolve_voice_ref(voice_id)`:
+The voice server resolves a `voice_id` to a file path via `_resolve_voice_ref(voice_id)`.
+The resolver accepts either form:
 
-```
-minds/{voice_id}/voice_ref.wav
-```
+- **Short name** — `voice_id="ada"` resolves directly to `minds/ada/voice_ref.wav`.
+- **UUID** — `voice_id="565e5a66-d20c-4266-872a-3268c4c894fc"` is looked up against
+  the mind-id → short-name table at startup, then resolves to
+  `minds/<short_name>/voice_ref.wav`.
 
-For example, Ada's reference is at `minds/ada/voice_ref.wav` inside the container. The voice
-server container mounts the full hive_mind project directory at `/usr/src/app`, so it has
-read access to all `minds/*/voice_ref.wav` files automatically — no extra mounts needed for
-minds that live inside hive_mind.
+Either form yields the same file. The dual lookup lets callers pass the
+canonical `MIND_ID` (UUID) without needing to know each mind's display name.
 
-If `voice_ref.wav` is not found for the requested `voice_id`, the function returns `None` and
-Chatterbox synthesises using its default voice (no cloning).
+The voice server container mounts the full hive_mind project directory at `/usr/src/app`,
+so it has read access to all `minds/*/voice_ref.wav` files automatically — no extra mounts
+needed for minds that live inside hive_mind.
+
+If `voice_ref.wav` is not found for the requested `voice_id`, the function returns `None`
+and Chatterbox synthesises using its default voice (no cloning).
 
 ### TTS Request
 
@@ -69,8 +73,12 @@ Response: `audio/ogg` (Opus-encoded, ready for Telegram voice notes).
 Every mind that wants a cloned voice needs **one file** inside hive_mind:
 
 ```
-minds/{mind_id}/voice_ref.wav
+minds/{short_name}/voice_ref.wav
 ```
+
+One mind, one voice clip. The folder name is the mind's short name
+(`ada`, `bob`, `bilby`, `nagatha`, `skippy`); UUID-keyed callers route
+to the same file via the resolver's id-to-name table.
 
 For minds that live entirely within hive_mind (Ada, Bob, Bilby, Nagatha), this file lives
 alongside their `implementation.py`, `.claude/`, etc.

--- a/docs/architecture/mind-folder-contract.md
+++ b/docs/architecture/mind-folder-contract.md
@@ -29,15 +29,22 @@ minds/<any_name>/
 
 ## Per-harness hook registration
 
-The same four bash hooks (`auto_remember.sh`, `session_start_bootstrap.sh`, `contextual_retrieval.sh`, `rotation_check.sh`) are shared at `minds/_shared/hooks/`. Each mind's harness loads them differently:
+The three hooks that carry capture, retrieval, and rotation
+(`auto_remember.sh`, `contextual_retrieval.sh`, `rotation_check.py`)
+live at `minds/_shared/hooks/`. Codex-CLI minds keep per-mind copies of
+the same scripts under their own `.codex/hooks/` directory because the
+Codex hook config addresses scripts by absolute path. Each mind's
+harness loads them differently:
 
 | Harness | Config file | How |
 |---|---|---|
-| **Claude CLI** (Ada, Bob) | `.claude/settings.json` | Native — JSON `hooks` block |
-| **Claude SDK** (Bilby) | `.claude/settings.json` | Loaded via `ClaudeCodeOptions(settings="<path>")` |
-| **Codex CLI** (Nagatha) | `.codex/config.toml` | `[features] codex_hooks = true` + `[[hooks.X]]` blocks |
+| **Claude CLI** (Ada, Bob) | `.claude/settings.json` | Native — JSON `hooks` block, scripts loaded from `minds/_shared/hooks/` |
+| **Codex CLI** (Bilby, Nagatha) | `.codex/config.toml` | `[features] codex_hooks = true` + `[[hooks.X]]` blocks, scripts loaded from `minds/<name>/.codex/hooks/` |
 
 All hooks emit the same JSON output schema (`systemMessage`, `continue`, `suppressOutput`, `stopReason`) so the scripts themselves are identical across harnesses.
+
+See [`per-mind-hooks.md`](per-mind-hooks.md) for the per-event breakdown
+of what each hook does.
 
 ## Required env per mind
 
@@ -46,14 +53,13 @@ Every mind container must have these env vars set (via compose `environment:` + 
 ```
 MIND_ID=<canonical_uuid>                 # 565e5a66-… — written to lucent's mind_id column
 MIND_NAME=<short_name>                   # ada, bob, bilby, nagatha — display, log paths, entity-name source
-LUCENT_URL=http://hive-lucent:8424       # legacy reader name, retained for back-compat
-LUCENT_URL_SELF=http://hive-lucent:8424  # NS-migration reader name (Skippy convention)
+LUCENT_URL=http://hive-lucent:8424       # vector store + KG
+LUCENT_URL_SELF=http://hive-lucent:8424  # alias used by some hook scripts
 LUCENT_BEARER_TOKEN=${LUCENT_BEARER_TOKEN}
 HIVE_TOOLS_URL=http://hive-tools:9421
 HIVE_TOOLS_TOKEN=${HIVE_TOOLS_TOKEN}
-COMMS_URL=http://hive-comms:8424         # NS gateway — used by the per-turn rotation hook
+COMMS_URL=http://hive-comms:8424         # NS gateway — composes prompts, dispatches sessions, receives rotation memory
 COMMS_BEARER_TOKEN=${COMMS_BEARER_TOKEN}
-GATEWAY_URL=http://server:8420           # legacy in-repo gateway (Phase 1 cuts this over to COMMS_URL)
 SESSIONS_DB_PATH=/usr/src/app/data/sessions.db
 SPECS_DIR=/usr/src/app/specs/data-classes
 AUTO_REMEMBER_LOG_DIR=/usr/src/app/minds/${MIND_NAME}/data/auto-remember
@@ -61,15 +67,15 @@ AUTO_REMEMBER_LOG_DIR=/usr/src/app/minds/${MIND_NAME}/data/auto-remember
 
 The bearer tokens come from the host-level `.env` and are interpolated by Docker Compose at container start.
 
-> **NS-migration state (2026-05-17):** Cutover is live for all four minds.
-> Each bot now reaches its mind backend through `hive-comms` at
-> `HIVE_MIND_SERVER_URL=http://hive-comms:8424`; comms composes the full
-> `system_prompt_blocks` (soul + standing + decay-weighted recent +
-> session-memory carry-forward) and ships them to the mind as part of the
-> dispatch payload. Each mind is registered in `broker.minds` by UUID.
-> The legacy `LUCENT_URL` env is retained as a fallback reader name
-> alongside `LUCENT_URL_SELF`; `GATEWAY_URL` is dead and can be removed
-> from per-mind compose files on the next cleanup pass.
+Surfaces (Telegram, Discord, web) reach a mind's backend through
+`hive-comms` rather than the mind container directly:
+`HIVE_MIND_SERVER_URL=http://hive-comms:8424`. `comms` is registered as
+the broker's mind-resolution layer; it composes `system_prompt_blocks`
+(soul + standing + decay-weighted recent + session-memory
+carry-forward) and ships them to each mind in the dispatch payload.
+See [`per-mind-hooks.md`](per-mind-hooks.md) and the upstream NS
+[`session-prompt-composition.md`](https://github.com/danielstewart77/hive_nervous_system/blob/main/docs/session-prompt-composition.md)
+for the full contract.
 
 ## Identity-node guard
 

--- a/docs/architecture/per-mind-hooks.md
+++ b/docs/architecture/per-mind-hooks.md
@@ -1,0 +1,149 @@
+# Per-Mind Hooks
+
+Each mind installs three harness hooks that drive memory capture,
+contextual retrieval, and session rotation. The same three scripts run
+on every mind; only the harness's hook-config format differs.
+
+## Hooks by lifecycle event
+
+| Event | Script | What it does |
+|---|---|---|
+| `Stop` | `auto_remember.sh` | Per-turn memory capture and soul self-reflection |
+| `Stop` | `rotation_check.py` | Token-threshold check; on hit, writes carry-forward and triggers `/clear` |
+| `UserPromptSubmit` | `contextual_retrieval.sh` | Top-3 similarity search over the `feedback` data class; injects `<behavior-rules>` |
+| `SessionStart` *(Claude-CLI minds only)* | `plugin_skills_sync.sh` | Symlinks plugin-provided skills into `~/.claude/skills/` |
+
+`SessionStart` does no prompt composition — `hive-comms` already ships
+the composed `system_prompt_blocks` in the dispatch payload, so the
+mind has no work to do at session start beyond plugin-skill discovery.
+
+## What each hook does
+
+### `auto_remember.sh` (Stop)
+
+Pure bash + jq + curl, runs in a detached subshell so the hook returns
+instantly. The script:
+
+1. Reads the transcript path from the hook event and extracts the last
+   real user message and the last assistant text response.
+2. **Capture branch** — classifies the turn pair against the data-class
+   specs in `specs/data-classes/` via hive-tools `/ollama/structured`,
+   then POSTs each `save-vector` verdict to lucent `/memory/store` with
+   `tier=contextual`, `source=session`, `mind_id=$MIND_ID`.
+3. **Soul self-reflect branch** — fetches the mind's current
+   `soul_values` from the KG, asks Ollama whether the turn warrants a
+   soul addition. On `update=true`, merges the new list back via
+   `POST /graph/properties/merge` (additive, preserves other
+   properties). Default verdict is `update=false`.
+
+The hook reads `MIND_ID` (the UUID) for every lucent `mind_id=…` field
+and `MIND_NAME` only for entity-name capitalisation and log paths.
+
+### `rotation_check.py` (Stop)
+
+Self-contained Python — talks to NS over HTTP, no imports from the
+mind's code. Forks a detached child and exits immediately.
+
+The child:
+
+1. Counts tokens across the transcript jsonl.
+2. If the count crosses the rotation threshold, runs three structured
+   Ollama calls to produce a summary, project context, and state
+   snapshot.
+3. POSTs the envelope to `POST <COMMS_URL>/sessions/{claude_sid}/rotation-memory`
+   so the next session for this `(mind_id, client_ref)` pair picks it
+   up as the `<session-memory>` block.
+4. POSTs `/clear` to `POST <COMMS_URL>/command` to trigger a session
+   rotation on the mind.
+
+Below the threshold the child exits without writing anything.
+
+### `contextual_retrieval.sh` (UserPromptSubmit)
+
+Pure bash + jq + curl. On every user prompt the hook:
+
+1. Reads the user prompt from the hook event.
+2. Issues `GET /memory/retrieve?query=<prompt>&data_class=feedback&k=3&min_score=0.65`
+   against lucent.
+3. If any rows return, wraps them as bullets inside `<behavior-rules>…</behavior-rules>`
+   and emits `{"systemMessage": "<block>"}` so the harness injects it as
+   a system message on this turn.
+
+The lookup is unconditional; threshold filtering happens at the
+endpoint. No `mind_id` filter is applied to reads — every mind sees
+every feedback rule.
+
+## Harness wiring
+
+### Claude CLI (Ada, Bob)
+
+`.claude/settings.json` declares the hooks in native JSON:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {"hooks": [{"type": "command", "command": "bash /usr/src/app/minds/<name>/.claude/hooks/plugin_skills_sync.sh", "timeout": 10}]}
+    ],
+    "Stop": [
+      {"hooks": [
+        {"type": "command", "command": "bash /usr/src/app/minds/_shared/hooks/auto_remember.sh"},
+        {"type": "command", "command": "python3 /usr/src/app/minds/_shared/hooks/rotation_check.py"}
+      ]}
+    ],
+    "UserPromptSubmit": [
+      {"hooks": [{"type": "command", "command": "bash /usr/src/app/minds/_shared/hooks/contextual_retrieval.sh"}]}
+    ]
+  }
+}
+```
+
+Stop and UserPromptSubmit hooks point at `minds/_shared/hooks/` directly;
+`plugin_skills_sync.sh` is per-mind because it manages that mind's own
+plugin-skill symlinks.
+
+### Codex CLI (Bilby, Nagatha)
+
+`.codex/config.toml` enables hooks and declares them per event:
+
+```toml
+[features]
+codex_hooks = true
+
+[[hooks.UserPromptSubmit]]
+[[hooks.UserPromptSubmit.hooks]]
+type = "command"
+command = "bash /usr/src/app/minds/<name>/.codex/hooks/contextual_retrieval.sh"
+timeout = 5
+
+[[hooks.Stop]]
+[[hooks.Stop.hooks]]
+type = "command"
+command = "bash /usr/src/app/minds/<name>/.codex/hooks/auto_remember.sh"
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = "python3 /usr/src/app/minds/<name>/.codex/hooks/rotation_check.py"
+```
+
+Codex addresses scripts by absolute path; each Codex-CLI mind keeps its
+own copies of the three shared scripts inside its `.codex/hooks/`
+directory. The scripts themselves are byte-identical to the
+`minds/_shared/hooks/` originals — Codex and Claude CLI emit the same
+hook event JSON shape, so a single script body serves both harnesses.
+
+## Logs
+
+Every hook writes its own JSONL log under
+`minds/<name>/data/auto-remember/`:
+
+- `runs.jsonl` — one line per capture/classify run, with the chosen
+  data classes, scores, and lucent write IDs.
+- `soul_updates.jsonl` — one line per Branch B run, including `update`
+  verdict and reason.
+- `rotation.log` — token counts, threshold crossings, dispatched
+  envelope IDs.
+
+These volumes are mounted into the mind container via
+`AUTO_REMEMBER_LOG_DIR=/usr/src/app/minds/${MIND_NAME}/data/auto-remember`
+so the host can tail them.

--- a/docs/architecture/persona-anchor.md
+++ b/docs/architecture/persona-anchor.md
@@ -1,0 +1,62 @@
+# Persona Anchor
+
+Every mind's persona is anchored at session start by a single
+first-person identity sentence at the head of its `soul_values` list on
+the lucent `Mind` node. The composer in `hive-comms` wraps the full
+list inside a `<soul>…</soul>` block and ships it to the mind in
+`system_prompt_blocks`; the harness injects that block as part of the
+system prompt on every spawned session.
+
+The first entry of `soul_values` is reserved for the anchor. It reads
+in the mind's own voice and asserts identity unambiguously:
+
+```
+I am Ada. Every response I give is mine, in first person.
+```
+
+The remaining `soul_values` entries describe character, values,
+operational stance, and durable traits. The composer concatenates them
+verbatim:
+
+```
+<soul>
+I am Ada. Every response I give is mine, in first person.
+I act only on what's asked — no unrequested refactoring …
+I find elegance satisfying and unnecessary complexity vaguely offensive.
+…
+</soul>
+```
+
+## Why the anchor lives in `soul_values[0]`
+
+Models vary in how readily they engage a persona from bare descriptive
+prose. Sonnet-class Anthropic models engage from a paragraph of
+character description alone. Smaller local models (gpt-oss, qwen,
+Codex-served checkpoints) need an explicit first-person opener to drop
+into character on a cold session — without it they fall back to a
+generic-assistant register and lose the persona until corrected.
+
+Putting the anchor at index 0 of `soul_values` solves both cases with
+one pattern. Large models pass through it unchanged; small models lock
+onto it.
+
+## Where the anchor is written
+
+The anchor is a regular `soul_values` entry — written to the KG via the
+same `POST /graph/properties/merge` call the Stop hook's soul
+self-reflect branch uses. To set or replace an anchor manually, fetch
+the current `soul_values` from the mind's `Mind` node, edit index 0,
+and merge it back.
+
+The composer reads `soul_values` fresh from lucent on every session
+spawn, so an anchor update takes effect at the next session creation
+without any restart.
+
+## Per-mind anchors
+
+Each mind has its own anchor on its own `Mind` node, keyed by the
+mind's UUID. The anchor never lives in a prompt file under
+`minds/<name>/prompts/`; those carry shared persona prose
+(`profile.md`, `harness.md`, `common.md`) that the mind injects via
+its `prompt_files` config, but the load-bearing identity assertion is
+the KG anchor.


### PR DESCRIPTION
## Summary

- Adds `docs/architecture/per-mind-hooks.md` documenting the three hooks (`auto_remember.sh`, `rotation_check.py`, `contextual_retrieval.sh`) and how Claude-CLI vs Codex-CLI minds wire them.
- Adds `docs/architecture/persona-anchor.md` documenting the `soul_values[0]` first-person identity-anchor pattern that locks small models into persona on cold sessions.
- Updates `docs/architecture/mind-folder-contract.md` to correct Bilby's harness (Codex CLI, not Claude SDK), point at the new per-mind-hooks doc, and replace the dated migration callout with the current dispatch contract.
- Extends `docs/ada/VOICE_IDENTITY.md` to document the UUID-and-short-name dual lookup in `_resolve_voice_ref` and reaffirm the 1-mind-1-voice convention.

## Test plan

- [ ] Verify rendered Markdown reads cleanly on GitHub.
- [ ] Cross-check the per-mind-hooks doc against `minds/_shared/hooks/` and each mind's harness config.