### PR TITLE
fix(scheduler): thread voice_id through TTS so per-mind voice ref resolves

### DIFF
--- a/bots/scheduler.py
+++ b/bots/scheduler.py
@@ -86,18 +86,18 @@ def _strip_markdown(text: str) -> str:
     return text.strip()
 
 
-async def _tts(http: aiohttp.ClientSession, text: str) -> bytes:
-    async with http.post(f"{VOICE_SERVER_URL}/tts", json={"text": text}) as resp:
+async def _tts(http: aiohttp.ClientSession, text: str, voice_id: str) -> bytes:
+    async with http.post(f"{VOICE_SERVER_URL}/tts", json={"text": text, "voice_id": voice_id}) as resp:
         if resp.status != 200:
             raise RuntimeError(f"TTS error {resp.status}: {await resp.text()}")
         return await resp.read()
 
 
-async def _try_send_voice(bot_token: str, chat_id: int, text: str, label: str) -> None:
+async def _try_send_voice(bot_token: str, chat_id: int, text: str, voice_id: str, label: str) -> None:
     """Fire-and-forget: synthesise TTS and send voice note. Logs but never raises."""
     try:
         async with aiohttp.ClientSession() as http:
-            audio = await _tts(http, text)
+            audio = await _tts(http, text, voice_id)
         await _send_voice(bot_token, chat_id, audio)
         log.info("Voice delivery complete for %s", label)
     except Exception:
@@ -224,7 +224,7 @@ async def fire_skill(skill: ScheduledSkill) -> None:
 
     await _send_text(bot_token, chat_id, response)
     if skill.voice:
-        asyncio.create_task(_try_send_voice(bot_token, chat_id, response, label))
+        asyncio.create_task(_try_send_voice(bot_token, chat_id, response, skill.mind_id, label))
 
 
 RECONCILE_INTERVAL_SEC = 30

--- a/tests/unit/test_scheduler_tts.py
+++ b/tests/unit/test_scheduler_tts.py
@@ -1,0 +1,57 @@
+"""Tests for the scheduler's TTS call path.
+
+Verifies that the scheduler threads `voice_id` through `_tts` and
+`_try_send_voice`, so the voice server can resolve the correct per-mind
+voice reference clip instead of falling back to a literal `"default"`.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bots import scheduler
+
+
+class _AsyncCtx:
+    def __init__(self, ret):
+        self._ret = ret
+
+    async def __aenter__(self):
+        return self._ret
+
+    async def __aexit__(self, *_):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_tts_sends_voice_id_in_payload():
+    resp = MagicMock()
+    resp.status = 200
+    resp.read = AsyncMock(return_value=b"OGGBYTES")
+
+    http = MagicMock()
+    http.post = MagicMock(return_value=_AsyncCtx(resp))
+
+    audio = await scheduler._tts(http, "hello", "ada-uuid-1234")
+
+    assert audio == b"OGGBYTES"
+    http.post.assert_called_once()
+    _, kwargs = http.post.call_args
+    assert kwargs["json"] == {"text": "hello", "voice_id": "ada-uuid-1234"}
+
+
+@pytest.mark.asyncio
+async def test_try_send_voice_threads_voice_id_to_tts():
+    with (
+        patch.object(scheduler, "_tts", new=AsyncMock(return_value=b"OGG")) as tts_mock,
+        patch.object(scheduler, "_send_voice", new=AsyncMock()) as send_mock,
+    ):
+        await scheduler._try_send_voice(
+            bot_token="tok", chat_id=42, text="hi", voice_id="ada-uuid", label="1pm"
+        )
+
+    tts_mock.assert_awaited_once()
+    args, _ = tts_mock.call_args
+    assert args[1] == "hi"
+    assert args[2] == "ada-uuid"
+    send_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Scheduler `_tts()` posted only `{"text": ...}`, so the voice server's `TTSRequest` defaulted `voice_id="default"` and 400ed for lack of `minds/default/voice_ref.wav` — scheduled briefings (7am / 1pm) arrived text-only.
- Pass `skill.mind_id` (UUID; voice server resolves both UUID and short name) through `_try_send_voice` → `_tts`.

## Test plan
- [x] `tests/unit/test_scheduler_tts.py` — `_tts` sends `voice_id` in payload; `_try_send_voice` threads it through.
- [x] Broader scheduler/voice/epilogue suite: 32 passed.
- [ ] Confirm tomorrow's 7am briefing arrives as voice.