### PR TITLE
docs: un-share hooks between Ada and Bob

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:24.04
 WORKDIR /usr/src/app
 
 # System deps + Node.js (for Claude Code CLI) + GitHub CLI
-# jq required by the shared bash hooks under minds/_shared/hooks/.
+# jq required by the per-mind bash hooks under minds/<name>/.claude/hooks/ and .codex/hooks/.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 python3-pip python3-venv python3-dev gcc libpq-dev curl jq \
     nodejs npm \

--- a/docs/architecture/mind-folder-contract.md
+++ b/docs/architecture/mind-folder-contract.md
@@ -11,7 +11,7 @@ minds/<any_name>/
 ├── prompts/                  # per-mind prompt fragments (common.md, harness.md, profile.md)
 ├── .claude/                  # for Claude CLI / SDK minds
 │   ├── settings.json         #   declares Stop / SessionStart / UserPromptSubmit hooks
-│   └── hooks/                #   per-mind hook scripts (or symlinks to minds/_shared/hooks/)
+│   └── hooks/                #   per-mind hook scripts (one copy per mind, no sharing)
 ├── .codex/                   # for Codex CLI minds (instead of .claude)
 │   ├── config.toml           #   declares hooks via [[hooks.X]] blocks
 │   └── hooks/                #   identical scripts
@@ -31,14 +31,16 @@ minds/<any_name>/
 
 The three hooks that carry capture, retrieval, and rotation
 (`auto_remember.sh`, `contextual_retrieval.sh`, `rotation_check.py`)
-live at `minds/_shared/hooks/`. Codex-CLI minds keep per-mind copies of
-the same scripts under their own `.codex/hooks/` directory because the
-Codex hook config addresses scripts by absolute path. Each mind's
-harness loads them differently:
+live in each mind's own hook directory — Claude-CLI minds under
+`minds/<name>/.claude/hooks/`, Codex-CLI minds under
+`minds/<name>/.codex/hooks/`. The script bodies are byte-identical
+across minds today, but every mind owns its own copy so a change to
+one mind's hooks never affects another. Each mind's harness loads
+them differently:
 
 | Harness | Config file | How |
 |---|---|---|
-| **Claude CLI** (Ada, Bob) | `.claude/settings.json` | Native — JSON `hooks` block, scripts loaded from `minds/_shared/hooks/` |
+| **Claude CLI** (Ada, Bob) | `.claude/settings.json` | Native — JSON `hooks` block, scripts loaded from `minds/<name>/.claude/hooks/` |
 | **Codex CLI** (Bilby, Nagatha) | `.codex/config.toml` | `[features] codex_hooks = true` + `[[hooks.X]]` blocks, scripts loaded from `minds/<name>/.codex/hooks/` |
 
 All hooks emit the same JSON output schema (`systemMessage`, `continue`, `suppressOutput`, `stopReason`) so the scripts themselves are identical across harnesses.

--- a/docs/architecture/nervous-system.md
+++ b/docs/architecture/nervous-system.md
@@ -7,8 +7,7 @@ The vector store + knowledge graph that backs every mind's memory lives in a sep
 This repo (`hive_mind`) contains only the **consumer side**:
 
 - `core/lucent_client.py` — HTTP+bearer wrapper, the single Python entry point for memory + graph writes from hive_mind code.
-- `minds/_shared/hooks/` — the four bash hooks each mind installs (capture, bootstrap, retrieval, rotation).
-- `minds/_shared/scripts/` — `/remember` and `/always-remember` skill backends.
+- `minds/<name>/.claude/hooks/` (or `.codex/hooks/`) — the per-turn hook scripts each mind owns its own copy of: capture, retrieval, rotation.
 
 ## Network wiring
 

--- a/docs/architecture/per-mind-hooks.md
+++ b/docs/architecture/per-mind-hooks.md
@@ -87,20 +87,21 @@ every feedback rule.
     ],
     "Stop": [
       {"hooks": [
-        {"type": "command", "command": "bash /usr/src/app/minds/_shared/hooks/auto_remember.sh"},
-        {"type": "command", "command": "python3 /usr/src/app/minds/_shared/hooks/rotation_check.py"}
+        {"type": "command", "command": "bash /usr/src/app/minds/<name>/.claude/hooks/auto_remember.sh"},
+        {"type": "command", "command": "python3 /usr/src/app/minds/<name>/.claude/hooks/rotation_check.py"}
       ]}
     ],
     "UserPromptSubmit": [
-      {"hooks": [{"type": "command", "command": "bash /usr/src/app/minds/_shared/hooks/contextual_retrieval.sh"}]}
+      {"hooks": [{"type": "command", "command": "bash /usr/src/app/minds/<name>/.claude/hooks/contextual_retrieval.sh"}]}
     ]
   }
 }
 ```
 
-Stop and UserPromptSubmit hooks point at `minds/_shared/hooks/` directly;
-`plugin_skills_sync.sh` is per-mind because it manages that mind's own
-plugin-skill symlinks.
+Each mind keeps its own copies of all four hooks under
+`minds/<name>/.claude/hooks/`. The scripts are byte-identical across
+minds today, but the files are physically separate so changes to one
+mind's hooks never affect another.
 
 ### Codex CLI (Bilby, Nagatha)
 
@@ -127,10 +128,10 @@ command = "python3 /usr/src/app/minds/<name>/.codex/hooks/rotation_check.py"
 ```
 
 Codex addresses scripts by absolute path; each Codex-CLI mind keeps its
-own copies of the three shared scripts inside its `.codex/hooks/`
-directory. The scripts themselves are byte-identical to the
-`minds/_shared/hooks/` originals — Codex and Claude CLI emit the same
-hook event JSON shape, so a single script body serves both harnesses.
+own copies of the three hook scripts inside its `.codex/hooks/`
+directory. Claude CLI and Codex emit the same hook event JSON shape,
+so a single script body serves both harnesses — but every mind owns
+its own copy.
 
 ## Logs
 


### PR DESCRIPTION
## Summary
- Deleted `minds/_shared/` — no more cross-mind hook coupling.
- Each Claude-CLI mind now owns its own copy of `auto_remember.sh`, `contextual_retrieval.sh`, and `rotation_check.py` under `minds/<name>/.claude/hooks/` (Codex minds already had this layout).
- Updated `docs/architecture/{mind-folder-contract,nervous-system,per-mind-hooks}.md` and the Dockerfile path comment to match.

The settings.json repoint and hook-file copies for Ada and Bob are gitignored (per `minds/` ignore rule) — they're already live on the host.

## Test plan
- [x] Both `settings.json` files parse as JSON
- [x] All hook paths in both settings files point at the per-mind copies
- [x] `minds/_shared/` is deleted on the host
- [x] No remaining `_shared/hooks` or `_shared/scripts` references in code, docs, or Dockerfile