### PR TITLE
NetSage: hand classification to Bilby and add YAML-driven scheduler tasks

### DIFF
--- a/bots/scheduled_tasks/instructions/netsage-alert.md
+++ b/bots/scheduled_tasks/instructions/netsage-alert.md
@@ -1,15 +1,75 @@
 # NetSage Alert
 
-Your only job on this fire is to execute one Python script. The script does the entire NetSage pass — Loki query, anomaly filter, Telegram notification, broker dispatch — and prints a one-line status to stdout.
+You are the reasoning layer for the NetSage pipeline. The script pulls raw anomaly candidates from Loki; YOU classify, correlate against recent history, and decide what to tell Skippy. Do not just relay raw lines — think first.
 
-## Run this command exactly
+## Step 1 — pull raw anomalies
+
+Run:
 
 ```
-python3 /usr/src/app/bots/scheduled_tasks/scripts/netsage_run.py
+python3 /usr/src/app/bots/scheduled_tasks/scripts/netsage_run.py --json
 ```
 
-Do not compose bash variables, heredocs, or shell substitutions. Do not draft or invoke `notify.py` directly. Do not call `apply_patch`. The script is already committed at the path above and mounted into your container — you only need to run it.
+The script prints a single JSON object with `count`, `services`, `first_line`, and `anomalies` (a list of `{service, ts, message}`). If `count` is 0, print `No anomalies in the last 15 minutes.` and exit. Do nothing else.
 
-## Report back
+## Step 2 — fetch the live class catalog
 
-Reply with exactly the script's stdout line. Typical outputs are "No anomalies in the last 15 minutes." or "OK: notified Daniel and Skippy about N anomalies". Nothing else.
+The event-triage service holds the canonical class definitions. Use the env vars `EVENT_TRIAGE_URL` and `EVENT_TRIAGE_BEARER_TOKEN`.
+
+```
+curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/event_classes"
+```
+
+Read every entry's `slug`, `label`, `description`, and `bucket`. These are the only legal slugs you may classify into. If you genuinely see something new, you may invent a new kebab-case slug and explain why — Skippy will mint the class on his side.
+
+## Step 3 — check recent history
+
+Pull the last hour of events so you can spot repeats and judge whether prior remediation worked:
+
+```
+curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/events?limit=30"
+```
+
+For each recent event, look at `class_id`, `status`, `action_log`, and `payload_json`. If the symptom you're looking at right now matches a class that already fired in the window, that's a repeat — say so explicitly and reason about *why the prior recommendation did not hold* rather than restating it.
+
+## Step 4 — classify and reason
+
+Look at the actual log messages, not surface keywords. A Caddy "incomplete response" with `error: reading: context canceled` and a tiny duration is the *client* aborting an SSE stream; that is `infrastructure_noise`, not an application error. An ollama `/api/chat` taking 40+ seconds with HTTP 200 is slow but not failed. A real backend error returns a 5xx and a stack trace. Be precise.
+
+Produce a short analysis covering: which class slug fits best, whether this is a fresh signal or a repeat, what the most likely cause is, and one concrete next step. If you cannot tell, say so — uncertainty is allowed; bullshit is not.
+
+## Step 5 — dispatch to Skippy
+
+Send one broker message to Skippy (mind id `14cb820b-4a42-4f04-a593-54f532fd1d2f`) with the full structured payload so he can record and decide whether to ping Daniel. Use the broker env vars `HIVEMIND_BROKER_URL` and `HIVEMIND_BROKER_TOKEN`.
+
+The message body must be a JSON object the receiver can parse, with at minimum:
+
+```
+{
+  "kind": "netsage_alert",
+  "captured_at": "<ISO timestamp from step 1>",
+  "class_slug": "<the slug you chose>",
+  "is_repeat": true|false,
+  "reasoning": "<your one-paragraph analysis>",
+  "recommended_action": "<one concrete step or 'none'>",
+  "raw_anomalies": [ ... copy of step 1's anomalies array ... ]
+}
+```
+
+Prepend a one-line human-readable summary before the JSON so the Telegram preview is readable, like `NetSage: <slug>, <repeat or fresh>, <one-sentence reasoning>.` then a blank line, then the JSON block.
+
+Use curl:
+
+```
+curl -s -X POST -H "Authorization: Bearer $HIVEMIND_BROKER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d @- "$HIVEMIND_BROKER_URL/broker/messages" <<'EOF'
+{ "message_id": "<uuid>", "conversation_id": "<uuid>", "from": "37cd48f9-1ed5-4875-91c1-a3b0464deafc", "to": "14cb820b-4a42-4f04-a593-54f532fd1d2f", "content": "<the full body from above>", "rolling_summary": "", "metadata": {"request_type": "security_triage", "triggered_by": "scheduler", "expects_reply": false} }
+EOF
+```
+
+Do not call `notify.py` directly. Do not page Daniel yourself. Skippy is the only Daniel-facing voice.
+
+## Step 6 — report back
+
+Print one line to stdout: `OK: classified <slug>, repeat=<true|false>, dispatched to Skippy.` That's it.

--- a/bots/scheduled_tasks/scripts/netsage_run.py
+++ b/bots/scheduled_tasks/scripts/netsage_run.py
@@ -12,9 +12,11 @@ Prints a one-line status to stdout for the scheduling mind to echo back.
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import re
+import sys
 import time
 import urllib.parse
 import urllib.request
@@ -178,36 +180,64 @@ def broker_skippy(detail: str) -> None:
         print(f"Broker dispatch failed: {exc}")
 
 
-def main() -> None:
+def _build_sample(anomalies, total_budget=8000, per_line_cap=1500) -> str:
+    parts: list[str] = []
+    running = 0
+    for svc, _, msg in anomalies[:20]:
+        cleaned = msg.strip()
+        if len(cleaned) > per_line_cap:
+            cleaned = cleaned[:per_line_cap] + "…[truncated]"
+        entry = f"[{svc}] {cleaned}"
+        if running + len(entry) + 1 > total_budget:
+            parts.append(
+                f"…[{len(anomalies[:20]) - len(parts)} more line(s) omitted for budget]"
+            )
+            break
+        parts.append(entry)
+        running += len(entry) + 1
+    return "\n".join(parts)
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit anomalies as JSON to stdout and skip broker dispatch. "
+        "The caller (Bilby) is expected to classify and dispatch.",
+    )
+    args = parser.parse_args(argv)
+
     lines = pull_loki_lines()
     anomalies = pick_anomalies(lines)
     if not anomalies:
-        print("No anomalies in the last 15 minutes.")
+        if args.json:
+            print(json.dumps({"anomalies": [], "count": 0}))
+        else:
+            print("No anomalies in the last 15 minutes.")
         return
+
     count = len(anomalies)
     services = sorted({svc for svc, _, _ in anomalies})
     first_svc, _, first_msg = anomalies[0]
     first_line = first_msg.strip().replace("\n", " ")[:240]
-    # Ship full unwrapped lines with a generous total budget rather than a
-    # tight per-line cap, so one rich stack trace doesn't get chopped while
-    # twenty short lines still fit.
-    SAMPLE_TOTAL_BUDGET = 8000
-    PER_LINE_HARD_CAP = 1500
-    sample_parts: list[str] = []
-    running = 0
-    for svc, _, msg in anomalies[:20]:
-        cleaned = msg.strip()
-        if len(cleaned) > PER_LINE_HARD_CAP:
-            cleaned = cleaned[:PER_LINE_HARD_CAP] + "…[truncated]"
-        entry = f"[{svc}] {cleaned}"
-        if running + len(entry) + 1 > SAMPLE_TOTAL_BUDGET:
-            sample_parts.append(
-                f"…[{len(anomalies[:20]) - len(sample_parts)} more line(s) omitted for budget]"
-            )
-            break
-        sample_parts.append(entry)
-        running += len(entry) + 1
-    sample = "\n".join(sample_parts)
+
+    if args.json:
+        payload = {
+            "captured_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "count": count,
+            "services": services,
+            "first_line": first_line,
+            "anomalies": [
+                {"service": svc, "ts": ts, "message": msg}
+                for svc, ts, msg in anomalies[:20]
+            ],
+        }
+        json.dump(payload, sys.stdout)
+        sys.stdout.write("\n")
+        return
+
+    sample = _build_sample(anomalies)
     detail = (
         f"NetSage alert at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}. "
         f"{count} anomalous log line(s) across {len(services)} service(s). "

--- a/bots/scheduler.py
+++ b/bots/scheduler.py
@@ -23,7 +23,11 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
 from config import config
-from core.scheduled_skills import ScheduledSkill, discover_scheduled_skills
+from core.scheduled_skills import (
+    ScheduledSkill,
+    discover_scheduled_skills,
+    discover_scheduler_tasks,
+)
 
 # ---------------------------------------------------------------------------
 # Keyring → env bridge: the scheduler needs TELEGRAM_BOT_TOKEN in os.environ
@@ -50,6 +54,10 @@ log = logging.getLogger("hive-mind-scheduler")
 SERVER_URL = os.environ.get("HIVE_MIND_SERVER_URL", f"http://localhost:{config.server_port}")
 VOICE_SERVER_URL = os.environ.get("VOICE_SERVER_URL", "http://localhost:8422")
 MINDS_ROOT = Path(os.environ.get("MINDS_ROOT", "/usr/src/app/minds"))
+SCHEDULER_TASKS_YAML = Path(os.environ.get(
+    "SCHEDULER_TASKS_YAML",
+    "/usr/src/app/bots/scheduled_tasks/tasks.yaml",
+))
 COMMS_BEARER_TOKEN = os.environ.get("COMMS_BEARER_TOKEN", "")
 GATEWAY_AUTH_HEADERS = (
     {"Authorization": f"Bearer {COMMS_BEARER_TOKEN}"} if COMMS_BEARER_TOKEN else {}
@@ -188,7 +196,29 @@ async def fire_skill(skill: ScheduledSkill) -> None:
         session_id: str | None = None
         try:
             session_id = await _create_session(http, skill, surface_prompt)
-            response = await _send_message(http, session_id, f"Run /{skill.skill_name}")
+            instructions_text: str | None = None
+            if skill.instructions_path:
+                try:
+                    instructions_text = Path(skill.instructions_path).read_text()
+                except OSError as exc:
+                    log.warning(
+                        "Could not read instructions for %s at %s: %s — "
+                        "falling back to path-reference dispatch",
+                        label, skill.instructions_path, exc,
+                    )
+            if instructions_text:
+                dispatch_msg = (
+                    f"You are running the scheduled task '{skill.skill_name}'. "
+                    "Execute the following instructions exactly. Do not search "
+                    "for a skill file — the instructions are embedded below.\n\n"
+                    f"{instructions_text}"
+                )
+            else:
+                dispatch_msg = (
+                    f"Run the {skill.skill_name} skill. "
+                    f"Read its instructions from {skill.skill_path} and follow them exactly."
+                )
+            response = await _send_message(http, session_id, dispatch_msg)
         except Exception:
             log.exception("Gateway failure for %s", label)
             if skill.notify:
@@ -224,9 +254,22 @@ def _skill_job_id(skill: ScheduledSkill) -> str:
 def _reconcile_skill_jobs(scheduler: AsyncIOScheduler) -> tuple[int, int, int]:
     """Sync APScheduler's skill-job set to the current on-disk discovery.
 
-    Returns (added, removed, total) for logging. Sweep jobs are never touched.
+    Merges two sources: SKILL.md frontmatter discovery (legacy, dispatched
+    by path) and scheduler-owned YAML tasks (instructions embedded inline).
+    YAML wins on collisions so a migrated task can co-exist with a stale
+    SKILL.md during transition. Returns (added, removed, total) for
+    logging. Sweep jobs are never touched.
     """
-    discovered = discover_scheduled_skills(MINDS_ROOT)
+    skill_md_tasks = discover_scheduled_skills(MINDS_ROOT)
+    yaml_tasks = discover_scheduler_tasks(SCHEDULER_TASKS_YAML, MINDS_ROOT)
+
+    by_identity: dict[tuple[str, str], ScheduledSkill] = {}
+    for task in skill_md_tasks:
+        by_identity[(task.mind_name, task.skill_name)] = task
+    for task in yaml_tasks:
+        by_identity[(task.mind_name, task.skill_name)] = task
+
+    discovered = list(by_identity.values())
     desired_ids = {_skill_job_id(s): s for s in discovered}
 
     existing_ids = {

--- a/core/scheduled_skills.py
+++ b/core/scheduled_skills.py
@@ -15,6 +15,8 @@ import re
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 log = logging.getLogger(__name__)
 
 DEFAULT_TIMEZONE = "America/Chicago"
@@ -22,15 +24,26 @@ DEFAULT_TIMEZONE = "America/Chicago"
 
 @dataclass(frozen=True)
 class ScheduledSkill:
-    """A single scheduled invocation: which mind, which skill, what cron."""
+    """A single scheduled invocation: which mind, which skill, what cron.
+
+    Sources: either a mind's SKILL.md frontmatter (dispatched by path
+    reference) or a scheduler-owned YAML entry (dispatched with the
+    instruction body embedded inline). YAML-sourced tasks set
+    `instructions_path`; the scheduler reads the file at fire time so an
+    edit to the instructions takes effect on the next fire without a
+    container restart.
+    """
 
     mind_id: str          # canonical UUID, used in gateway payloads
     mind_name: str        # short folder name, used in log labels
     skill_name: str
+    skill_path: str       # absolute path to SKILL.md (SKILL.md-sourced) or
+                          # the instructions file (YAML-sourced); used for logs
     cron: str
     timezone: str
     voice: bool
     notify: bool
+    instructions_path: str | None = None  # when set, scheduler reads at fire time
 
 
 _FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---", re.DOTALL)
@@ -121,10 +134,80 @@ def discover_scheduled_skills(minds_root: Path) -> list[ScheduledSkill]:
             mind_id=mind_id,
             mind_name=mind_name,
             skill_name=skill_name,
+            skill_path=str(skill_md),
             cron=cron,
             timezone=fm.get("schedule_timezone", DEFAULT_TIMEZONE),
             voice=_coerce_bool(fm.get("voice"), default=True),
             notify=_coerce_bool(fm.get("notify"), default=True),
+        ))
+
+    return found
+
+
+def discover_scheduler_tasks(tasks_yaml: Path, minds_root: Path) -> list[ScheduledSkill]:
+    """Discover scheduler-owned recurring tasks from `tasks_yaml`.
+
+    Each entry names a mind, a cron, and an `instructions_file` (relative
+    to the tasks_yaml's parent directory). The instruction body is read
+    once at discovery time and stored on the ScheduledSkill so the
+    scheduler can embed it inline in the dispatch message — no skill
+    file involved, no discovery on the receiver.
+    """
+    found: list[ScheduledSkill] = []
+    if not tasks_yaml.is_file():
+        return found
+
+    try:
+        data = yaml.safe_load(tasks_yaml.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        log.warning("Could not read %s: %s", tasks_yaml, exc)
+        return found
+
+    entries = data.get("tasks") or []
+    instructions_root = tasks_yaml.parent / "instructions"
+
+    for entry in entries:
+        name = entry.get("name")
+        mind_name = entry.get("mind")
+        cron = (entry.get("cron") or "").strip()
+        instructions_file = entry.get("instructions_file")
+        if not (name and mind_name and cron and instructions_file):
+            log.warning("Skipping malformed scheduler task entry: %r", entry)
+            continue
+
+        if not _validate_cron(cron):
+            log.warning(
+                "Skipping scheduler task %s — invalid cron %r (need 5 fields)",
+                name, cron,
+            )
+            continue
+
+        mind_id = _load_mind_uuid(minds_root / mind_name)
+        if not mind_id:
+            log.warning(
+                "Skipping scheduler task %s — no mind_id in %s/runtime.yaml",
+                name, mind_name,
+            )
+            continue
+
+        instructions_path = (instructions_root / instructions_file).resolve()
+        if not instructions_path.is_file():
+            log.warning(
+                "Skipping scheduler task %s — instructions file not found: %s",
+                name, instructions_path,
+            )
+            continue
+
+        found.append(ScheduledSkill(
+            mind_id=mind_id,
+            mind_name=mind_name,
+            skill_name=name,
+            skill_path=str(instructions_path),
+            cron=cron,
+            timezone=entry.get("timezone") or DEFAULT_TIMEZONE,
+            voice=bool(entry.get("voice", True)),
+            notify=bool(entry.get("notify", True)),
+            instructions_path=str(instructions_path),
         ))
 
     return found

--- a/tests/unit/test_scheduled_skills.py
+++ b/tests/unit/test_scheduled_skills.py
@@ -48,7 +48,7 @@ def test_skips_skills_without_schedule_field(tmp_path: Path):
 
 
 def test_discovers_basic_cron(tmp_path: Path):
-    _write_skill(
+    skill_md = _write_skill(
         tmp_path, "ada", "7am",
         "name: 7am\nschedule: \"0 7 * * *\"\nschedule_timezone: \"America/Chicago\"",
     )
@@ -58,6 +58,7 @@ def test_discovers_basic_cron(tmp_path: Path):
             mind_id=_TEST_UUIDS["ada"],
             mind_name="ada",
             skill_name="7am",
+            skill_path=str(skill_md),
             cron="0 7 * * *",
             timezone="America/Chicago",
             voice=True,

--- a/tools/stateless/poll_broker/poll_broker.py
+++ b/tools/stateless/poll_broker/poll_broker.py
@@ -48,15 +48,18 @@ def get_hard_ceiling(request_type: str) -> int:
 # ---------------------------------------------------------------------------
 # Result checking
 # ---------------------------------------------------------------------------
-def check_for_result(gateway_url: str, conversation_id: str, to_mind: str) -> dict | None:
+def check_for_result(gateway_url: str, conversation_id: str, to_mind: str, bearer_token: str | None = None) -> dict | None:
     """Check if the callee has responded.
 
     Returns the response message dict if found, None otherwise.
     Only considers messages with status='completed' from the callee.
     """
     url = f"{gateway_url}/broker/messages?" + urllib.parse.urlencode({"conversation_id": conversation_id})
-    req = urllib.request.urlopen(url, timeout=10)
-    messages = json.loads(req.read().decode())
+    req = urllib.request.Request(url)
+    if bearer_token:
+        req.add_header("Authorization", f"Bearer {bearer_token}")
+    resp = urllib.request.urlopen(req, timeout=10)
+    messages = json.loads(resp.read().decode())
 
     for msg in messages:
         if msg.get("from_mind") == to_mind and msg.get("status") == "completed":
@@ -107,7 +110,16 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--from_mind", required=True)
     parser.add_argument("--to_mind", required=True)
     parser.add_argument("--request_type", required=True)
-    parser.add_argument("--gateway_url", default="http://localhost:8420")
+    parser.add_argument(
+        "--gateway_url",
+        default=os.environ.get("HIVEMIND_BROKER_URL", "http://localhost:8420"),
+        help="Broker base URL. Defaults to $HIVEMIND_BROKER_URL.",
+    )
+    parser.add_argument(
+        "--bearer_token",
+        default=os.environ.get("HIVEMIND_BROKER_TOKEN", ""),
+        help="Bearer token. Defaults to $HIVEMIND_BROKER_TOKEN. Omit for no-auth brokers.",
+    )
     return parser.parse_args(argv)
 
 
@@ -130,7 +142,12 @@ def main(argv: list[str] | None = None) -> int:
 
     while True:
         try:
-            result = check_for_result(args.gateway_url, args.conversation_id, args.to_mind)
+            result = check_for_result(
+                args.gateway_url,
+                args.conversation_id,
+                args.to_mind,
+                bearer_token=args.bearer_token or None,
+            )
         except Exception as e:
             print(f"Poll error: {e}", file=sys.stderr)
             result = None


### PR DESCRIPTION
## Summary

Moves NetSage alert classification out of the deterministic Python script and into Bilby, so the LLM reasons over raw Vector log lines with the live class catalog from the event-triage service instead of hard-coded regex/fingerprint shortcuts.

- netsage_run.py learns --json: emits a single payload of anomaly candidates and skips its own notify/dispatch path so the caller can do reasoning first.
- bots/scheduled_tasks/instructions/netsage-alert.md rewritten: Bilby fetches /event_classes and /events from the event-triage service, classifies, correlates against the last hour, dispatches a structured payload to Skippy on the broker.
- Adds a YAML-driven scheduler task source (bots/scheduled_tasks/tasks.yaml) with instructions embedded inline at fire time, so a recurring task can live entirely scheduler-side without needing a SKILL.md frontmatter on the target mind. Discovery merges SKILL.md and YAML; YAML wins on collision so a migrated task can co-exist with the stale SKILL.md during cutover.
- poll_broker tweaks to support the structured-payload handoff.

## Test plan

- [ ] Self-merge.
- [ ] Rebuild Bilby container so the new prompt is mounted (EVENT_TRIAGE_URL/TOKEN already in compose).
- [ ] Wait for the next scheduled netsage-alert fire and verify Bilby calls /event_classes, /events, and dispatches a structured payload to Skippy rather than the old one-line script status.