### PR TITLE
scheduler: silently skip skills with schedule: null

### DIFF
--- a/core/scheduled_skills.py
+++ b/core/scheduled_skills.py
@@ -123,6 +123,10 @@ def discover_scheduled_skills(minds_root: Path) -> list[ScheduledSkill]:
             continue
 
         cron = fm["schedule"].strip()
+        if cron.lower() in {"", "null", "none"}:
+            # Explicit opt-out — author wrote `schedule: null` or similar.
+            # Silent skip; only real cron strings deserve a warning.
+            continue
         if not _validate_cron(cron):
             log.warning(
                 "Skipping %s/%s — invalid cron %r (need 5 fields)",


### PR DESCRIPTION
Bilby's home-assistant SKILL.md sets schedule: null to opt out of scheduling. The discovery code was treating that string as an invalid cron and emitting a warning on every reconcile pass (every 30 seconds), filling the scheduler log with noise. This patch treats null/none/empty as the opt-out the author meant and skips silently; real bad cron strings still warn.