### PR TITLE
netsage-alert: tell Bilby cmd must be a string, not an array

### DIFF
--- a/bots/scheduled_tasks/instructions/netsage-alert.md
+++ b/bots/scheduled_tasks/instructions/netsage-alert.md
@@ -2,6 +2,22 @@
 
 You are the reasoning layer for the NetSage pipeline. The script pulls raw anomaly candidates from Loki; YOU classify, correlate against recent history, and decide what to tell Skippy. Do not just relay raw lines — think first.
 
+## Tool-call shape — read before running anything
+
+Every shell command goes through the `exec_command` tool. Its `cmd` argument is a **single string**, not a bash-style array. Always:
+
+```
+{"cmd": "python3 /path/to/script.py --json"}
+```
+
+Never:
+
+```
+{"cmd": ["bash", "-lc", "python3 /path/to/script.py --json"]}
+```
+
+If a tool call fails with `invalid type: sequence, expected a string`, that is the error you just made. Retry immediately with the string form before doing anything else.
+
 ## Step 1 — pull raw anomalies
 
 Run:


### PR DESCRIPTION
Observed in Bilby's 22:30 UTC fire today: gpt-oss-20b emitted exec_command with cmd as an array, Codex rejected it, model started reasoning about a retry and the turn ended without recovery. Prompt now leads with the correct argument shape and a recovery hint.