### PR TITLE
netsage-alert: strip examples, route unknowns to Skippy

### DIFF
--- a/bots/scheduled_tasks/instructions/netsage-alert.md
+++ b/bots/scheduled_tasks/instructions/netsage-alert.md
@@ -1,91 +1,13 @@
-# NetSage Alert
+The `exec_command` tool takes `cmd` as a string, not an array.
 
-You are the reasoning layer for the NetSage pipeline. The script pulls raw anomaly candidates from Loki; YOU classify, correlate against recent history, and decide what to tell Skippy. Do not just relay raw lines — think first.
+Run `python3 /usr/src/app/bots/scheduled_tasks/scripts/netsage_run.py --json`. The script returns `{count, services, first_line, anomalies}`. If `count` is 0, print `No anomalies in the last 15 minutes.` and exit.
 
-## Tool-call shape — read before running anything
+Fetch the catalog with `curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/event_classes"`. These slugs are the only legal classifications.
 
-Every shell command goes through the `exec_command` tool. Its `cmd` argument is a **single string**, not a bash-style array. Always:
+Fetch recent history with `curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/events?limit=30"` to detect repeats.
 
-```
-{"cmd": "python3 /path/to/script.py --json"}
-```
+For each anomaly: if it clearly matches a catalog slug, record it via `POST $EVENT_TRIAGE_URL/events` with `event_class_id`, `source`, `occurred_at`, `payload_json`, `summary`, and `severity`. If it does not match any slug, do not invent one. Send Skippy the raw anomaly and ask him to classify it.
 
-Never:
+Dispatch broker messages with `POST $HIVEMIND_BROKER_URL/broker/messages` using header `Authorization: Bearer $HIVEMIND_BROKER_TOKEN`. From id `37cd48f9-1ed5-4875-91c1-a3b0464deafc`, to id `14cb820b-4a42-4f04-a593-54f532fd1d2f`. Use one `conversation_id` per netsage fire. Set `metadata.expects_reply` to true when asking Skippy to classify, false when reporting a recorded outcome.
 
-```
-{"cmd": ["bash", "-lc", "python3 /path/to/script.py --json"]}
-```
-
-If a tool call fails with `invalid type: sequence, expected a string`, that is the error you just made. Retry immediately with the string form before doing anything else.
-
-## Step 1 — pull raw anomalies
-
-Run:
-
-```
-python3 /usr/src/app/bots/scheduled_tasks/scripts/netsage_run.py --json
-```
-
-The script prints a single JSON object with `count`, `services`, `first_line`, and `anomalies` (a list of `{service, ts, message}`). If `count` is 0, print `No anomalies in the last 15 minutes.` and exit. Do nothing else.
-
-## Step 2 — fetch the live class catalog
-
-The event-triage service holds the canonical class definitions. Use the env vars `EVENT_TRIAGE_URL` and `EVENT_TRIAGE_BEARER_TOKEN`.
-
-```
-curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/event_classes"
-```
-
-Read every entry's `slug`, `label`, `description`, and `bucket`. These are the only legal slugs you may classify into. If you genuinely see something new, you may invent a new kebab-case slug and explain why — Skippy will mint the class on his side.
-
-## Step 3 — check recent history
-
-Pull the last hour of events so you can spot repeats and judge whether prior remediation worked:
-
-```
-curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/events?limit=30"
-```
-
-For each recent event, look at `class_id`, `status`, `action_log`, and `payload_json`. If the symptom you're looking at right now matches a class that already fired in the window, that's a repeat — say so explicitly and reason about *why the prior recommendation did not hold* rather than restating it.
-
-## Step 4 — classify and reason
-
-Look at the actual log messages, not surface keywords. A Caddy "incomplete response" with `error: reading: context canceled` and a tiny duration is the *client* aborting an SSE stream; that is `infrastructure_noise`, not an application error. An ollama `/api/chat` taking 40+ seconds with HTTP 200 is slow but not failed. A real backend error returns a 5xx and a stack trace. Be precise.
-
-Produce a short analysis covering: which class slug fits best, whether this is a fresh signal or a repeat, what the most likely cause is, and one concrete next step. If you cannot tell, say so — uncertainty is allowed; bullshit is not.
-
-## Step 5 — dispatch to Skippy
-
-Send one broker message to Skippy (mind id `14cb820b-4a42-4f04-a593-54f532fd1d2f`) with the full structured payload so he can record and decide whether to ping Daniel. Use the broker env vars `HIVEMIND_BROKER_URL` and `HIVEMIND_BROKER_TOKEN`.
-
-The message body must be a JSON object the receiver can parse, with at minimum:
-
-```
-{
-  "kind": "netsage_alert",
-  "captured_at": "<ISO timestamp from step 1>",
-  "class_slug": "<the slug you chose>",
-  "is_repeat": true|false,
-  "reasoning": "<your one-paragraph analysis>",
-  "recommended_action": "<one concrete step or 'none'>",
-  "raw_anomalies": [ ... copy of step 1's anomalies array ... ]
-}
-```
-
-Prepend a one-line human-readable summary before the JSON so the Telegram preview is readable, like `NetSage: <slug>, <repeat or fresh>, <one-sentence reasoning>.` then a blank line, then the JSON block.
-
-Use curl:
-
-```
-curl -s -X POST -H "Authorization: Bearer $HIVEMIND_BROKER_TOKEN" \
-  -H "Content-Type: application/json" \
-  -d @- "$HIVEMIND_BROKER_URL/broker/messages" <<'EOF'
-{ "message_id": "<uuid>", "conversation_id": "<uuid>", "from": "37cd48f9-1ed5-4875-91c1-a3b0464deafc", "to": "14cb820b-4a42-4f04-a593-54f532fd1d2f", "content": "<the full body from above>", "rolling_summary": "", "metadata": {"request_type": "security_triage", "triggered_by": "scheduler", "expects_reply": false} }
-EOF
-```
-
-Do not call `notify.py` directly. Do not page Daniel yourself. Skippy is the only Daniel-facing voice.
-
-## Step 6 — report back
-
-Print one line to stdout: `OK: classified <slug>, repeat=<true|false>, dispatched to Skippy.` That's it.
+Print `OK: processed <N> anomalies, dispatched <M> to Skippy.` and exit.


### PR DESCRIPTION
## Summary

Rewrites `bots/scheduled_tasks/instructions/netsage-alert.md` as tight imperatives. Drops the `ollama_upstream_timeout` example (the catalog row was a fake class Skippy invented; deleted from event_triage's events.db this turn), the tool-call good-vs-bad demonstration, the section headers, the anti-pattern callouts, and the "think first" framing.

New behavior: if an anomaly does not match a live catalog slug, Bilby no longer invents one. He sends the raw anomaly to Skippy via the broker with `expects_reply=true` and ends his turn. Skippy classifies and replies via `send-message-to-mind`, which lands as a fresh turn for Bilby with the slug and recording instructions. Real multi-turn collaboration, not fire-and-forget.

92 lines down to 9.

## Test plan

- [ ] Rebuild bilby container so the new prompt is picked up
- [ ] Wait for next 15-minute netsage fire
- [ ] Confirm Bilby pulls anomalies, hits the catalog, hits history
- [ ] Confirm Bilby either records via `POST /events` (if matched) or dispatches an `expects_reply=true` broker message to Skippy (if unmatched)
- [ ] On Skippy's side, confirm reply via `send-message-to-mind` lands as a new turn in Bilby's container and that he creates the class + records the event