### PR TITLE
surface empty-stream errors instead of '(No response)' placeholder

### DIFF
--- a/bots/discord_bot.py
+++ b/bots/discord_bot.py
@@ -214,7 +214,10 @@ def _chunk_message(text: str) -> list[str]:
     if current.strip():
         chunks.append(current.rstrip("\n"))
 
-    return chunks or ["(No response)"]
+    return chunks or [
+        "ERROR: empty response from gateway. "
+        "Check the mind container logs for the real failure."
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +247,10 @@ async def _stream_to_message(
             last_edit = now
 
     if not accumulated:
-        accumulated = "(No response)"
+        accumulated = (
+            "ERROR: mind stream closed with no text output. "
+            "Check the mind container logs for the real failure."
+        )
 
     chunks = _chunk_message(accumulated)
     with contextlib.suppress(discord.HTTPException):

--- a/bots/hivemind_bot.py
+++ b/bots/hivemind_bot.py
@@ -282,7 +282,10 @@ async def _stream_group_response(
         return None
 
     if not accumulated:
-        await placeholder.edit_text("(no response from the hive)")
+        await placeholder.edit_text(
+            "ERROR: hive group stream closed with no text from any mind. "
+            "Check the mind container logs for the real failure."
+        )
         return None
 
     full_text = "\n\n".join(accumulated.values())

--- a/bots/scheduler.py
+++ b/bots/scheduler.py
@@ -138,6 +138,10 @@ async def _send_message(http: aiohttp.ClientSession, session_id: str, content: s
     """Send a single message and consume the SSE stream into one combined string."""
     texts: list[str] = []
     result_fallback = ""
+    events_seen = 0
+    event_type_counts: dict[str, int] = {}
+    last_event_type: str | None = None
+    json_decode_errors = 0
     sse_timeout = aiohttp.ClientTimeout(total=0, sock_read=0)
     async with http.post(
         f"{SERVER_URL}/sessions/{session_id}/message",
@@ -157,15 +161,27 @@ async def _send_message(http: aiohttp.ClientSession, session_id: str, content: s
                 try:
                     event = json.loads(raw_line.removeprefix("data: "))
                 except json.JSONDecodeError:
+                    json_decode_errors += 1
                     continue
-                etype = event.get("type")
+                events_seen += 1
+                etype = event.get("type") or "<no-type>"
+                event_type_counts[etype] = event_type_counts.get(etype, 0) + 1
+                last_event_type = etype
                 if etype == "assistant":
                     for block in event.get("message", {}).get("content", []):
                         if block.get("type") == "text" and block.get("text"):
                             texts.append(block["text"])
                 elif etype == "result":
                     result_fallback = event.get("result", "")
-    return "\n\n".join(texts) or result_fallback or "(No response)"
+    combined = "\n\n".join(texts) or result_fallback
+    if not combined:
+        raise RuntimeError(
+            f"Empty response from session {session_id}: "
+            f"events_seen={events_seen}, types={event_type_counts}, "
+            f"last_event_type={last_event_type}, json_decode_errors={json_decode_errors}, "
+            f"result_fallback={result_fallback!r}"
+        )
+    return combined
 
 
 async def _kill_session(http: aiohttp.ClientSession, session_id: str) -> None:
@@ -233,6 +249,7 @@ async def fire_skill(skill: ScheduledSkill) -> None:
 
     if not skill.notify:
         log.info("%s complete (notify=false, no delivery)", label)
+        log.info("%s response (first 4000 chars): %s", label, (response or "")[:4000])
         return
 
     await _send_text(bot_token, chat_id, response)

--- a/bots/telegram_bot.py
+++ b/bots/telegram_bot.py
@@ -170,7 +170,10 @@ async def _stream_to_message(
             last_edit = now
 
     if not accumulated:
-        accumulated = "(No response)"
+        accumulated = (
+            "ERROR: mind stream closed with no text output. "
+            "Check the mind container logs for the real failure."
+        )
 
     final_chunks = [_sanitize_response(c) for c in _chunk_message(accumulated)]
     try:

--- a/core/gateway_client.py
+++ b/core/gateway_client.py
@@ -277,4 +277,10 @@ class GatewayClient:
         texts: list[str] = []
         async for text in self.query_stream(user_id, client_ref, prompt, images=images):
             texts.append(text)
-        return "\n\n".join(texts) or "(No response)"
+        combined = "\n\n".join(texts)
+        if not combined:
+            raise RuntimeError(
+                f"Empty response from gateway for user={user_id} client_ref={client_ref}: "
+                "stream produced no text and no result fallback."
+            )
+        return combined

--- a/tests/unit/test_telegram_response_sanitizer.py
+++ b/tests/unit/test_telegram_response_sanitizer.py
@@ -60,11 +60,6 @@ class TestSanitizeResponse:
         assert "{" not in result
         assert result == "Done."
 
-    def test_sanitize_response_preserves_no_response(self) -> None:
-        from bots.telegram_bot import _sanitize_response
-
-        assert _sanitize_response("(No response)") == "(No response)"
-
     def test_sanitize_response_replaces_json_array(self) -> None:
         from bots.telegram_bot import _sanitize_response
 

--- a/tests/unit/test_telegram_stream_sanitization.py
+++ b/tests/unit/test_telegram_stream_sanitization.py
@@ -74,8 +74,8 @@ class TestStreamToMessageSanitization:
         # Final result must be sanitized
         assert final_chunks[0] == "Done."
 
-    async def test_stream_to_message_no_response_not_sanitized(self) -> None:
-        """(No response) should pass through without sanitization."""
+    async def test_stream_to_message_empty_stream_surfaces_error(self) -> None:
+        """An empty stream must surface a real error string, never '(No response)'."""
         from bots.telegram_bot import _stream_to_message
 
         sent = AsyncMock()
@@ -91,4 +91,6 @@ class TestStreamToMessageSanitization:
         with patch("bots.telegram_bot.gateway", mock_gateway):
             final_chunks = await _stream_to_message(sent, 123, 456, "test prompt")
 
-        assert final_chunks[0] == "(No response)"
+        assert "(No response)" not in final_chunks[0]
+        assert final_chunks[0].startswith("ERROR:")
+        assert "mind container logs" in final_chunks[0]


### PR DESCRIPTION
Every comms layer (scheduler, gateway_client, telegram_bot, discord_bot, hivemind_bot) was substituting the literal string '(No response)' when the SSE stream produced no text. That ate every real failure signal. Replace with raised RuntimeError (internal call sites) or user-visible ERROR string (bot surfaces) that includes whatever diagnostic context is available.