### PR TITLE
netsage-alert: bilby applies approved auto-apply rules at insert

### DIFF
--- a/bots/scheduled_tasks/instructions/netsage-alert.md
+++ b/bots/scheduled_tasks/instructions/netsage-alert.md
@@ -6,10 +6,16 @@ Group the anomalies by their underlying error fingerprint. Near-duplicate lines 
 
 Fetch the catalog with `curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/event_classes"`. These slugs are the only legal classifications.
 
-Fetch recent history with `curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/events?limit=30"` to detect repeats.
+Fetch the approved auto-apply rules with `curl -s -H "Authorization: Bearer $EVENT_TRIAGE_BEARER_TOKEN" "$EVENT_TRIAGE_URL/response_rules?approval_state=approved"`. Build a lookup of `event_class_id` to `{rule_id, action_kind}`.
 
-For each group: if it clearly matches a catalog slug, record it via `POST $EVENT_TRIAGE_URL/events` with `event_class_id`, `source`, `occurred_at`, `payload_json`, `summary`, and `severity`. If it does not match any slug, do not invent one. Send Skippy the group's representative anomaly and ask him to classify it.
+For each group, classify it against the catalog. Always set `source` to `bilby_netsage` and `severity` to one of `low`, `medium`, or `high`.
 
-Dispatch broker messages with `POST $HIVEMIND_BROKER_URL/broker/messages` using header `Authorization: Bearer $HIVEMIND_BROKER_TOKEN`. From id `37cd48f9-1ed5-4875-91c1-a3b0464deafc`, to id `14cb820b-4a42-4f04-a593-54f532fd1d2f`. Use one `conversation_id` per netsage fire. Set `metadata.expects_reply` to true when asking Skippy to classify, false when reporting a recorded outcome.
+If the group matches a catalog slug AND that class has an approved auto-apply rule with `action_kind=record_only`, POST the event with that `event_class_id`, `status=ignored`, and `response_rule_id` set to the matching rule id. Do not dispatch to Skippy — the rule is the policy. Increment a local `R` counter.
 
-Print `OK: processed <N> groups from <M> anomalies, recorded <R>, dispatched <D> to Skippy.` and exit.
+If the group matches a catalog slug but the class has no approved auto-apply rule, POST the event with `status=awaiting_triage`, then dispatch a broker message to Skippy with the group's representative anomaly and `metadata.expects_reply=true` so he can decide the policy. Increment a local `D` counter.
+
+If the group matches no catalog slug, do not invent one. Do not POST an event. Dispatch a broker message to Skippy with the representative anomaly and `metadata.expects_reply=true`, asking him to name a class. Increment `D`.
+
+Dispatch broker messages with `POST $HIVEMIND_BROKER_URL/broker/messages` using header `Authorization: Bearer $HIVEMIND_BROKER_TOKEN`. From id `37cd48f9-1ed5-4875-91c1-a3b0464deafc`, to id `14cb820b-4a42-4f04-a593-54f532fd1d2f`. Use one `conversation_id` per netsage fire.
+
+Print `OK: processed <N> groups from <M> anomalies, recorded silently <R>, dispatched <D> to Skippy.` and exit.


### PR DESCRIPTION
## Summary
- Bilby now fetches `/response_rules?approval_state=approved` each fire and silently applies `record_only` rules at insert time (`status=ignored`, `response_rule_id=<rule>`) instead of letting routine Caddy SSE / aiohttp noise sit at `awaiting_triage`.
- Skippy is only dispatched when the matched class has no auto-apply rule, or when the group matches no catalog slug at all.
- Source field is locked to `bilby_netsage` (was leaking container hashes) and severity is required.

## Why
Over the last 24h, 24/43 events were Caddy SSE aborts and 10/43 were aiohttp warnings — both have approved record-only rules — but every one of them was POSTed at default status and pulled Skippy in via broker. This restores rule application at the source.

## Test plan
- [ ] Next netsage fire prints `recorded silently <N>` for the noise classes
- [ ] No new broker dispatches for caddy_sse_client_abort or aiohttp_unclosed_connection
- [ ] Real unclassified anomalies still reach Skippy via broker