### PR TITLE
scheduler: raise per-fire timeout from 13 to 14 minutes

### DIFF
--- a/bots/scheduler.py
+++ b/bots/scheduler.py
@@ -207,7 +207,7 @@ async def fire_skill(skill: ScheduledSkill) -> None:
     log.info("Firing %s", label)
     surface_prompt = VOICE_SURFACE_PROMPT if skill.voice else DEV_SURFACE_PROMPT
 
-    timeout = aiohttp.ClientTimeout(total=780)
+    timeout = aiohttp.ClientTimeout(total=840)
     async with aiohttp.ClientSession(timeout=timeout, headers=GATEWAY_AUTH_HEADERS) as http:
         session_id: str | None = None
         try:


### PR DESCRIPTION
## Summary
Bumps `aiohttp.ClientTimeout(total=...)` in the scheduler's per-skill dispatch from 780 seconds (13 minutes) to 840 seconds (14 minutes).

The previous incremental raise from 5 minutes stopped at 13. Bilby's netsage-alert turns under the group-then-classify prompt have been landing in the 2-7 minute range so far, but a full minute of headroom past the prior ceiling matches Daniel's stated preference and avoids future client-side cutoffs on the longer Bilby fires.

## Test plan
- [ ] PR self-merges
- [ ] `docker restart hive-mind-scheduler` picks up the bind-mounted edit
- [ ] Next scheduled fire logs no client-timeout exceptions