### PR TITLE
scheduler: support command-typed tasks; strip Bilby from netsage-alert

### DIFF
--- a/bots/scheduled_tasks/tasks.yaml
+++ b/bots/scheduled_tasks/tasks.yaml
@@ -1,10 +1,16 @@
 # Scheduler-owned recurring tasks.
 #
-# Each entry is a recurring instruction sent to a mind on a cron schedule.
-# The instruction body lives in instructions/<name>.md and is embedded
-# inline into the dispatch message — the receiving mind never has to
-# discover a skill file, which makes the dispatch deterministic across
-# every harness (Claude, codex, openai-cloud).
+# Two task shapes are supported:
+#
+# 1. Mind-dispatched: `mind:` + `instructions_file:` — the instruction
+#    body lives in instructions/<name>.md and is embedded inline into a
+#    dispatch message to the named mind. Use this when the task genuinely
+#    needs an LLM's judgement.
+#
+# 2. Command: `command:` — a string or list[str] the scheduler runs as a
+#    subprocess at cron time. Use this for fully deterministic tasks; the
+#    command is responsible for any downstream effects (broker dispatch,
+#    HTTP POST, etc.) and the scheduler only logs its stdout/stderr.
 #
 # Use this file for tasks that are purely scheduler-fired and not meant
 # to be user-invocable in chat. User-invocable skills still live under
@@ -12,9 +18,10 @@
 
 tasks:
   - name: netsage-alert
-    mind: bilby
     cron: "*/15 * * * *"
     timezone: America/Chicago
     voice: false
     notify: false
-    instructions_file: netsage-alert.md
+    command:
+      - /opt/venv/bin/python3
+      - /usr/src/app/bots/scheduled_tasks/scripts/netsage_run.py

--- a/bots/scheduler.py
+++ b/bots/scheduler.py
@@ -194,8 +194,40 @@ async def _kill_session(http: aiohttp.ClientSession, session_id: str) -> None:
         log.exception("Failed to delete session %s", session_id)
 
 
+async def _fire_command(skill: ScheduledSkill) -> None:
+    """Run a command-type scheduled task as a subprocess.
+
+    Output goes to scheduler logs. Notify/voice are intentionally ignored
+    here — these tasks talk to the system (broker, event_triage, etc.) on
+    their own; they don't return text to deliver.
+    """
+    label = f"{skill.mind_name}/{skill.skill_name}"
+    cmd = list(skill.command or ())
+    if not cmd:
+        log.error("Command task %s has empty command list", label)
+        return
+    log.info("Firing %s as command: %s", label, cmd)
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        stdout_bytes, _ = await proc.communicate()
+        stdout_text = (stdout_bytes or b"").decode(errors="replace").strip()
+        if proc.returncode == 0:
+            log.info("%s exit=0 output=%r", label, stdout_text[:2000])
+        else:
+            log.error("%s exit=%s output=%r", label, proc.returncode, stdout_text[:2000])
+    except Exception:
+        log.exception("Command task %s failed", label)
+
+
 async def fire_skill(skill: ScheduledSkill) -> None:
     """Fire a single scheduled skill: fresh session → run → kill → deliver."""
+    if skill.command:
+        await _fire_command(skill)
+        return
     label = f"{skill.mind_name}/{skill.skill_name}"
     bot_token = os.environ.get("TELEGRAM_BOT_TOKEN", "")
     chat_id = config.telegram_owner_chat_id

--- a/core/scheduled_skills.py
+++ b/core/scheduled_skills.py
@@ -34,7 +34,10 @@ class ScheduledSkill:
     container restart.
     """
 
-    mind_id: str          # canonical UUID, used in gateway payloads
+    mind_id: str          # canonical UUID, used in gateway payloads.
+                          # For command-typed tasks this is "scheduler" — no
+                          # gateway dispatch happens, the field is kept for
+                          # log labelling.
     mind_name: str        # short folder name, used in log labels
     skill_name: str
     skill_path: str       # absolute path to SKILL.md (SKILL.md-sourced) or
@@ -44,6 +47,9 @@ class ScheduledSkill:
     voice: bool
     notify: bool
     instructions_path: str | None = None  # when set, scheduler reads at fire time
+    command: tuple[str, ...] | None = None  # when set, scheduler runs subprocess
+                          # instead of dispatching a turn to a mind. Tasks
+                          # with `command` set ignore mind / instructions_file.
 
 
 _FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---", re.DOTALL)
@@ -172,18 +178,46 @@ def discover_scheduler_tasks(tasks_yaml: Path, minds_root: Path) -> list[Schedul
 
     for entry in entries:
         name = entry.get("name")
-        mind_name = entry.get("mind")
         cron = (entry.get("cron") or "").strip()
-        instructions_file = entry.get("instructions_file")
-        if not (name and mind_name and cron and instructions_file):
+        if not (name and cron):
             log.warning("Skipping malformed scheduler task entry: %r", entry)
             continue
-
         if not _validate_cron(cron):
             log.warning(
                 "Skipping scheduler task %s — invalid cron %r (need 5 fields)",
                 name, cron,
             )
+            continue
+
+        command = entry.get("command")
+        if command:
+            if isinstance(command, str):
+                command_tuple: tuple[str, ...] = tuple(command.split())
+            elif isinstance(command, list) and all(isinstance(p, str) for p in command):
+                command_tuple = tuple(command)
+            else:
+                log.warning(
+                    "Skipping scheduler task %s — `command` must be a string or list[str]",
+                    name,
+                )
+                continue
+            found.append(ScheduledSkill(
+                mind_id="scheduler",
+                mind_name="scheduler",
+                skill_name=name,
+                skill_path=command_tuple[0],
+                cron=cron,
+                timezone=entry.get("timezone") or DEFAULT_TIMEZONE,
+                voice=bool(entry.get("voice", False)),
+                notify=bool(entry.get("notify", False)),
+                command=command_tuple,
+            ))
+            continue
+
+        mind_name = entry.get("mind")
+        instructions_file = entry.get("instructions_file")
+        if not (mind_name and instructions_file):
+            log.warning("Skipping malformed scheduler task entry: %r", entry)
             continue
 
         mind_id = _load_mind_uuid(minds_root / mind_name)


### PR DESCRIPTION
## Summary
- Adds a `command` field on `ScheduledSkill` and a `command:` shape on scheduler `tasks.yaml` entries. When present, the scheduler runs the command as a subprocess instead of dispatching a turn to a mind.
- Migrates the `netsage-alert` task from a Bilby LLM dispatch to a direct invocation of `bots/scheduled_tasks/scripts/netsage_run.py`, which already does the whole Loki-query-and-broker-dispatch job in non-JSON mode.
- Bilby kept "running" but never doing useful netsage work: he was spending the turn exploring the file tree and trying to author `netsage_alert_handler.py` instead of running the Loki query. Removing the LLM step kills both the silent-fire bug and the malformed-dispatch bug.

The dispatch still uses Bilby's UUID as `from_mind` so Skippy's `respond-to-netsage-alert-from-bilby` auto-trigger skill keeps working unchanged.

## Test plan
- [ ] PR self-merges, `docker restart hive-mind-scheduler` picks up the bind-mounted edit
- [ ] Next `*/15` fire logs `Firing scheduler/netsage-alert as command:` and `exit=0`
- [ ] Skippy receives a `NetSage alert at ...` broker dispatch and the skill triggers
- [ ] `events.db` gets per-anomaly rows via `process_event.py` instead of nothing