### PR TITLE
bots/telegram_bot: register global error handler

### DIFF
--- a/bots/telegram_bot.py
+++ b/bots/telegram_bot.py
@@ -778,6 +778,14 @@ async def _on_shutdown(app) -> None:
         await http.close()
 
 
+async def _on_error(update: object, context: ContextTypes.DEFAULT_TYPE) -> None:
+    err = context.error
+    if isinstance(err, (NetworkError, TimedOut)):
+        log.info("transient telegram network error (%s): %s", err.__class__.__name__, err)
+        return
+    log.exception("unhandled exception in telegram handler", exc_info=err)
+
+
 if __name__ == "__main__":
     token = _get_bot_token()
 
@@ -794,6 +802,8 @@ if __name__ == "__main__":
         .post_shutdown(_on_shutdown)
         .build()
     )
+
+    app.add_error_handler(_on_error)
 
     app.add_handler(CommandHandler("sessions", cmd_sessions))
     app.add_handler(CommandHandler("new", cmd_new))

--- a/tests/unit/test_telegram_error_handler.py
+++ b/tests/unit/test_telegram_error_handler.py
@@ -1,0 +1,38 @@
+"""Unit tests for the global error handler in telegram_bot."""
+
+import logging
+
+import pytest
+from unittest.mock import MagicMock
+from telegram.error import NetworkError, TimedOut
+
+from bots.telegram_bot import _on_error
+
+
+@pytest.mark.asyncio
+async def test_on_error_swallows_network_error_at_info(caplog):
+    ctx = MagicMock()
+    ctx.error = NetworkError("Bad Gateway")
+    with caplog.at_level(logging.INFO, logger="hive-mind-telegram"):
+        await _on_error(MagicMock(), ctx)
+    assert any("transient telegram network error" in r.message for r in caplog.records)
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_error_swallows_timed_out_at_info(caplog):
+    ctx = MagicMock()
+    ctx.error = TimedOut("read timed out")
+    with caplog.at_level(logging.INFO, logger="hive-mind-telegram"):
+        await _on_error(MagicMock(), ctx)
+    assert any("transient telegram network error" in r.message for r in caplog.records)
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_on_error_logs_other_exceptions_at_error(caplog):
+    ctx = MagicMock()
+    ctx.error = RuntimeError("boom")
+    with caplog.at_level(logging.ERROR, logger="hive-mind-telegram"):
+        await _on_error(MagicMock(), ctx)
+    assert any("unhandled exception" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Telegram's API returned a transient 502 Bad Gateway during getUpdates polling on nagatha-bot. With no error handler registered, PTB logged "No error handlers are registered, logging exception" and surfaced the traceback. NetSage caught it as an application_error anomaly.

This ports the `_on_error` handler already in use on Skippy (skippy@ad809b4): `NetworkError` and `TimedOut` log at info, anything else logs with full traceback, the bot stays alive.

## Test plan

- [x] 3 new unit tests in `tests/unit/test_telegram_error_handler.py`, all passing
- [x] Restarted all five bot containers (telegram-bot, telegram-bot-2, bob-bot, bilby-bot, nagatha-bot) — clean startup