### PR TITLE
mind_templates/codex_cli_ollama: replace scaffold with Bilby-derived implementation

### DIFF
--- a/mind_templates/codex_cli_ollama.py
+++ b/mind_templates/codex_cli_ollama.py
@@ -1,74 +1,332 @@
-# UNTESTED — scaffold only. Validate before production use.
 """Codex CLI + Ollama models template.
 
-Not yet tested. Scaffolded from codex_cli_codex.py.
-Expected to work with Ollama-provided models via the Codex CLI,
-but Codex's Ollama compatibility has not been verified.
+Tested. Based on Bilby's implementation. Spawns one Codex subprocess
+per turn (`codex exec --json --dangerously-bypass-approvals-and-sandbox`)
+against an Ollama-hosted model via a per-mind model_provider override.
+Stores `thread_id` so subsequent turns resume the same Codex thread.
+
+The system prompt is composed upstream by hive-comms and shipped as
+``system_prompt_blocks`` in the spawn payload — this module does not
+compose anything locally.
+
+When the model emits its tool call in a dialect Codex does not parse
+(Llama 3 sentinels, Mistral [TOOL_CALLS] prose, an improvised JSON
+schema, etc.), Codex files the text as ``agent_reasoning`` and closes
+the turn with no ``agent_message``. To stop that surfacing as the
+generic "mind stream closed with no text output" placeholder, the relay
+yields a synthetic assistant frame containing
+``compose_empty_turn_diagnostic`` output.
 """
+
+from __future__ import annotations
 
 import asyncio
 import json
 import logging
+import os
+import signal
 from pathlib import Path
-from typing import Any, AsyncGenerator
+from typing import Any
+from uuid import uuid4
 
-log = logging.getLogger(__name__)
+import aiohttp
+import yaml
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 
-_sessions: dict[str, dict] = {}
 
+def compose_empty_turn_diagnostic(
+    last_reasoning_text: str,
+    last_other_item_type: str,
+) -> str:
+    """Build the diagnostic body for a turn that produced no agent_message.
 
-async def spawn(
-    session_id: str,
-    model: str,
-    autopilot: bool = False,
-    resume_sid: str | None = None,
-    surface_prompt: str | None = None,
-    allowed_directories: list[str] | None = None,
-    soul_file: Path | None = None,
-    mind_id: str = "MIND_NAME",
-    build_base_prompt: Any = None,
-    mcp_config: str = "",
-    registry: Any = None,
-    config_obj: Any = None,
-    is_group_session: bool = False,
-    prompt_files: list[str] | None = None,
-) -> dict:
-    base = (
-        build_base_prompt(
-            allowed_directories=allowed_directories,
-            soul_file=soul_file,
-            mind_id=mind_id,
-            prompt_files=prompt_files,
+    Inputs are best-effort observations from the relay loop:
+      - last_reasoning_text: text from the most recent agent_reasoning item,
+        if any. Empty string if none was seen.
+      - last_other_item_type: type of the most recent non-agent_message
+        item.completed event, if any (e.g. "command_execution"). Empty
+        string if none was seen.
+    """
+    parts = ["Mind produced no agent message this turn."]
+    if last_reasoning_text:
+        parts.append(
+            "The model emitted text on the reasoning channel instead, which "
+            "usually means it tried to call a tool in a dialect Codex does "
+            "not parse. Raw reasoning text follows:"
         )
-        if build_base_prompt else ""
-    )
-    full_prompt = base if not surface_prompt else f"{base}\n\n{surface_prompt}"
-    state = {"system_prompt": full_prompt, "thread_id": resume_sid}
-    _sessions[session_id] = state
-    log.info("Session %s initialised (resume=%s)", session_id, resume_sid or "new")
-    return state
+        parts.append(last_reasoning_text)
+    elif last_other_item_type:
+        parts.append(
+            f"Last item type Codex received was '{last_other_item_type}'."
+        )
+    else:
+        parts.append(
+            "No reasoning or other content was captured. Check the rollout "
+            "JSONL under .codex/sessions for details."
+        )
+    return "\n\n".join(parts)
 
 
-async def send(session_id: str, content: str, images: list[dict] | None = None, db: Any = None) -> AsyncGenerator[dict, None]:
-    state = _sessions.get(session_id)
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+)
+log = logging.getLogger("hive-mind.minds.MIND_NAME")
+
+HERE = Path(__file__).parent
+PROJECT_DIR = Path("/usr/src/app")
+
+RUNTIME = yaml.safe_load((HERE / "runtime.yaml").read_text())
+NAME: str = RUNTIME["name"]
+MIND_ID: str = RUNTIME["mind_id"]
+DEFAULT_MODEL: str = RUNTIME["default_model"]
+PROVIDER: str = RUNTIME["provider"]
+RUNTIME_ENV: dict[str, Any] = RUNTIME.get("env", {}) or {}
+
+NS_URL = os.environ.get("HIVE_MIND_SERVER_URL", "http://server:8420")
+
+CODEX_HOME = Path(RUNTIME.get("runtime_config_dir", f"/usr/src/app/minds/{NAME}/.codex"))
+
+app = FastAPI(title=f"Mind: {NAME}")
+
+# session_id -> {"system_prompt": str, "thread_id": str | None, "model": str}
+SESSIONS: dict[str, dict] = {}
+
+
+def _setup_codex_home() -> None:
+    CODEX_HOME.mkdir(parents=True, exist_ok=True)
+    os.environ["CODEX_HOME"] = str(CODEX_HOME)
+
+
+_setup_codex_home()
+
+
+async def _fetch_secrets_on_startup() -> None:
+    _ENV_MAP = {"gh_oauth_token": "GH_TOKEN", "mcp_auth_token": "MCP_AUTH_TOKEN"}
+    try:
+        async with aiohttp.ClientSession() as http:
+            async with http.get(
+                f"{NS_URL}/secrets/scopes/{NAME}",
+                timeout=aiohttp.ClientTimeout(total=5),
+            ) as resp:
+                if resp.status != 200:
+                    return
+                scopes = await resp.json()
+                secret_keys = scopes.get("secret_keys", []) or []
+            for key in secret_keys:
+                try:
+                    async with http.get(
+                        f"{NS_URL}/secrets/{key}",
+                        timeout=aiohttp.ClientTimeout(total=5),
+                    ) as resp:
+                        if resp.status == 200:
+                            data = await resp.json()
+                            value = data.get("value")
+                            if value:
+                                env_name = _ENV_MAP.get(key, key.upper())
+                                os.environ[env_name] = value
+                                log.info("Secret %s loaded into %s", key, env_name)
+                except Exception:
+                    log.debug("Could not fetch secret %s", key)
+    except Exception:
+        log.debug("Could not connect to NS for secrets")
+
+
+def _provider_args() -> list[str]:
+    if PROVIDER != "ollama":
+        return []
+
+    base_url = str(
+        RUNTIME_ENV.get("OLLAMA_BASE_URL")
+        or RUNTIME_ENV.get("OPENAI_BASE_URL")
+        or "http://localhost:11434/v1"
+    ).rstrip("/")
+
+    provider_key = f"{NAME}_ollama"
+    return [
+        "-c",
+        f'model_provider="{provider_key}"',
+        "-c",
+        f'model_providers.{provider_key}.name="{NAME.capitalize()} Ollama"',
+        "-c",
+        f'model_providers.{provider_key}.base_url="{base_url}"',
+    ]
+
+
+async def _reap_proc(proc: asyncio.subprocess.Process | None) -> None:
+    """Kill the codex subprocess group and wait for it to exit.
+
+    codex is a node wrapper that spawns a rust binary as its child. Killing
+    only the node parent would orphan the rust child to PID 1 (us). Spawning
+    with start_new_session=True puts both in their own process group; killpg
+    on SIGKILL takes them both down. Safe to call when proc is None or already
+    exited.
+    """
+    if proc is None or proc.returncode is not None:
+        return
+    try:
+        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=5.0)
+    except asyncio.TimeoutError:
+        log.warning("codex pid %s did not exit within 5s of SIGKILL", proc.pid)
+
+
+@app.on_event("startup")
+async def _startup() -> None:
+    await _fetch_secrets_on_startup()
+    log.info("%s ready (mind_id=%s, default_model=%s, codex_home=%s)",
+             NAME, MIND_ID, DEFAULT_MODEL, CODEX_HOME)
+
+
+@app.get("/health")
+async def health() -> dict:
+    return {"name": NAME, "mind_id": MIND_ID, "ok": True, "sessions": len(SESSIONS)}
+
+
+@app.get("/sessions")
+async def list_sessions() -> list[dict]:
+    return [
+        {"id": sid, "mind_id": MIND_ID, "model": s.get("model", "unknown"), "status": "running"}
+        for sid, s in SESSIONS.items()
+    ]
+
+
+@app.post("/sessions")
+async def create_session(req: Request) -> Any:
+    body = await req.json()
+    sid = body.get("session_id") or str(uuid4())
+    model = body.get("model") or DEFAULT_MODEL
+    resume_sid = body.get("resume_sid")
+    system_prompt_blocks = body.get("system_prompt_blocks") or ""
+    surface_prompt = body.get("surface_prompt")
+    # Spawn-env metadata for the rotation hook. The hook reads these from
+    # the codex subprocess env to attribute the rotation summary to the
+    # right (mind_id, client_ref) row in NS's session_memory table.
+    client_ref = body.get("client_ref") or ""
+    owner_type = body.get("owner_type") or ""
+    owner_ref = body.get("owner_ref") or ""
+    try:
+        if system_prompt_blocks and surface_prompt:
+            full_prompt = f"{system_prompt_blocks}\n\n{surface_prompt}"
+        elif surface_prompt:
+            full_prompt = surface_prompt
+        else:
+            full_prompt = system_prompt_blocks
+        SESSIONS[sid] = {
+            "system_prompt": full_prompt,
+            "thread_id": resume_sid,
+            "model": model,
+            "client_ref": client_ref,
+            "owner_type": owner_type,
+            "owner_ref": owner_ref,
+        }
+        log.info("%s session %s initialised (model=%s resume=%s)",
+                 NAME, sid, model, resume_sid or "new")
+        return {"session_id": sid, "mind_id": MIND_ID, "name": NAME, "status": "running", "model": model}
+    except Exception as exc:
+        log.exception("Failed to create session for %s", NAME)
+        return JSONResponse({"error": str(exc)}, status_code=500)
+
+
+async def _run_codex_turn(sid: str, content: str, images: list[dict] | None) -> Any:
+    state = SESSIONS.get(sid)
     if state is None:
         yield {"type": "result", "is_error": True}
         return
 
     thread_id = state.get("thread_id")
     if thread_id:
-        cmd = ["codex", "exec", "--json", "--dangerously-bypass-approvals-and-sandbox", "resume", thread_id, "-"]
+        cmd = [
+            "codex",
+            "exec",
+            "--json",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--model",
+            state["model"],
+            *_provider_args(),
+            "resume",
+            thread_id,
+            "-",
+        ]
         stdin_content = content
     else:
-        cmd = ["codex", "exec", "--json", "--dangerously-bypass-approvals-and-sandbox", "-"]
+        cmd = [
+            "codex",
+            "exec",
+            "--json",
+            "--dangerously-bypass-approvals-and-sandbox",
+            "--model",
+            state["model"],
+            *_provider_args(),
+            "-",
+        ]
         stdin_content = f"{state['system_prompt']}\n\n---\n\n{content}"
 
-    proc = await asyncio.create_subprocess_exec(*cmd, stdin=asyncio.subprocess.PIPE, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, limit=10*1024*1024)
+    if images:
+        log.warning("%s session %s: image input not supported, ignoring", NAME, sid)
+
+    log.info("%s session %s: spawning codex turn (thread=%s)", NAME, sid, thread_id or "new")
+
+    env = os.environ.copy()
+    env.update({k: str(v) for k, v in RUNTIME_ENV.items()})
+    # Per-spawn metadata for the rotation_check Stop hook. The hook reads
+    # these to attribute the rotation summary to the right (mind_id,
+    # client_ref) row in NS's session_memory table. Empty values stay
+    # unset so the hook can detect the no-op case ("missing mind_id/
+    # client_ref in env") instead of writing under a fake key.
+    if state.get("client_ref"):
+        env["CLIENT_REF"] = state["client_ref"]
+    if state.get("owner_type"):
+        env["OWNER_TYPE"] = state["owner_type"]
+    if state.get("owner_ref"):
+        env["OWNER_REF"] = state["owner_ref"]
+
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        limit=10 * 1024 * 1024,
+        env=env,
+        cwd=str(PROJECT_DIR),
+        start_new_session=True,
+    )
+    state["proc"] = proc
     proc.stdin.write(stdin_content.encode())
     await proc.stdin.drain()
     proc.stdin.close()
 
     current_thread_id = thread_id
+
+    # Track whether the model produced any assistant text this turn, plus the
+    # most recent reasoning text and the most recent non-agent_message item
+    # type. If the turn closes without an agent_message, the relay synthesises
+    # a diagnostic assistant frame from these so the operator sees what the
+    # model actually emitted instead of dead air.
+    saw_agent_message = False
+    last_reasoning_text = ""
+    last_other_item_type = ""
+
+    def _empty_turn_frame() -> dict:
+        return {
+            "type": "assistant",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": compose_empty_turn_diagnostic(
+                            last_reasoning_text, last_other_item_type
+                        ),
+                    }
+                ],
+            },
+        }
+
     async for raw_line in proc.stdout:
         line = raw_line.decode().strip()
         if not line:
@@ -77,27 +335,137 @@ async def send(session_id: str, content: str, images: list[dict] | None = None, 
             event = json.loads(line)
         except json.JSONDecodeError:
             continue
+
         etype = event.get("type", "")
+        yield {
+            "type": "codex_event",
+            "session_id": sid,
+            "event": event,
+            "_observer_only": True,
+        }
+
         if etype == "thread.started":
             current_thread_id = event.get("thread_id")
             state["thread_id"] = current_thread_id
-            if db and current_thread_id:
-                await db.execute("UPDATE sessions SET claude_sid = ? WHERE id = ?", (current_thread_id, session_id))
         elif etype == "item.completed":
             item = event.get("item", {})
-            if item.get("type") == "agent_message" and item.get("text"):
-                yield {"type": "assistant", "message": {"role": "assistant", "content": [{"type": "text", "text": item["text"]}]}}
+            item_type = item.get("type", "")
+            if item_type == "agent_message":
+                text = item.get("text", "")
+                if text:
+                    saw_agent_message = True
+                    yield {
+                        "type": "assistant",
+                        "message": {
+                            "role": "assistant",
+                            "content": [{"type": "text", "text": text}],
+                        },
+                    }
+            elif item_type in ("agent_reasoning", "reasoning"):
+                text = item.get("text", "") or item.get("content", "")
+                if text:
+                    last_reasoning_text = text
+            elif item_type:
+                last_other_item_type = item_type
         elif etype == "turn.completed":
-            await proc.wait()
-            yield {"type": "result", "session_id": current_thread_id, "stop_reason": "end_turn", "is_error": False}
+            if not saw_agent_message:
+                yield _empty_turn_frame()
+            await _reap_proc(proc)
+            state["proc"] = None
+            yield {
+                "type": "result",
+                "session_id": current_thread_id,
+                "stop_reason": "end_turn",
+                "is_error": False,
+            }
             return
         elif etype == "turn.failed":
-            await proc.wait()
+            error_msg = event.get("error", {}).get("message", "Unknown error")
+            log.error("%s session %s: turn failed: %s", NAME, sid, error_msg)
+            # Clear the cached thread_id so the next turn starts fresh
+            # rather than resuming a thread Codex still has an unanswered
+            # turn sitting in (otherwise the next message gets the failed
+            # turn's response — the operator ends up one turn behind).
+            state["thread_id"] = None
+            if not saw_agent_message:
+                yield _empty_turn_frame()
+            await _reap_proc(proc)
+            state["proc"] = None
             yield {"type": "result", "is_error": True}
             return
-    await proc.wait()
+
+    # Stream ended without turn.completed or turn.failed — treat as
+    # incomplete. Same reasoning as turn.failed: don't leave thread_id
+    # dirty or the next turn will resume into a broken thread.
+    state["thread_id"] = None
+    if not saw_agent_message:
+        yield _empty_turn_frame()
+    await _reap_proc(proc)
+    state["proc"] = None
     yield {"type": "result", "session_id": current_thread_id, "is_error": False}
 
 
-async def kill(session_id: str) -> None:
-    _sessions.pop(session_id, None)
+@app.post("/sessions/{sid}/message")
+async def send_message(sid: str, req: Request) -> Any:
+    body = await req.json()
+    content = body.get("content", "")
+    images = body.get("images")
+    if sid not in SESSIONS:
+        return JSONResponse({"error": f"Session {sid} not found"}, status_code=404)
+
+    # Turn-bleed guard. Codex CLI spawns a fresh subprocess per turn, but two
+    # concurrent calls would race against the same state["thread_id"] — both
+    # trying to resume the same Codex thread. Refuse to start a second turn
+    # while one is in flight; caller retries.
+    sess = SESSIONS[sid]
+    if sess.get("in_flight"):
+        return JSONResponse(
+            {"error": "Turn in progress, retry shortly"},
+            status_code=409,
+        )
+    sess["in_flight"] = True
+
+    async def stream() -> Any:
+        try:
+            async for event in _run_codex_turn(sid, content, images):
+                yield f"data: {json.dumps(event)}\n\n"
+        finally:
+            # Clear in_flight on every exit path: normal completion, generator
+            # cancellation (client disconnect), or exception. Without this, an
+            # abandoned stream would lock the session out of all future turns.
+            sess["in_flight"] = False
+            # Reap the codex subprocess on cancellation. Without this, an SSE
+            # client disconnect (broker timeout, etc.) leaves the codex node +
+            # rust child running until they crash on their own, leaking file
+            # descriptors. The _run_codex_turn exit paths clear state["proc"]
+            # on normal completion, so this only fires when the generator was
+            # cancelled mid-stream.
+            leftover = sess.get("proc")
+            if leftover is not None:
+                await _reap_proc(leftover)
+                sess["proc"] = None
+
+    return StreamingResponse(stream(), media_type="text/event-stream")
+
+
+@app.post("/sessions/{sid}/interrupt")
+async def interrupt_session(sid: str) -> Any:
+    if sid not in SESSIONS:
+        return JSONResponse({"error": f"Session {sid} not found"}, status_code=404)
+    return {"ok": True, "session_id": sid, "message": "codex_per_turn"}
+
+
+@app.delete("/sessions/{sid}")
+async def kill_session(sid: str) -> dict:
+    sess = SESSIONS.pop(sid, None)
+    if sess is not None:
+        await _reap_proc(sess.get("proc"))
+    log.info("Killed %s session %s", NAME, sid)
+    return {"session_id": sid, "status": "closed"}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    port = int(os.environ.get("MIND_SERVER_PORT", "8420"))
+    uvicorn.run(app, host="0.0.0.0", port=port, log_level="info")

--- a/tests/unit/test_codex_cli_ollama_template.py
+++ b/tests/unit/test_codex_cli_ollama_template.py
@@ -1,0 +1,84 @@
+"""Tests for the inlined empty-turn diagnostic helper in the codex_cli_ollama template.
+
+When Codex closes a turn with no `agent_message` item — typically because
+the model emitted its tool call in a non-Responses dialect that landed
+on the reasoning channel — the template's relay synthesises a diagnostic
+assistant frame so the operator sees what the model actually produced
+instead of the generic "mind stream closed with no text output"
+placeholder. This file pins the helper's behaviour.
+
+The template module reads a `runtime.yaml` next to itself at import time
+(and instantiates a FastAPI app), so the helper is loaded by extracting
+just its function definition from the source via ast — no module import,
+no side effects.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+from typing import Callable
+
+TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "mind_templates"
+    / "codex_cli_ollama.py"
+)
+
+
+def _load_helper() -> Callable[[str, str], str]:
+    source = TEMPLATE_PATH.read_text()
+    tree = ast.parse(source)
+    func_node: ast.FunctionDef | None = None
+    for node in tree.body:
+        if (
+            isinstance(node, ast.FunctionDef)
+            and node.name == "compose_empty_turn_diagnostic"
+        ):
+            func_node = node
+            break
+    assert func_node is not None, "compose_empty_turn_diagnostic missing from template"
+    module = ast.Module(body=[func_node], type_ignores=[])
+    namespace: dict = {}
+    exec(compile(module, str(TEMPLATE_PATH), "exec"), namespace)
+    return namespace["compose_empty_turn_diagnostic"]
+
+
+compose_empty_turn_diagnostic = _load_helper()
+
+
+def test_reasoning_text_is_surfaced_verbatim() -> None:
+    raw = "<|tool_call_start|>[exec_command(cmd='ls -la')]<|tool_call_end|>"
+    out = compose_empty_turn_diagnostic(
+        last_reasoning_text=raw, last_other_item_type=""
+    )
+    assert "no agent message" in out.lower()
+    assert "reasoning channel" in out
+    assert raw in out
+
+
+def test_other_item_type_is_named_when_no_reasoning() -> None:
+    out = compose_empty_turn_diagnostic(
+        last_reasoning_text="", last_other_item_type="command_execution"
+    )
+    assert "no agent message" in out.lower()
+    assert "command_execution" in out
+    assert "reasoning channel" not in out
+
+
+def test_minimal_diagnostic_when_nothing_captured() -> None:
+    out = compose_empty_turn_diagnostic(
+        last_reasoning_text="", last_other_item_type=""
+    )
+    assert "no agent message" in out.lower()
+    assert "rollout" in out.lower()
+    assert "reasoning channel" not in out
+
+
+def test_reasoning_takes_precedence_over_other_item_type() -> None:
+    raw = '[TOOL_CALLS]{"name": "exec_command", "arguments": {"cmd": "ls"}}'
+    out = compose_empty_turn_diagnostic(
+        last_reasoning_text=raw, last_other_item_type="command_execution"
+    )
+    assert raw in out
+    assert "command_execution" not in out

--- a/tests/unit/test_poll_broker.py
+++ b/tests/unit/test_poll_broker.py
@@ -31,7 +31,8 @@ class TestParseArgs:
         assert args.to_mind == "nagatha"
         assert args.request_type == "quick_query"
 
-    def test_parse_args_gateway_url_default(self):
+    def test_parse_args_gateway_url_default(self, monkeypatch):
+        monkeypatch.delenv("HIVEMIND_BROKER_URL", raising=False)
         mod = _import_poll()
         args = mod.parse_args([
             "--conversation_id", "conv-1",


### PR DESCRIPTION
## Summary

Replace the untested Codex CLI + Ollama scaffold with the FastAPI-shaped implementation Bilby is running in production, with the empty-turn diagnostic helper inlined so the template stays a single self-contained file (which is what `/create-mind` expects when it does `cp mind_templates/<selected>.py minds/<name>/implementation.py`).

When the model emits its tool call in a dialect Codex does not parse (Llama 3 `<|tool_call_start|>` sentinels, Mistral `[TOOL_CALLS]` prose, an improvised JSON shape, etc.), Codex files the text as `agent_reasoning` and closes the turn with no `agent_message`. The relay now synthesises a diagnostic assistant frame so the Telegram surface no longer falls back to the generic "mind stream closed with no text output" placeholder; instead it surfaces the raw reasoning text so the operator can see which dialect the model used.

Bilby's live implementation has been verified against five models:

- `lfm2.5:latest` — Llama 3 sentinels surfaced verbatim
- `qwen3-coder:latest` — improvised JSON schema surfaced verbatim
- `mistral-nemo` — Mistral bracket `[TOOL_CALLS]` surfaced verbatim
- `qwen3:30b-a3b-instruct-2507-q4_K_M` — no captured content, third diagnostic branch fires
- `gpt-oss:20b-32k` — clean function-call path, no regression (control)

## Other changes

`tests/unit/test_poll_broker.py::TestParseArgs::test_parse_args_gateway_url_default` was reading `HIVEMIND_BROKER_URL` out of the host environment and asserting against a hard-coded default. Monkeypatched the env var out so the assertion is environment-independent.

## Test plan

- [x] `tests/unit/test_codex_cli_ollama_template.py` pins the inlined helper via ast-extracted exec (no module-load side effects).
- [x] Full unit suite: `248 passed, 43 warnings`.
- [x] End-to-end: Bilby on host verified against the five models listed above; diagnostic frame fires on the four broken-dialect runs and stays silent on the gpt-oss control.