### PR TITLE
netsage_run: surface Suricata IDS alerts

### DIFF
--- a/bots/scheduled_tasks/scripts/netsage_run.py
+++ b/bots/scheduled_tasks/scripts/netsage_run.py
@@ -29,6 +29,14 @@ ANOMALY_REGEX = re.compile(
     r"\b(?:" + "|".join(ANOMALY_PATTERNS) + r")\b", re.IGNORECASE
 )
 MAX_JOURNAL_PRIORITY = 4
+
+# Suricata IDS expresses badness through a numeric severity field and a
+# signature name, not the English crisis words ANOMALY_REGEX hunts for, so
+# eve.json alerts slip past the generic text filter entirely. Suricata
+# severity is inverted: 1 is the most severe (active attack), 3 the least
+# (informational noise such as "Ethertype unknown" or our own Telegram
+# traffic showing up in ET HUNTING rules). Forward severity 1 and 2; drop 3.
+SURICATA_SEVERITY_CEILING = 2
 BENIGN_SUBSTRINGS = (
     "auto_remember",
     "scheduled_skill",
@@ -126,10 +134,53 @@ def _service_label(record: dict | None, raw_svc: str) -> str:
     return raw_svc
 
 
+def _suricata_alert(record: dict | None) -> str | None:
+    """Return a readable one-liner for a worth-forwarding Suricata alert.
+
+    Vector merges the parsed eve.json line into the record, so an alert event
+    carries a top-level event_type=="alert" and an alert sub-object with
+    severity/signature/category. Returns None for non-alert Suricata events
+    (flow, dns, tls, stats…) and for alerts at or below the noise ceiling.
+    """
+    if not record or record.get("event_type") != "alert":
+        return None
+    alert = record.get("alert")
+    if not isinstance(alert, dict):
+        return None
+    try:
+        severity = int(alert.get("severity"))
+    except (TypeError, ValueError):
+        severity = None
+    if severity is not None and severity > SURICATA_SEVERITY_CEILING:
+        return None
+    signature = alert.get("signature") or "unknown signature"
+    category = alert.get("category") or ""
+    src = record.get("src_ip")
+    dst = record.get("dest_ip")
+    sev_label = severity if severity is not None else "?"
+    parts = [f"Suricata alert severity {sev_label}: {signature}"]
+    if category:
+        parts.append(f"({category})")
+    if src or dst:
+        parts.append(f"{src or '?'} to {dst or '?'}")
+    return " ".join(parts)
+
+
 def pick_anomalies(lines):
     out = []
     for svc, ts, msg in lines:
         record = _decode_envelope(msg)
+        suricata_line = _suricata_alert(record)
+        if suricata_line is not None:
+            host = record.get("host") if record else None
+            out.append((f"suricata@{host or svc}", ts, suricata_line))
+            continue
+        if record and record.get("source_app") == "suricata":
+            # Any other Suricata event (stats, flow, dns, tls…) only ever
+            # surfaces via the alert path above. Skip it before the generic
+            # text filter, whose crisis words (e.g. "error") match substrings
+            # in Suricata's own internal stats counter names.
+            continue
         priority = _journal_priority(record)
         if priority is not None and priority > MAX_JOURNAL_PRIORITY:
             continue

--- a/tests/unit/test_netsage_run.py
+++ b/tests/unit/test_netsage_run.py
@@ -1,0 +1,144 @@
+"""Unit tests for the NetSage scheduler alert pass.
+
+Focus is the anomaly picker, specifically that Suricata IDS alerts — which
+express badness through a numeric severity field rather than the English
+crisis words the generic regex hunts for — are surfaced, while informational
+Suricata noise and non-alert Suricata events (flow/dns/tls) are dropped.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = _PROJECT_ROOT / "bots/scheduled_tasks/scripts/netsage_run.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("netsage_run", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+netsage = _load_module()
+
+
+def _suricata_eve(event_type="alert", severity=1, signature="ET ATTACK Something",
+                  category="A Network Trojan was Detected", src="10.0.0.5",
+                  dst="10.0.0.1", host="NetSage"):
+    """Build the JSON envelope Vector ships to Loki for a Suricata eve line."""
+    record = {
+        "event_type": event_type,
+        "host": host,
+        "source_app": "suricata",
+        "src_ip": src,
+        "dest_ip": dst,
+        "in_iface": "enp2s0",
+    }
+    if event_type == "alert":
+        record["alert"] = {
+            "severity": severity,
+            "signature": signature,
+            "category": category,
+            "action": "allowed",
+        }
+    return json.dumps(record)
+
+
+# ---------------------------------------------------------------------------
+# _suricata_alert
+# ---------------------------------------------------------------------------
+
+def test_high_severity_alert_is_surfaced():
+    record = json.loads(_suricata_eve(severity=1, signature="ET ATTACK X"))
+    line = netsage._suricata_alert(record)
+    assert line is not None
+    assert "severity 1" in line
+    assert "ET ATTACK X" in line
+    assert "10.0.0.5 to 10.0.0.1" in line
+
+
+def test_ceiling_severity_alert_is_surfaced():
+    record = json.loads(_suricata_eve(severity=netsage.SURICATA_SEVERITY_CEILING))
+    assert netsage._suricata_alert(record) is not None
+
+
+def test_informational_severity_alert_is_dropped():
+    record = json.loads(_suricata_eve(severity=3, signature="SURICATA Ethertype unknown"))
+    assert netsage._suricata_alert(record) is None
+
+
+def test_non_alert_suricata_event_is_dropped():
+    record = json.loads(_suricata_eve(event_type="flow"))
+    assert netsage._suricata_alert(record) is None
+
+
+def test_alert_without_severity_still_surfaces():
+    record = json.loads(_suricata_eve())
+    del record["alert"]["severity"]
+    line = netsage._suricata_alert(record)
+    assert line is not None
+    assert "severity ?" in line
+
+
+def test_non_suricata_record_returns_none():
+    assert netsage._suricata_alert({"message": "some app log"}) is None
+    assert netsage._suricata_alert(None) is None
+
+
+# ---------------------------------------------------------------------------
+# pick_anomalies integration
+# ---------------------------------------------------------------------------
+
+def test_pick_anomalies_surfaces_suricata_alert():
+    lines = [("unknown_service", "1", _suricata_eve(severity=1, signature="ET ATTACK X"))]
+    out = netsage.pick_anomalies(lines)
+    assert len(out) == 1
+    label, _ts, msg = out[0]
+    assert label == "suricata@NetSage"
+    assert "ET ATTACK X" in msg
+
+
+def test_pick_anomalies_drops_suricata_noise():
+    lines = [
+        ("unknown_service", "1", _suricata_eve(severity=3, signature="SURICATA Ethertype unknown")),
+        ("unknown_service", "2", _suricata_eve(event_type="dns")),
+        ("unknown_service", "3", _suricata_eve(event_type="flow")),
+    ]
+    assert netsage.pick_anomalies(lines) == []
+
+
+def test_pick_anomalies_drops_suricata_stats_with_error_counter():
+    # Suricata stats payloads carry counter names containing "error"; they
+    # must never reach the generic English-word filter.
+    stats = json.dumps({
+        "event_type": "stats",
+        "source_app": "suricata",
+        "host": "NetSage",
+        "stats": {"app_layer": {"error": {"http": {"alloc": 0}}}, "capture": {"errors": 0}},
+    })
+    assert "error" in stats
+    assert netsage.pick_anomalies([("unknown_service", "1", stats)]) == []
+
+
+def test_pick_anomalies_still_catches_plain_text_errors():
+    lines = [("ollama.service", "1", "CRITICAL: model failed to load")]
+    out = netsage.pick_anomalies(lines)
+    assert len(out) == 1
+    assert "CRITICAL" in out[0][2]
+
+
+def test_pick_anomalies_mixed_stream():
+    lines = [
+        ("unknown_service", "1", _suricata_eve(severity=1, signature="ET ATTACK X")),
+        ("unknown_service", "2", _suricata_eve(severity=3, signature="Ethertype unknown")),
+        ("skippy.service", "3", "Traceback (most recent call last):"),
+        ("unknown_service", "4", _suricata_eve(event_type="tls")),
+    ]
+    out = netsage.pick_anomalies(lines)
+    assert len(out) == 2
+    labels = {label for label, _, _ in out}
+    assert labels == {"suricata@NetSage", "skippy.service"}


### PR DESCRIPTION
## Why

NetSage has been silent since Suricata was wired in. The 15-minute alert pass filtered every Loki line through an English crisis-word regex (`error/critical/panic/...`). Suricata signals badness via a numeric `alert.severity` field and a signature name, so eve.json alerts never matched the regex and **no IDS event ever reached Skippy**. Separately, Suricata's `stats` payloads contain counter names with the substring `error`, so those leaked through as false anomalies.

## What

- New `_suricata_alert()` helper: returns a readable one-liner for `event_type=alert` events at severity 1 or 2 (Suricata severity is inverted; 1 is most severe). Severity 3 is informational noise (`Ethertype unknown`, our own Telegram traffic in ET HUNTING rules) and is dropped.
- `pick_anomalies()` now forwards Suricata alerts and short-circuits all other Suricata events (`stats/flow/dns/tls`) before the generic text filter.

## Verification

- 11 unit tests in `tests/unit/test_netsage_run.py`, all passing.
- Live run in `hive-mind-scheduler` against production Loki: Suricata stats noise dropped (anomaly count 31 → 12, remaining 12 are genuine container logs). Suricata alert path confirmed against real eve.json envelopes.