### PR TITLE
training_capture: storage layer for harness fine-tuning dataset

### DIFF
--- a/core/training_capture.py
+++ b/core/training_capture.py
@@ -1,0 +1,216 @@
+"""Training-example capture: storage layer.
+
+One SQLite table, ``training_examples``, holding raw harness sessions for
+harness-fidelity fine-tuning. The dataset teaches an open model to *drive*
+the Claude Code and Codex CLI harnesses — tool-call syntax, skill
+invocations, structural delimiters, and the policy of when to reach for
+which tool — not to reproduce a teacher's prose.
+
+Two properties define this layer:
+
+- **Lossless and raw.** No sanitization, no curation, no redaction. The row
+  stores exactly what the harness emitted. Filtering and key-substitution
+  are deliberately deferred to optional export-time passes over this
+  immutable store (see the spark_to_bloom backlog memo
+  ``clawd-harness-finetuning.md``).
+- **Upsert by ``session_id``.** Each Stop-hook fire re-reads the full
+  transcript and upserts one row keyed by ``session_id``. Whatever shape the
+  session has at its final turn is what persists, so the capture path does
+  not depend on a ``SessionEnd`` primitive and cannot race a closing session.
+
+This module is intentionally dumb: it persists what it is given. Transcript
+parsing and tool-call normalization live in the per-harness consumers that
+call ``upsert_example``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Harness identifiers stored in the ``harness`` column.
+HARNESS_CLAUDE_CODE = "claude_code"
+HARNESS_CODEX = "codex"
+VALID_HARNESSES = frozenset({HARNESS_CLAUDE_CODE, HARNESS_CODEX})
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS training_examples (
+    id                INTEGER PRIMARY KEY,
+    session_id        TEXT NOT NULL UNIQUE,
+    mind_id           TEXT,
+    harness           TEXT NOT NULL,
+    source_model      TEXT,
+    harness_version   TEXT,
+    captured_at       INTEGER,
+    system_prompt     TEXT,
+    turns             TEXT,
+    turn_count        INTEGER,
+    tool_call_count   INTEGER,
+    length_tokens     INTEGER,
+    quality_flag      TEXT NOT NULL DEFAULT 'pending',
+    judge_verdict     TEXT,
+    judge_confidence  REAL,
+    exclusion_reason  TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_training_examples_harness
+    ON training_examples (harness);
+CREATE INDEX IF NOT EXISTS idx_training_examples_source_model
+    ON training_examples (source_model);
+"""
+
+# Columns written on upsert. ``id`` is autoincrement; the judge/exclusion
+# columns are populated by later curation passes, not at capture time.
+_UPSERT_COLUMNS = (
+    "session_id",
+    "mind_id",
+    "harness",
+    "source_model",
+    "harness_version",
+    "captured_at",
+    "system_prompt",
+    "turns",
+    "turn_count",
+    "tool_call_count",
+    "length_tokens",
+)
+
+
+@dataclass
+class TrainingExample:
+    """One captured harness session, ready to persist.
+
+    ``turns`` is the normalized turn array (a list of dicts); it is stored as
+    JSON text. ``turn_count`` and ``tool_call_count`` are derived from it by
+    :meth:`from_turns` so they cannot drift from the stored turns.
+    """
+
+    session_id: str
+    harness: str
+    mind_id: str | None = None
+    source_model: str | None = None
+    harness_version: str | None = None
+    captured_at: int | None = None
+    system_prompt: str | None = None
+    turns: list[dict] = field(default_factory=list)
+    turn_count: int = 0
+    tool_call_count: int = 0
+    length_tokens: int | None = None
+
+    def __post_init__(self) -> None:
+        if self.harness not in VALID_HARNESSES:
+            raise ValueError(
+                f"unknown harness {self.harness!r}; "
+                f"expected one of {sorted(VALID_HARNESSES)}"
+            )
+
+    @classmethod
+    def from_turns(
+        cls,
+        *,
+        session_id: str,
+        harness: str,
+        turns: list[dict],
+        **kwargs,
+    ) -> "TrainingExample":
+        """Build an example, deriving the counts from ``turns``.
+
+        ``turn_count`` is the number of turns. ``tool_call_count`` sums the
+        ``tool_calls`` entries across all turns, which is the metric that
+        matters for prioritizing tool-heavy sessions.
+        """
+        tool_calls = sum(len(t.get("tool_calls") or []) for t in turns)
+        return cls(
+            session_id=session_id,
+            harness=harness,
+            turns=turns,
+            turn_count=len(turns),
+            tool_call_count=tool_calls,
+            **kwargs,
+        )
+
+    def _row_values(self) -> tuple:
+        return (
+            self.session_id,
+            self.mind_id,
+            self.harness,
+            self.source_model,
+            self.harness_version,
+            self.captured_at,
+            self.system_prompt,
+            json.dumps(self.turns, ensure_ascii=False),
+            self.turn_count,
+            self.tool_call_count,
+            self.length_tokens,
+        )
+
+
+def connect(db_path: str | Path) -> sqlite3.Connection:
+    """Open a connection with a ``Row`` factory and foreign keys on."""
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def init_db(db_path: str | Path) -> None:
+    """Create the table and indexes if they do not already exist."""
+    path = Path(db_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with connect(path) as conn:
+        conn.executescript(SCHEMA)
+
+
+def upsert_example(db_path: str | Path, example: TrainingExample) -> None:
+    """Insert or replace a row keyed by ``session_id``.
+
+    On conflict the capture-time columns are overwritten with the latest
+    transcript shape while ``id`` is preserved. The curation columns
+    (``quality_flag``, ``judge_*``, ``exclusion_reason``) are left untouched
+    so a re-capture of a session does not clobber a verdict already assigned
+    by a later pass.
+    """
+    init_db(db_path)
+    placeholders = ", ".join("?" for _ in _UPSERT_COLUMNS)
+    columns = ", ".join(_UPSERT_COLUMNS)
+    updates = ", ".join(
+        f"{col} = excluded.{col}"
+        for col in _UPSERT_COLUMNS
+        if col != "session_id"
+    )
+    sql = (
+        f"INSERT INTO training_examples ({columns}) VALUES ({placeholders}) "
+        f"ON CONFLICT(session_id) DO UPDATE SET {updates}"
+    )
+    with connect(db_path) as conn:
+        conn.execute(sql, example._row_values())
+
+
+def get_example(db_path: str | Path, session_id: str) -> dict | None:
+    """Return one row as a dict (with ``turns`` decoded), or ``None``."""
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT * FROM training_examples WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+    if row is None:
+        return None
+    record = dict(row)
+    record["turns"] = json.loads(record["turns"]) if record["turns"] else []
+    return record
+
+
+def count_examples(db_path: str | Path, harness: str | None = None) -> int:
+    """Count rows, optionally filtered by ``harness``."""
+    with connect(db_path) as conn:
+        if harness is None:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM training_examples"
+            ).fetchone()
+        else:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM training_examples WHERE harness = ?",
+                (harness,),
+            ).fetchone()
+    return int(row[0])

--- a/tests/unit/test_training_capture.py
+++ b/tests/unit/test_training_capture.py
@@ -1,0 +1,243 @@
+"""Unit tests for the training-example storage layer.
+
+Covers schema creation, upsert-by-session_id idempotency, count derivation
+from turns, harness validation, and that re-capture preserves curation
+columns assigned by a later pass.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.training_capture import (
+    HARNESS_CLAUDE_CODE,
+    HARNESS_CODEX,
+    TrainingExample,
+    connect,
+    count_examples,
+    get_example,
+    init_db,
+    upsert_example,
+)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return tmp_path / "nested" / "training_examples.db"
+
+
+def _turns():
+    return [
+        {"role": "user", "content": "do the thing"},
+        {
+            "role": "assistant",
+            "content": "on it",
+            "tool_calls": [
+                {"type": "Bash", "input": {"command": "ls"}},
+                {"type": "Read", "input": {"path": "x"}},
+            ],
+        },
+        {"role": "tool", "content": "result", "tool_call_id": "t1"},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# schema / init
+# ---------------------------------------------------------------------------
+
+def test_init_db_creates_table_and_parent_dir(db_path):
+    assert not db_path.parent.exists()
+    init_db(db_path)
+    assert db_path.exists()
+    with connect(db_path) as conn:
+        names = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+    assert "training_examples" in names
+
+
+def test_init_db_is_idempotent(db_path):
+    init_db(db_path)
+    init_db(db_path)  # must not raise
+    assert count_examples(db_path) == 0
+
+
+# ---------------------------------------------------------------------------
+# from_turns derivation
+# ---------------------------------------------------------------------------
+
+def test_from_turns_derives_counts():
+    ex = TrainingExample.from_turns(
+        session_id="s1", harness=HARNESS_CLAUDE_CODE, turns=_turns()
+    )
+    assert ex.turn_count == 3
+    assert ex.tool_call_count == 2
+
+
+def test_from_turns_handles_missing_tool_calls():
+    turns = [{"role": "user", "content": "hi"}]
+    ex = TrainingExample.from_turns(
+        session_id="s1", harness=HARNESS_CODEX, turns=turns
+    )
+    assert ex.turn_count == 1
+    assert ex.tool_call_count == 0
+
+
+def test_invalid_harness_rejected():
+    with pytest.raises(ValueError):
+        TrainingExample(session_id="s1", harness="bashrc")
+
+
+# ---------------------------------------------------------------------------
+# upsert / get
+# ---------------------------------------------------------------------------
+
+def test_upsert_then_get_roundtrips(db_path):
+    ex = TrainingExample.from_turns(
+        session_id="s1",
+        harness=HARNESS_CLAUDE_CODE,
+        turns=_turns(),
+        mind_id="14cb820b",
+        source_model="claude-opus-4-7",
+        harness_version="1.0.0",
+        captured_at=1781649576,
+        system_prompt="you are skippy",
+        length_tokens=42,
+    )
+    upsert_example(db_path, ex)
+
+    got = get_example(db_path, "s1")
+    assert got is not None
+    assert got["session_id"] == "s1"
+    assert got["harness"] == HARNESS_CLAUDE_CODE
+    assert got["mind_id"] == "14cb820b"
+    assert got["source_model"] == "claude-opus-4-7"
+    assert got["turn_count"] == 3
+    assert got["tool_call_count"] == 2
+    assert got["length_tokens"] == 42
+    assert got["quality_flag"] == "pending"
+    assert got["turns"] == _turns()
+
+
+def test_get_missing_returns_none(db_path):
+    init_db(db_path)
+    assert get_example(db_path, "nope") is None
+
+
+def test_upsert_creates_db_if_absent(db_path):
+    # No explicit init_db — upsert must stand up the schema itself.
+    ex = TrainingExample.from_turns(
+        session_id="s1", harness=HARNESS_CODEX, turns=_turns()
+    )
+    upsert_example(db_path, ex)
+    assert count_examples(db_path) == 1
+
+
+def test_upsert_is_idempotent_by_session_id(db_path):
+    ex = TrainingExample.from_turns(
+        session_id="s1", harness=HARNESS_CLAUDE_CODE, turns=_turns()
+    )
+    upsert_example(db_path, ex)
+    upsert_example(db_path, ex)
+    assert count_examples(db_path) == 1
+
+
+def test_upsert_overwrites_capture_columns_and_preserves_id(db_path):
+    first = TrainingExample.from_turns(
+        session_id="s1",
+        harness=HARNESS_CLAUDE_CODE,
+        turns=_turns()[:1],
+        source_model="claude-sonnet-4-6",
+    )
+    upsert_example(db_path, first)
+    with connect(db_path) as conn:
+        original_id = conn.execute(
+            "SELECT id FROM training_examples WHERE session_id='s1'"
+        ).fetchone()[0]
+
+    grown = TrainingExample.from_turns(
+        session_id="s1",
+        harness=HARNESS_CLAUDE_CODE,
+        turns=_turns(),
+        source_model="claude-opus-4-7",
+    )
+    upsert_example(db_path, grown)
+
+    got = get_example(db_path, "s1")
+    assert count_examples(db_path) == 1
+    assert got["turn_count"] == 3
+    assert got["tool_call_count"] == 2
+    assert got["source_model"] == "claude-opus-4-7"
+    with connect(db_path) as conn:
+        new_id = conn.execute(
+            "SELECT id FROM training_examples WHERE session_id='s1'"
+        ).fetchone()[0]
+    assert new_id == original_id
+
+
+def test_recapture_preserves_curation_columns(db_path):
+    ex = TrainingExample.from_turns(
+        session_id="s1", harness=HARNESS_CLAUDE_CODE, turns=_turns()
+    )
+    upsert_example(db_path, ex)
+    # A later curation pass assigns a verdict.
+    with connect(db_path) as conn:
+        conn.execute(
+            "UPDATE training_examples SET quality_flag='clean', "
+            "judge_confidence=0.9 WHERE session_id='s1'"
+        )
+        conn.commit()
+
+    # Re-capture of the same session must not clobber the verdict.
+    upsert_example(db_path, ex)
+    got = get_example(db_path, "s1")
+    assert got["quality_flag"] == "clean"
+    assert got["judge_confidence"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# count filtering
+# ---------------------------------------------------------------------------
+
+def test_count_filters_by_harness(db_path):
+    upsert_example(
+        db_path,
+        TrainingExample.from_turns(
+            session_id="a", harness=HARNESS_CLAUDE_CODE, turns=_turns()
+        ),
+    )
+    upsert_example(
+        db_path,
+        TrainingExample.from_turns(
+            session_id="b", harness=HARNESS_CLAUDE_CODE, turns=_turns()
+        ),
+    )
+    upsert_example(
+        db_path,
+        TrainingExample.from_turns(
+            session_id="c", harness=HARNESS_CODEX, turns=_turns()
+        ),
+    )
+    assert count_examples(db_path) == 3
+    assert count_examples(db_path, harness=HARNESS_CLAUDE_CODE) == 2
+    assert count_examples(db_path, harness=HARNESS_CODEX) == 1
+
+
+def test_turns_stored_as_json_text(db_path):
+    upsert_example(
+        db_path,
+        TrainingExample.from_turns(
+            session_id="s1", harness=HARNESS_CODEX, turns=_turns()
+        ),
+    )
+    with connect(db_path) as conn:
+        raw = conn.execute(
+            "SELECT turns FROM training_examples WHERE session_id='s1'"
+        ).fetchone()[0]
+    assert isinstance(raw, str)
+    assert json.loads(raw) == _turns()


### PR DESCRIPTION
First slice of the tool-call capture pipeline described in the spark_to_bloom backlog memo `clawd-harness-finetuning.md`. **Storage layer only** — no parsers, no hook wiring, no model.

## What

- New `training_examples` table and a thin `core/training_capture.py` SQLite helper.
- Upsert keyed by `session_id`: each Stop-hook fire re-reads the full transcript and overwrites the capture columns, preserving the row `id` and any curation verdict a later pass assigned.
- `TrainingExample.from_turns()` derives `turn_count` and `tool_call_count` from the turns array so the counts can't drift from stored content.
- Lossless and raw by design: no sanitization or curation here. Filtering and key-substitution are deferred to optional export-time passes over this immutable store.

## Verification

13 unit tests in `tests/unit/test_training_capture.py` (schema/init, upsert idempotency, count derivation, harness validation, recapture-preserves-curation, harness-filtered counts). Ruff and mypy clean.

## Not in this PR

The Claude and Codex transcript parsers/normalizers, the per-mind Stop-hook consumers (Skippy wired first), and fixture-based parser tests are the next slices.