### PR TITLE
training_capture_claude: Claude Code transcript consumer

### DIFF
--- a/core/training_capture_claude.py
+++ b/core/training_capture_claude.py
@@ -1,0 +1,280 @@
+"""Claude Code transcript → ``TrainingExample``.
+
+The per-harness consumer for the Claude Code side of the harness
+fine-tuning dataset. It reads a Claude Code session JSONL transcript off
+disk, normalizes it into the turn array defined in the spec, applies
+tool-call normalization, and upserts one row via
+:func:`core.training_capture.upsert_example`.
+
+This module is pure transcript→row logic. It does not fork, load ``.env``,
+or read a Stop payload — that orchestration lives in each mind's own
+Stop-hook wrapper (Skippy's lives under ``~/.claude/hooks/``). Keeping the
+parse/normalize logic here makes it importable and testable against
+fixture transcripts, and lets Ada reuse the exact same consumer.
+
+Capture is **lossless** in the sense the spec means: every user turn,
+assistant turn, tool call, and tool result is preserved in order, with
+tool results stored raw. The only transforms applied at capture time are:
+
+- **Tool-call normalization** — leaky identifiers (skill names, MCP tool
+  names, sub-agent types) are rewritten to their category bucket so the
+  student learns harness-shaped syntax, not a skill roster that changes
+  weekly. The wrapper, parameter structure, and result blocks are kept
+  verbatim.
+- **Thinking blocks are dropped** — extended-reasoning content is pure
+  token bloat for harness fidelity and is never graded, so it is not
+  stored.
+- **Sidechains are skipped** — sub-agent transcripts (``isSidechain``)
+  belong to their own session; the parent session keeps only the ``Agent``
+  tool call and its result.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from core.training_capture import (
+    HARNESS_CLAUDE_CODE,
+    TrainingExample,
+    upsert_example,
+)
+
+# Anonymization buckets — the leaky specific is replaced with these.
+SKILL_NAME_PLACEHOLDER = "<SKILL_NAME>"
+AGENT_TYPE_PLACEHOLDER = "<AGENT_TYPE>"
+MCP_TOOL_TYPE = "MCPTool"
+
+# Tool names that map to the ``Agent`` bucket (sub-agent invocation has been
+# named both ``Task`` and ``Agent`` across harness versions).
+_AGENT_TOOL_NAMES = frozenset({"Task", "Agent"})
+
+# The training DB lives next to the other state databases in this repo.
+# Module-relative so it resolves correctly whether Skippy runs it bare-metal
+# or Ada's container imports it at a different absolute path. Override with
+# ``TRAINING_DB_PATH`` for tests or an alternate location.
+_DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "data" / "training_examples.db"
+
+
+def default_db_path() -> Path:
+    """Resolve the training DB path, honoring ``TRAINING_DB_PATH``."""
+    override = os.environ.get("TRAINING_DB_PATH")
+    return Path(override) if override else _DEFAULT_DB_PATH
+
+
+def normalize_tool_call(name: str, tool_input: dict) -> dict:
+    """Return a normalized ``tool_calls`` entry: ``{"type", "input"}``.
+
+    Harness primitives (``Bash``, ``Read``, ``Edit`` …) keep their name and
+    their input verbatim. Skill / sub-agent / MCP calls keep their parameter
+    structure but have the leaky identifier swapped for a category bucket.
+    """
+    tool_input = tool_input if isinstance(tool_input, dict) else {}
+    if name == "Skill":
+        anon = dict(tool_input)
+        if "skill" in anon:
+            anon["skill"] = SKILL_NAME_PLACEHOLDER
+        return {"type": "Skill", "input": anon}
+    if name in _AGENT_TOOL_NAMES:
+        anon = dict(tool_input)
+        if "subagent_type" in anon:
+            anon["subagent_type"] = AGENT_TYPE_PLACEHOLDER
+        return {"type": "Agent", "input": anon}
+    if name.startswith("mcp__"):
+        # The tool *name* is the leaky specific; the type bucket drops it.
+        return {"type": MCP_TOOL_TYPE, "input": tool_input}
+    # Stable harness primitive — kept as-is.
+    return {"type": name, "input": tool_input}
+
+
+def _content_text(content) -> str:
+    """Extract assistant/user text from a content value (string or blocks).
+
+    Thinking blocks are skipped. Tool-use / tool-result blocks are handled
+    by the caller, not here.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            c.get("text", "")
+            for c in content
+            if isinstance(c, dict) and c.get("type") == "text"
+        ]
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def _tool_result_text(content) -> str:
+    """Flatten a tool_result block's ``content`` (string or block array)."""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for c in content:
+            if isinstance(c, dict):
+                # text blocks carry ``text``; other block types (e.g. image)
+                # carry no plain text and are represented by their type.
+                parts.append(c.get("text") or f"[{c.get('type', 'block')}]")
+            else:
+                parts.append(str(c))
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def parse_transcript(transcript_path: str | Path) -> list[dict]:
+    """Parse a Claude Code JSONL transcript into the normalized turn array.
+
+    Each turn is one of::
+
+        {"role": "user", "content": "..."}
+        {"role": "assistant", "content": "...", "tool_calls": [...]}
+        {"role": "tool", "content": "...", "tool_call_id": "..."}
+
+    Turns are emitted in transcript order. Sidechain (sub-agent) events and
+    non user/assistant events are skipped. Thinking blocks are dropped.
+    """
+    path = Path(transcript_path)
+    turns: list[dict] = []
+    try:
+        raw = path.read_text()
+    except Exception:
+        return turns
+
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if ev.get("type") not in ("user", "assistant"):
+            continue
+        if ev.get("isSidechain"):
+            continue
+        msg = ev.get("message") or {}
+        role = msg.get("role") or ev.get("type")
+        content = msg.get("content")
+
+        if role == "assistant":
+            text = _content_text(content)
+            tool_calls = []
+            if isinstance(content, list):
+                for c in content:
+                    if isinstance(c, dict) and c.get("type") == "tool_use":
+                        call = normalize_tool_call(c.get("name", ""), c.get("input") or {})
+                        call["id"] = c.get("id", "")
+                        tool_calls.append(call)
+            if not text and not tool_calls:
+                continue
+            turn: dict = {"role": "assistant", "content": text}
+            if tool_calls:
+                turn["tool_calls"] = tool_calls
+            turns.append(turn)
+            continue
+
+        # role == "user": may carry a plain message, tool results, or both.
+        if isinstance(content, str):
+            if content:
+                turns.append({"role": "user", "content": content})
+            continue
+        if isinstance(content, list):
+            pending_text: list[str] = []
+            for c in content:
+                if not isinstance(c, dict):
+                    continue
+                ctype = c.get("type")
+                if ctype == "tool_result":
+                    if pending_text:
+                        turns.append({"role": "user", "content": "\n".join(pending_text)})
+                        pending_text = []
+                    turns.append({
+                        "role": "tool",
+                        "content": _tool_result_text(c.get("content")),
+                        "tool_call_id": c.get("tool_use_id", ""),
+                    })
+                elif ctype == "text" and c.get("text"):
+                    pending_text.append(c["text"])
+            if pending_text:
+                turns.append({"role": "user", "content": "\n".join(pending_text)})
+    return turns
+
+
+def _session_metadata(transcript_path: str | Path) -> dict:
+    """Pull ``source_model`` and ``harness_version`` from assistant events.
+
+    Uses the last assistant event that carries each field, so a model swap
+    mid-session records the model the session ended on.
+    """
+    path = Path(transcript_path)
+    model = None
+    version = None
+    try:
+        raw = path.read_text()
+    except Exception:
+        return {"source_model": None, "harness_version": None}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if ev.get("version"):
+            version = ev["version"]
+        if ev.get("type") == "assistant":
+            m = (ev.get("message") or {}).get("model")
+            if m:
+                model = m
+    return {"source_model": model, "harness_version": version}
+
+
+def build_example(
+    transcript_path: str | Path,
+    *,
+    session_id: str,
+    mind_id: str | None = None,
+    captured_at: int | None = None,
+) -> TrainingExample | None:
+    """Build a :class:`TrainingExample` from a transcript, or ``None``.
+
+    Returns ``None`` when the transcript yields no turns (nothing to store).
+    """
+    turns = parse_transcript(transcript_path)
+    if not turns:
+        return None
+    meta = _session_metadata(transcript_path)
+    length_chars = sum(len(t.get("content") or "") for t in turns)
+    return TrainingExample.from_turns(
+        session_id=session_id,
+        harness=HARNESS_CLAUDE_CODE,
+        turns=turns,
+        mind_id=mind_id,
+        source_model=meta["source_model"],
+        harness_version=meta["harness_version"],
+        captured_at=captured_at if captured_at is not None else int(time.time()),
+        system_prompt=None,
+        length_tokens=length_chars // 4,
+    )
+
+
+def capture_session(
+    transcript_path: str | Path,
+    *,
+    session_id: str,
+    mind_id: str | None = None,
+    db_path: str | Path | None = None,
+) -> bool:
+    """Parse a transcript and upsert one row. Returns ``True`` if written.
+
+    No-op (returns ``False``) when the transcript has no usable turns.
+    """
+    example = build_example(transcript_path, session_id=session_id, mind_id=mind_id)
+    if example is None:
+        return False
+    upsert_example(db_path if db_path is not None else default_db_path(), example)
+    return True

--- a/tests/unit/test_training_capture_claude.py
+++ b/tests/unit/test_training_capture_claude.py
@@ -1,0 +1,224 @@
+"""Unit tests for the Claude Code transcript consumer.
+
+Covers transcript parsing into the normalized turn array, tool-call
+normalization (skill / agent / MCP anonymization, primitives kept),
+thinking-block dropping, sidechain skipping, metadata extraction, and the
+end-to-end ``capture_session`` upsert.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.training_capture import HARNESS_CLAUDE_CODE, count_examples, get_example
+from core.training_capture_claude import (
+    AGENT_TYPE_PLACEHOLDER,
+    MCP_TOOL_TYPE,
+    SKILL_NAME_PLACEHOLDER,
+    build_example,
+    capture_session,
+    normalize_tool_call,
+    parse_transcript,
+)
+
+
+def _ev(**kw) -> str:
+    return json.dumps(kw)
+
+
+def _assistant(content, *, model="claude-opus-4-8", version="2.1.179", sidechain=False):
+    return _ev(
+        type="assistant",
+        isSidechain=sidechain,
+        version=version,
+        message={"role": "assistant", "model": model, "content": content},
+    )
+
+
+def _user(content, *, version="2.1.179", sidechain=False):
+    return _ev(
+        type="user",
+        isSidechain=sidechain,
+        version=version,
+        message={"role": "user", "content": content},
+    )
+
+
+@pytest.fixture
+def transcript(tmp_path):
+    """A representative session: text, thinking, primitive + skill + agent +
+    mcp tool calls, a tool result, a sidechain event, and noise lines."""
+    lines = [
+        _ev(type="summary", summary="ignored"),
+        _user("fix the thing"),
+        _assistant([
+            {"type": "thinking", "thinking": "secret reasoning, must be dropped"},
+            {"type": "text", "text": "on it"},
+            {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
+        ]),
+        _user([
+            {"type": "tool_result", "tool_use_id": "t1", "content": "file.txt"},
+        ]),
+        _assistant([
+            {"type": "tool_use", "id": "t2", "name": "Skill",
+             "input": {"skill": "hivemind:planka", "args": "list"}},
+            {"type": "tool_use", "id": "t3", "name": "mcp__hive-mind-tools__graph_query",
+             "input": {"query": "MATCH (n) RETURN n"}},
+            {"type": "tool_use", "id": "t4", "name": "Task",
+             "input": {"subagent_type": "Explore", "prompt": "look around"}},
+        ]),
+        # tool_result content as a block array (not a bare string)
+        _user([
+            {"type": "tool_result", "tool_use_id": "t2",
+             "content": [{"type": "text", "text": "card list"}]},
+        ]),
+        # sidechain (sub-agent) turns must be skipped entirely
+        _assistant([{"type": "text", "text": "subagent internal chatter"}], sidechain=True),
+        _user("subagent internal prompt", sidechain=True),
+        _assistant([{"type": "text", "text": "done"}]),
+    ]
+    p = tmp_path / "session-abc.jsonl"
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# normalize_tool_call
+# ---------------------------------------------------------------------------
+
+def test_primitive_kept_verbatim():
+    assert normalize_tool_call("Bash", {"command": "ls"}) == {
+        "type": "Bash", "input": {"command": "ls"}
+    }
+
+
+def test_skill_name_anonymized_structure_kept():
+    out = normalize_tool_call("Skill", {"skill": "hivemind:planka", "args": "x"})
+    assert out["type"] == "Skill"
+    assert out["input"]["skill"] == SKILL_NAME_PLACEHOLDER
+    assert out["input"]["args"] == "x"
+
+
+def test_agent_subagent_type_anonymized():
+    out = normalize_tool_call("Agent", {"subagent_type": "Explore", "prompt": "p"})
+    assert out["type"] == "Agent"
+    assert out["input"]["subagent_type"] == AGENT_TYPE_PLACEHOLDER
+    assert out["input"]["prompt"] == "p"
+
+
+def test_task_normalizes_to_agent_bucket():
+    assert normalize_tool_call("Task", {"subagent_type": "Plan"})["type"] == "Agent"
+
+
+def test_mcp_tool_bucketed():
+    out = normalize_tool_call("mcp__hive-mind-tools__graph_query", {"query": "q"})
+    assert out["type"] == MCP_TOOL_TYPE
+    assert out["input"] == {"query": "q"}
+
+
+def test_non_dict_input_tolerated():
+    assert normalize_tool_call("Bash", None) == {"type": "Bash", "input": {}}
+
+
+# ---------------------------------------------------------------------------
+# parse_transcript
+# ---------------------------------------------------------------------------
+
+def test_parse_roles_in_order(transcript):
+    turns = parse_transcript(transcript)
+    roles = [t["role"] for t in turns]
+    assert roles == [
+        "user",       # "fix the thing"
+        "assistant",  # "on it" + Bash
+        "tool",       # t1 result
+        "assistant",  # Skill + mcp + Task
+        "tool",       # t2 result
+        "assistant",  # "done"
+    ]
+
+
+def test_thinking_blocks_dropped(transcript):
+    turns = parse_transcript(transcript)
+    assert all("secret reasoning" not in (t.get("content") or "") for t in turns)
+    assert turns[1]["content"] == "on it"
+
+
+def test_sidechain_skipped(transcript):
+    turns = parse_transcript(transcript)
+    blob = json.dumps(turns)
+    assert "subagent internal" not in blob
+
+
+def test_tool_calls_normalized_in_turn(transcript):
+    turns = parse_transcript(transcript)
+    skill_turn = turns[3]
+    types = [c["type"] for c in skill_turn["tool_calls"]]
+    assert types == ["Skill", MCP_TOOL_TYPE, "Agent"]
+    assert skill_turn["tool_calls"][0]["input"]["skill"] == SKILL_NAME_PLACEHOLDER
+    assert skill_turn["tool_calls"][2]["input"]["subagent_type"] == AGENT_TYPE_PLACEHOLDER
+
+
+def test_tool_result_links_id_and_flattens_blocks(transcript):
+    turns = parse_transcript(transcript)
+    assert turns[2] == {"role": "tool", "content": "file.txt", "tool_call_id": "t1"}
+    assert turns[4]["role"] == "tool"
+    assert turns[4]["content"] == "card list"
+    assert turns[4]["tool_call_id"] == "t2"
+
+
+def test_missing_file_returns_empty(tmp_path):
+    assert parse_transcript(tmp_path / "nope.jsonl") == []
+
+
+# ---------------------------------------------------------------------------
+# build_example
+# ---------------------------------------------------------------------------
+
+def test_build_example_counts_and_metadata(transcript):
+    ex = build_example(transcript, session_id="abc", mind_id="mind-uuid")
+    assert ex is not None
+    assert ex.session_id == "abc"
+    assert ex.mind_id == "mind-uuid"
+    assert ex.harness == HARNESS_CLAUDE_CODE
+    assert ex.source_model == "claude-opus-4-8"
+    assert ex.harness_version == "2.1.179"
+    assert ex.turn_count == 6
+    assert ex.tool_call_count == 4  # Bash + Skill + mcp + Task
+    assert ex.captured_at is not None
+
+
+def test_build_example_empty_transcript_returns_none(tmp_path):
+    p = tmp_path / "empty.jsonl"
+    p.write_text("")
+    assert build_example(p, session_id="x") is None
+
+
+# ---------------------------------------------------------------------------
+# capture_session
+# ---------------------------------------------------------------------------
+
+def test_capture_session_upserts(transcript, tmp_path):
+    db = tmp_path / "data" / "training_examples.db"
+    assert capture_session(transcript, session_id="abc", mind_id="m", db_path=db) is True
+    assert count_examples(db, harness=HARNESS_CLAUDE_CODE) == 1
+    row = get_example(db, "abc")
+    assert row["tool_call_count"] == 4
+    assert len(row["turns"]) == 6
+
+
+def test_capture_session_idempotent(transcript, tmp_path):
+    db = tmp_path / "training_examples.db"
+    capture_session(transcript, session_id="abc", db_path=db)
+    capture_session(transcript, session_id="abc", db_path=db)
+    assert count_examples(db) == 1
+
+
+def test_capture_session_noop_on_empty(tmp_path):
+    p = tmp_path / "empty.jsonl"
+    p.write_text("\n")
+    db = tmp_path / "training_examples.db"
+    # A no-op capture writes nothing — not even an empty DB file.
+    assert capture_session(p, session_id="x", db_path=db) is False
+    assert not db.exists()


### PR DESCRIPTION
Step 2 of the harness fine-tuning capture foundation (spec: `clawd-harness-finetuning.md`). Builds on the storage layer merged in #150.

Adds `core/training_capture_claude.py`, the Claude-side per-harness consumer:

- `parse_transcript` reads a Claude Code session JSONL into the normalized turn array (user / assistant / tool), in transcript order.
- `normalize_tool_call` rewrites leaky identifiers to category buckets — `Skill` name to `<SKILL_NAME>`, sub-agent `subagent_type` to `<AGENT_TYPE>`, `mcp__*` to `MCPTool` — while keeping harness primitives (`Bash`, `Read`, `Edit` …) and all parameter structure verbatim.
- Thinking blocks are dropped; sidechain (sub-agent) events are skipped so the parent session keeps only the `Agent` call and its result.
- `capture_session` derives `source_model` / `harness_version` from the transcript and upserts one row keyed by `session_id` via the storage layer.

Pure transcript->row logic with no forking or env handling, so it is importable, testable, and reusable by Ada. The detaching Stop-hook wrapper is per-mind and lives outside the repo (Skippy's is wired and validated end-to-end against a live session).

20 new tests; full suite green, ruff and mypy clean.