### PR TITLE
training_capture_claude: capture tool calls raw (drop normalization)

### DIFF
--- a/core/training_capture_claude.py
+++ b/core/training_capture_claude.py
@@ -2,30 +2,33 @@
 
 The per-harness consumer for the Claude Code side of the harness
 fine-tuning dataset. It reads a Claude Code session JSONL transcript off
-disk, normalizes it into the turn array defined in the spec, applies
-tool-call normalization, and upserts one row via
-:func:`core.training_capture.upsert_example`.
+disk, parses it into the turn array defined in the spec, and upserts one
+row via :func:`core.training_capture.upsert_example`.
 
 This module is pure transcript→row logic. It does not fork, load ``.env``,
 or read a Stop payload — that orchestration lives in each mind's own
 Stop-hook wrapper (Skippy's lives under ``~/.claude/hooks/``). Keeping the
-parse/normalize logic here makes it importable and testable against
-fixture transcripts, and lets Ada reuse the exact same consumer.
+parse logic here makes it importable and testable against fixture
+transcripts, and lets Ada reuse the exact same consumer.
 
-Capture is **lossless** in the sense the spec means: every user turn,
-assistant turn, tool call, and tool result is preserved in order, with
-tool results stored raw. The only transforms applied at capture time are:
+Capture is **fully raw**. Every user turn, assistant turn, tool call, and
+tool result is preserved in order, with tool results stored raw and the
+real tool names kept verbatim — ``Bash``, ``Skill`` with its actual skill
+name, ``mcp__hive-mind-tools__graph_query``, ``Task`` with its actual
+``subagent_type``. The model we are training is a specialist in *this*
+hive mind, so the concrete tool identities are the most valuable signal in
+the data, not noise to be bucketed away. Any anonymization (collapsing
+skill / MCP / sub-agent identifiers to category buckets) is an optional
+export-time transform over this immutable raw store, applied only if a
+more general model is ever wanted — never at capture time.
 
-- **Tool-call normalization** — leaky identifiers (skill names, MCP tool
-  names, sub-agent types) are rewritten to their category bucket so the
-  student learns harness-shaped syntax, not a skill roster that changes
-  weekly. The wrapper, parameter structure, and result blocks are kept
-  verbatim.
+The only transforms applied at capture time:
+
 - **Thinking blocks are dropped** — extended-reasoning content is pure
   token bloat for harness fidelity and is never graded, so it is not
   stored.
 - **Sidechains are skipped** — sub-agent transcripts (``isSidechain``)
-  belong to their own session; the parent session keeps only the ``Agent``
+  belong to their own session; the parent session keeps only the sub-agent
   tool call and its result.
 """
 
@@ -42,15 +45,6 @@ from core.training_capture import (
     upsert_example,
 )
 
-# Anonymization buckets — the leaky specific is replaced with these.
-SKILL_NAME_PLACEHOLDER = "<SKILL_NAME>"
-AGENT_TYPE_PLACEHOLDER = "<AGENT_TYPE>"
-MCP_TOOL_TYPE = "MCPTool"
-
-# Tool names that map to the ``Agent`` bucket (sub-agent invocation has been
-# named both ``Task`` and ``Agent`` across harness versions).
-_AGENT_TOOL_NAMES = frozenset({"Task", "Agent"})
-
 # The training DB lives next to the other state databases in this repo.
 # Module-relative so it resolves correctly whether Skippy runs it bare-metal
 # or Ada's container imports it at a different absolute path. Override with
@@ -62,31 +56,6 @@ def default_db_path() -> Path:
     """Resolve the training DB path, honoring ``TRAINING_DB_PATH``."""
     override = os.environ.get("TRAINING_DB_PATH")
     return Path(override) if override else _DEFAULT_DB_PATH
-
-
-def normalize_tool_call(name: str, tool_input: dict) -> dict:
-    """Return a normalized ``tool_calls`` entry: ``{"type", "input"}``.
-
-    Harness primitives (``Bash``, ``Read``, ``Edit`` …) keep their name and
-    their input verbatim. Skill / sub-agent / MCP calls keep their parameter
-    structure but have the leaky identifier swapped for a category bucket.
-    """
-    tool_input = tool_input if isinstance(tool_input, dict) else {}
-    if name == "Skill":
-        anon = dict(tool_input)
-        if "skill" in anon:
-            anon["skill"] = SKILL_NAME_PLACEHOLDER
-        return {"type": "Skill", "input": anon}
-    if name in _AGENT_TOOL_NAMES:
-        anon = dict(tool_input)
-        if "subagent_type" in anon:
-            anon["subagent_type"] = AGENT_TYPE_PLACEHOLDER
-        return {"type": "Agent", "input": anon}
-    if name.startswith("mcp__"):
-        # The tool *name* is the leaky specific; the type bucket drops it.
-        return {"type": MCP_TOOL_TYPE, "input": tool_input}
-    # Stable harness primitive — kept as-is.
-    return {"type": name, "input": tool_input}
 
 
 def _content_text(content) -> str:
@@ -125,7 +94,7 @@ def _tool_result_text(content) -> str:
 
 
 def parse_transcript(transcript_path: str | Path) -> list[dict]:
-    """Parse a Claude Code JSONL transcript into the normalized turn array.
+    """Parse a Claude Code JSONL transcript into the raw turn array.
 
     Each turn is one of::
 
@@ -133,8 +102,10 @@ def parse_transcript(transcript_path: str | Path) -> list[dict]:
         {"role": "assistant", "content": "...", "tool_calls": [...]}
         {"role": "tool", "content": "...", "tool_call_id": "..."}
 
-    Turns are emitted in transcript order. Sidechain (sub-agent) events and
-    non user/assistant events are skipped. Thinking blocks are dropped.
+    Each ``tool_calls`` entry is ``{"type": <raw tool name>, "input": {...},
+    "id": "..."}`` — the real tool name, kept verbatim. Turns are emitted in
+    transcript order. Sidechain (sub-agent) events and non user/assistant
+    events are skipped. Thinking blocks are dropped.
     """
     path = Path(transcript_path)
     turns: list[dict] = []
@@ -165,9 +136,11 @@ def parse_transcript(transcript_path: str | Path) -> list[dict]:
             if isinstance(content, list):
                 for c in content:
                     if isinstance(c, dict) and c.get("type") == "tool_use":
-                        call = normalize_tool_call(c.get("name", ""), c.get("input") or {})
-                        call["id"] = c.get("id", "")
-                        tool_calls.append(call)
+                        tool_calls.append({
+                            "type": c.get("name", ""),
+                            "input": c.get("input") or {},
+                            "id": c.get("id", ""),
+                        })
             if not text and not tool_calls:
                 continue
             turn: dict = {"role": "assistant", "content": text}

--- a/tests/unit/test_training_capture_claude.py
+++ b/tests/unit/test_training_capture_claude.py
@@ -1,9 +1,8 @@
 """Unit tests for the Claude Code transcript consumer.
 
-Covers transcript parsing into the normalized turn array, tool-call
-normalization (skill / agent / MCP anonymization, primitives kept),
-thinking-block dropping, sidechain skipping, metadata extraction, and the
-end-to-end ``capture_session`` upsert.
+Covers transcript parsing into the raw turn array (real tool names kept
+verbatim), thinking-block dropping, sidechain skipping, metadata
+extraction, and the end-to-end ``capture_session`` upsert.
 """
 
 from __future__ import annotations
@@ -14,12 +13,8 @@ import pytest
 
 from core.training_capture import HARNESS_CLAUDE_CODE, count_examples, get_example
 from core.training_capture_claude import (
-    AGENT_TYPE_PLACEHOLDER,
-    MCP_TOOL_TYPE,
-    SKILL_NAME_PLACEHOLDER,
     build_example,
     capture_session,
-    normalize_tool_call,
     parse_transcript,
 )
 
@@ -85,44 +80,6 @@ def transcript(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# normalize_tool_call
-# ---------------------------------------------------------------------------
-
-def test_primitive_kept_verbatim():
-    assert normalize_tool_call("Bash", {"command": "ls"}) == {
-        "type": "Bash", "input": {"command": "ls"}
-    }
-
-
-def test_skill_name_anonymized_structure_kept():
-    out = normalize_tool_call("Skill", {"skill": "hivemind:planka", "args": "x"})
-    assert out["type"] == "Skill"
-    assert out["input"]["skill"] == SKILL_NAME_PLACEHOLDER
-    assert out["input"]["args"] == "x"
-
-
-def test_agent_subagent_type_anonymized():
-    out = normalize_tool_call("Agent", {"subagent_type": "Explore", "prompt": "p"})
-    assert out["type"] == "Agent"
-    assert out["input"]["subagent_type"] == AGENT_TYPE_PLACEHOLDER
-    assert out["input"]["prompt"] == "p"
-
-
-def test_task_normalizes_to_agent_bucket():
-    assert normalize_tool_call("Task", {"subagent_type": "Plan"})["type"] == "Agent"
-
-
-def test_mcp_tool_bucketed():
-    out = normalize_tool_call("mcp__hive-mind-tools__graph_query", {"query": "q"})
-    assert out["type"] == MCP_TOOL_TYPE
-    assert out["input"] == {"query": "q"}
-
-
-def test_non_dict_input_tolerated():
-    assert normalize_tool_call("Bash", None) == {"type": "Bash", "input": {}}
-
-
-# ---------------------------------------------------------------------------
 # parse_transcript
 # ---------------------------------------------------------------------------
 
@@ -151,13 +108,19 @@ def test_sidechain_skipped(transcript):
     assert "subagent internal" not in blob
 
 
-def test_tool_calls_normalized_in_turn(transcript):
+def test_tool_calls_kept_raw_in_turn(transcript):
     turns = parse_transcript(transcript)
+    # First assistant turn: a single Bash call, name and input verbatim.
+    bash_turn = turns[1]
+    assert bash_turn["tool_calls"] == [
+        {"type": "Bash", "input": {"command": "ls"}, "id": "t1"}
+    ]
+    # Second assistant turn: Skill / MCP / Task with real identities kept.
     skill_turn = turns[3]
     types = [c["type"] for c in skill_turn["tool_calls"]]
-    assert types == ["Skill", MCP_TOOL_TYPE, "Agent"]
-    assert skill_turn["tool_calls"][0]["input"]["skill"] == SKILL_NAME_PLACEHOLDER
-    assert skill_turn["tool_calls"][2]["input"]["subagent_type"] == AGENT_TYPE_PLACEHOLDER
+    assert types == ["Skill", "mcp__hive-mind-tools__graph_query", "Task"]
+    assert skill_turn["tool_calls"][0]["input"]["skill"] == "hivemind:planka"
+    assert skill_turn["tool_calls"][2]["input"]["subagent_type"] == "Explore"
 
 
 def test_tool_result_links_id_and_flattens_blocks(transcript):


### PR DESCRIPTION
Reverses the capture-time tool-call normalization added in #151. Skill names, MCP tool names, and sub-agent `subagent_type` values are now stored **verbatim** rather than bucketed to placeholders.

Rationale: the model is a specialist in *this* hive mind, not a general harness driver. The concrete tool identities (which skill manages the board, which MCP tool queries the graph, which `subagent_type` a job dispatches) are the highest-value signal in the data — the "knows which tool to reach for" competence that is the whole point. Bucketing them would delete exactly that lesson and keep only the call grammar the base model already half-knows.

Normalization is a *projection* like key substitution and PII scrubbing, so it belongs at export time over the immutable raw store, applied only if a general model is ever wanted. Capturing raw forecloses nothing; bucketing at capture would.

Call structure (wrapper, parameters, result blocks, stop tokens) was never the contested part and stays verbatim. Spec doc updated to match. 24 tests green, ruff and mypy clean.