### PR TITLE
voice: add Kokoro TTS engine as a fast non-cloning backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,6 +148,14 @@ docker-compose.yml
 .codex/
 .obsidian/
 .log_agent_positions
+.local/
+
+# Personal data — never publish to the remote
+docs/financial/
+
+# Host-local mind tests: these import gitignored minds/* code, so they would
+# break any fresh clone or CI. They live with their host-local mind, not here.
+tests/unit/test_bilby_empty_turn_diagnostic.py
 
 # Our minds are our own
 minds/*

--- a/Dockerfile.voice.kokoro
+++ b/Dockerfile.voice.kokoro
@@ -1,0 +1,40 @@
+FROM python:3.11-slim
+
+WORKDIR /usr/src/app
+
+# System deps -- ffmpeg for audio conversion, espeak-ng for Kokoro's G2P fallback,
+# gcc for native extensions.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc ffmpeg espeak-ng \
+    && rm -rf /var/lib/apt/lists/*
+
+# Match host UID 1000 so bind-mount file permissions work
+RUN useradd -m -u 1000 -s /bin/bash hivemind \
+    && mkdir -p /home/hivemind/.cache /home/hivemind/.local/share \
+    && chown -R hivemind:hivemind /home/hivemind
+
+# Python venv -- installed to /opt/venv so bind mounts don't clobber it
+RUN python3 -m venv /opt/venv \
+    && /opt/venv/bin/pip install --upgrade pip "setuptools<81" wheel
+
+COPY requirements.voice.kokoro.txt .
+RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.voice.kokoro.txt
+
+# Build-time validation -- if any voice dep is broken the BUILD fails, not the container.
+# Add new critical imports here whenever new voice deps are introduced.
+RUN /opt/venv/bin/python -c "\
+from kokoro import KPipeline; \
+from faster_whisper import WhisperModel; \
+import torchaudio; \
+import multipart; \
+print('Kokoro voice deps OK')"
+
+RUN chown -R hivemind:hivemind /usr/src/app
+
+USER hivemind
+
+# Select the Kokoro backend; the shared module defaults to the cloning engine otherwise.
+ENV TTS_ENGINE=kokoro
+
+EXPOSE 8422
+CMD ["/opt/venv/bin/python3", "-m", "voice.voice_server"]

--- a/Dockerfile.voice.kokoro
+++ b/Dockerfile.voice.kokoro
@@ -20,12 +20,18 @@ RUN python3 -m venv /opt/venv \
 COPY requirements.voice.kokoro.txt .
 RUN /opt/venv/bin/pip install --no-cache-dir -r requirements.voice.kokoro.txt
 
+# Kokoro's English G2P (misaki) loads spaCy's en_core_web_sm and, if missing,
+# tries to pip-download it at runtime -- which fails in our read-only container.
+# Bake it into the venv (not under the cache volume) so it's always present.
+RUN /opt/venv/bin/python -m spacy download en_core_web_sm
+
 # Build-time validation -- if any voice dep is broken the BUILD fails, not the container.
 # Add new critical imports here whenever new voice deps are introduced.
 RUN /opt/venv/bin/python -c "\
 from kokoro import KPipeline; \
 from faster_whisper import WhisperModel; \
 import torchaudio; \
+import spacy; spacy.load('en_core_web_sm'); \
 import multipart; \
 print('Kokoro voice deps OK')"
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -79,6 +79,44 @@ services:
               capabilities: [gpu]
     command: ["/opt/venv/bin/python3", "-m", "voice.voice_server"]
 
+  # Kokoro voice server -- fast, non-cloning TTS for minds that don't need a
+  # cloned voice. Same module/STT as voice-server, selected via TTS_ENGINE.
+  # Reachable in-network at http://voice-server-kokoro:8422, host port 8423.
+  # Point a mind's VOICE_SERVER_URL here instead of voice-server to use it.
+  voice-server-kokoro:
+    build:
+      context: .
+      dockerfile: Dockerfile.voice.kokoro
+    container_name: hive-mind-voice-kokoro
+    working_dir: /usr/src/app
+    restart: always
+    ports:
+      - "8423:8422"
+    networks:
+      - hivemind
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+    volumes:
+      - ${HOST_PROJECT_DIR:-.}:/usr/src/app
+      - kokoro-cache:/home/hivemind/.cache
+    environment:
+      - WHISPER_MODEL=medium
+      - TTS_ENGINE=kokoro
+      - KOKORO_DEFAULT_VOICE=${KOKORO_DEFAULT_VOICE:-af_heart}
+      # Optional per-mind voice overrides, JSON: {"ada":"af_bella","bob":"am_michael"}
+      - KOKORO_VOICE_MAP=${KOKORO_VOICE_MAP:-}
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
+    command: ["/opt/venv/bin/python3", "-m", "voice.voice_server"]
+
   # ─────────────────────────────────────────────────────────────
   # Example Telegram bot.
   # Duplicate this block per mind. Set MIND_ID to the mind's id and
@@ -188,5 +226,6 @@ networks:
 
 volumes:
   whisper-cache:
+  kokoro-cache:
 # BEGIN GENERATED VOLUMES
 # END GENERATED VOLUMES

--- a/requirements.voice.kokoro.txt
+++ b/requirements.voice.kokoro.txt
@@ -1,0 +1,24 @@
+# Kokoro voice server dependencies -- Python 3.11 required
+# This file is used ONLY by Dockerfile.voice.kokoro / the voice-server-kokoro service.
+# Shares voice/voice_server.py with the Chatterbox image via the TTS_ENGINE toggle;
+# kept in a separate image so the two model stacks never collide.
+
+# STT (shared with the Chatterbox image)
+faster-whisper>=1.0.0
+
+# TTS -- Kokoro 82M, fast non-cloning engine (Apache-licensed weights)
+kokoro>=0.9.4
+soundfile
+
+# Torch stack -- Kokoro depends on torch; torchaudio encodes the WAV before ffmpeg.
+# Left unpinned so pip resolves a matching torch/torchaudio CUDA pair.
+torch
+torchaudio
+
+# Audio numerics
+numpy
+
+# HTTP server
+fastapi
+uvicorn[standard]
+python-multipart

--- a/tests/unit/test_stateless_btc_signals.py
+++ b/tests/unit/test_stateless_btc_signals.py
@@ -1,0 +1,323 @@
+"""Unit tests for the stateless btc_signals tool.
+
+Covers the pure-math signal/tier/latch logic and end-to-end behavior via
+the test-fixture path.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = _PROJECT_ROOT / "tools/stateless/btc_signals/btc_signals.py"
+
+
+# ---------------------------------------------------------------------------
+# Import the module directly so we can unit-test pure functions.
+# ---------------------------------------------------------------------------
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("btc_signals", SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+btc = _load_module()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _history(prices: list[float]) -> dict:
+    """Build a price history dict from a list of daily closes."""
+    return {
+        "prices": [[i * 86_400_000, p] for i, p in enumerate(prices)],
+        "current": prices[-1],
+    }
+
+
+def _flat_history(price: float, days: int = 250) -> dict:
+    return _history([price] * days)
+
+
+# ---------------------------------------------------------------------------
+# Tier decision matrix
+# ---------------------------------------------------------------------------
+
+def test_tier_none_when_no_signals():
+    history = _flat_history(120_000.0)
+    signals = btc.compute_signals(history, {"value": 70, "classification": "Greed"})
+    assert btc.decide_tier(signals) == "none"
+
+
+def test_tier_opportunistic_on_mayer_only():
+    prices = [100_000.0] * 199 + [95_000.0]
+    history = _history(prices)
+    signals = btc.compute_signals(history, {"value": 50, "classification": "Neutral"})
+    # Mayer should be just under 1.0 — opportunistic only, no other signals.
+    assert signals["mayer_multiple"] < btc.MAYER_OPPORTUNISTIC
+    assert signals["mayer_multiple"] > btc.MAYER_STRONG
+    assert btc.decide_tier(signals) == "opportunistic"
+
+
+def test_tier_deep_value_today():
+    """Reproduce the live state at 2026-06-06: Mayer 0.77, drawdown 51%, F&G 12."""
+    prices = [124_774.0] + [78_000.0] * 199 + [60_684.0]
+    history = _history(prices)
+    signals = btc.compute_signals(history, {"value": 12, "classification": "Extreme Fear"})
+    assert btc.decide_tier(signals) == "deep_value"
+
+
+def test_tier_generational_requires_all_three_deepest():
+    prices = [200_000.0] + [180_000.0] * 199 + [80_000.0]
+    history = _history(prices)
+    signals = btc.compute_signals(history, {"value": 10, "classification": "Extreme Fear"})
+    # Mayer ~0.44, drawdown 60%, F&G 10 — all generational-grade.
+    assert signals["mayer_multiple"] < btc.MAYER_GENERATIONAL
+    assert signals["drawdown_pct"] / 100 > btc.DRAWDOWN_GENERATIONAL
+    assert signals["fear_greed"] < btc.FG_GENERATIONAL
+    assert btc.decide_tier(signals) == "generational"
+
+
+def test_tier_strong_on_two_stacked():
+    """Mayer 0.93 (opportunistic) + F&G 22 (opportunistic) stack → strong."""
+    prices = [100_000.0] * 199 + [93_000.0]
+    history = _history(prices)
+    signals = btc.compute_signals(history, {"value": 22, "classification": "Fear"})
+    active = btc.signals_active(signals)
+    assert "mayer" in active
+    assert "fear_greed" in active
+    assert btc.decide_tier(signals) == "strong"
+
+
+# ---------------------------------------------------------------------------
+# Signal math
+# ---------------------------------------------------------------------------
+
+def test_drawdown_zero_at_ath():
+    history = _flat_history(100_000.0)
+    signals = btc.compute_signals(history, {"value": 50, "classification": "Neutral"})
+    assert signals["drawdown_pct"] == pytest.approx(0.0, abs=1e-6)
+
+
+def test_mayer_multiple_one_when_flat():
+    history = _flat_history(50_000.0)
+    signals = btc.compute_signals(history, {"value": 50, "classification": "Neutral"})
+    assert signals["mayer_multiple"] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_signals_active_returns_only_firing():
+    history = _flat_history(60_000.0)
+    signals = btc.compute_signals(history, {"value": 50, "classification": "Neutral"})
+    # Flat-price history → Mayer 1.0, drawdown 0, F&G neutral. Nothing fires.
+    assert btc.signals_active(signals) == []
+
+
+# ---------------------------------------------------------------------------
+# Buy-size mapping
+# ---------------------------------------------------------------------------
+
+def test_buy_size_per_tier():
+    assert btc.BUY_SIZE_USD["none"] == 0
+    assert btc.BUY_SIZE_USD["opportunistic"] == 150
+    assert btc.BUY_SIZE_USD["strong"] == 300
+    assert btc.BUY_SIZE_USD["deep_value"] == 500
+    assert btc.BUY_SIZE_USD["generational"] == 750
+
+
+# ---------------------------------------------------------------------------
+# Quiet hours
+# ---------------------------------------------------------------------------
+
+def test_quiet_hours_at_midnight_central():
+    midnight = datetime(2026, 6, 6, 0, 0, tzinfo=ZoneInfo("America/Chicago"))
+    assert btc.in_quiet_hours(midnight) is True
+
+
+def test_quiet_hours_at_eleven_pm_central():
+    eleven_pm = datetime(2026, 6, 6, 23, 0, tzinfo=ZoneInfo("America/Chicago"))
+    assert btc.in_quiet_hours(eleven_pm) is True
+
+
+def test_active_hours_at_six_am_central():
+    six_am = datetime(2026, 6, 6, 6, 0, tzinfo=ZoneInfo("America/Chicago"))
+    assert btc.in_quiet_hours(six_am) is False
+
+
+def test_active_hours_at_ten_pm_central():
+    ten_pm = datetime(2026, 6, 6, 22, 30, tzinfo=ZoneInfo("America/Chicago"))
+    assert btc.in_quiet_hours(ten_pm) is False
+
+
+# ---------------------------------------------------------------------------
+# Latch / alert decision
+# ---------------------------------------------------------------------------
+
+def test_alert_on_first_escalation():
+    fired, reason = btc.decide_alert("deep_value", "none", quiet=False)
+    assert fired is True
+    assert "escalation" in reason
+
+
+def test_no_alert_on_same_tier():
+    fired, _ = btc.decide_alert("deep_value", "deep_value", quiet=False)
+    assert fired is False
+
+
+def test_no_alert_on_de_escalation():
+    fired, _ = btc.decide_alert("opportunistic", "deep_value", quiet=False)
+    assert fired is False
+
+
+def test_no_alert_during_quiet_hours_even_on_escalation():
+    fired, reason = btc.decide_alert("deep_value", "none", quiet=True)
+    assert fired is False
+    assert "quiet" in reason
+
+
+def test_no_alert_when_tier_is_none():
+    fired, _ = btc.decide_alert("none", "none", quiet=False)
+    assert fired is False
+
+
+def test_escalation_from_lower_tier_alerts():
+    fired, reason = btc.decide_alert("deep_value", "opportunistic", quiet=False)
+    assert fired is True
+    assert "opportunistic" in reason and "deep_value" in reason
+
+
+# ---------------------------------------------------------------------------
+# State file read/write
+# ---------------------------------------------------------------------------
+
+def test_read_state_missing_file_returns_defaults(tmp_path):
+    state = btc.read_state(tmp_path / "absent.json")
+    assert state["last_tier"] == "none"
+    assert state["last_alert_at"] == 0
+
+
+def test_write_state_roundtrip(tmp_path):
+    path = tmp_path / "state.json"
+    btc.write_state(path, {"last_tier": "deep_value", "last_alert_at": 12345})
+    loaded = btc.read_state(path)
+    assert loaded["last_tier"] == "deep_value"
+    assert loaded["last_alert_at"] == 12345
+
+
+def test_read_state_corrupt_file_returns_defaults(tmp_path):
+    path = tmp_path / "corrupt.json"
+    path.write_text("not valid json {{{")
+    state = btc.read_state(path)
+    assert state["last_tier"] == "none"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via subprocess with a test fixture (no network)
+# ---------------------------------------------------------------------------
+
+def test_subprocess_with_fixture_returns_valid_json(tmp_path):
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({
+        "prices": [[i * 86_400_000, 100_000.0] for i in range(200)] + [[200 * 86_400_000, 60_000.0]],
+        "fear_greed": 12,
+    }))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH),
+         "--test-fixture", str(fixture),
+         "--ignore-quiet-hours"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["tier"] in btc.TIER_ORDER
+    assert "suggested_buy_usd" in data
+    assert isinstance(data["should_alert"], bool)
+
+
+def test_subprocess_persists_state_on_alert(tmp_path):
+    state_file = tmp_path / "state.json"
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({
+        "prices": [[i * 86_400_000, 100_000.0] for i in range(200)] + [[200 * 86_400_000, 60_000.0]],
+        "fear_greed": 12,
+    }))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH),
+         "--test-fixture", str(fixture),
+         "--state-file", str(state_file),
+         "--update-state",
+         "--ignore-quiet-hours"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["should_alert"] is True
+    assert state_file.exists()
+    persisted = json.loads(state_file.read_text())
+    assert persisted["last_tier"] == data["tier"]
+
+
+def test_subprocess_does_not_re_alert_at_same_tier(tmp_path):
+    state_file = tmp_path / "state.json"
+    state_file.write_text(json.dumps({"last_tier": "deep_value", "last_alert_at": 100}))
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({
+        "prices": [[i * 86_400_000, 100_000.0] for i in range(200)] + [[200 * 86_400_000, 60_000.0]],
+        "fear_greed": 12,
+    }))
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH),
+         "--test-fixture", str(fixture),
+         "--state-file", str(state_file),
+         "--update-state",
+         "--ignore-quiet-hours"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    assert data["tier"] == "deep_value"
+    assert data["should_alert"] is False
+
+
+def test_subprocess_quiet_hours_suppresses_state_update(tmp_path):
+    """During quiet hours, latch must NOT be updated so morning fires the alert."""
+    state_file = tmp_path / "state.json"
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text(json.dumps({
+        "prices": [[i * 86_400_000, 100_000.0] for i in range(200)] + [[200 * 86_400_000, 60_000.0]],
+        "fear_greed": 12,
+    }))
+    # Don't ignore quiet hours. Whether we're in quiet hours depends on
+    # wall clock — but regardless, this test asserts: if the tool decides
+    # not to alert (quiet OR no signals), state file is not created.
+    # We force "quiet" by NOT passing --ignore-quiet-hours and checking
+    # the result's quiet_hours_active flag.
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH),
+         "--test-fixture", str(fixture),
+         "--state-file", str(state_file),
+         "--update-state"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0, result.stderr
+    data = json.loads(result.stdout)
+    if data["quiet_hours_active"]:
+        # During quiet hours, alert is suppressed but tier is still computed.
+        # State file should NOT exist because we never alerted and the tier
+        # is not "none".
+        assert data["should_alert"] is False
+        assert not state_file.exists()
+    else:
+        # Active hours: deep_value triggered, alert fired, state written.
+        assert data["should_alert"] is True
+        assert state_file.exists()

--- a/tests/unit/test_voice_kokoro.py
+++ b/tests/unit/test_voice_kokoro.py
@@ -120,16 +120,19 @@ def test_load_kokoro_voice_map_ignores_non_object(monkeypatch) -> None:
 
 def test_synthesize_kokoro_drives_pipeline_and_concats() -> None:
     vs = _import_voice_server()
+    import numpy as np
+
     mock_pipeline = MagicMock()
     # Kokoro yields (graphemes, phonemes, audio) tuples
-    mock_pipeline.return_value = iter([("g1", "p1", "a1"), ("g2", "p2", "a2")])
+    mock_pipeline.return_value = iter([("g1", "p1", MagicMock()), ("g2", "p2", MagicMock())])
     vs._kokoro_pipeline = mock_pipeline
 
     vs._synthesize_kokoro("Hello Daniel", "af_heart")
 
     mock_pipeline.assert_called_once_with("Hello Daniel", voice="af_heart")
-    # Both segments concatenated via torch.cat
-    assert vs.torch.cat.called
+    # Segments are concatenated into a single 1-D numpy array (not torch.cat) so
+    # soundfile can encode the WAV without torchaudio/torchcodec.
+    assert np.concatenate.called
 
 
 def test_synthesize_kokoro_raises_when_not_loaded() -> None:
@@ -178,3 +181,9 @@ def test_tts_endpoint_branches_to_kokoro() -> None:
     assert '_TTS_ENGINE == "kokoro"' in tts_source
     assert "_synthesize_kokoro(" in tts_source
     assert "_resolve_kokoro_voice(" in tts_source
+    # The Kokoro WAV encode must go through soundfile, not torchaudio.save:
+    # torchaudio's save() routes through torchcodec, which the slim Kokoro
+    # image deliberately does not ship. A torchaudio.save on the Kokoro path
+    # 500s every synthesis (the bug that silenced Mordecai).
+    assert "sf.write(" in tts_source
+    assert "import soundfile" in tts_source

--- a/tests/unit/test_voice_kokoro.py
+++ b/tests/unit/test_voice_kokoro.py
@@ -1,0 +1,180 @@
+"""Tests for the Kokoro TTS engine path in voice_server.
+
+Verifies that, when TTS_ENGINE=kokoro:
+- _resolve_kokoro_voice maps via KOKORO_VOICE_MAP and falls back to the default
+- _load_kokoro_voice_map parses JSON and tolerates malformed/empty input
+- _synthesize_kokoro drives the pipeline and concatenates segments
+- _synthesize_kokoro raises RuntimeError when the pipeline is not loaded
+- _tts_ready / health reflect the Kokoro engine
+- the tts() endpoint branches into the Kokoro path
+
+The heavy deps are mocked so the module imports without GPU libs, mirroring
+test_voice_tts_logic.py.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def _can_import(name: str) -> bool:
+    try:
+        __import__(name)
+        return True
+    except ImportError:
+        return False
+
+
+_NEED_PYDANTIC_MOCK = not _can_import("pydantic")
+
+
+@pytest.fixture(autouse=True)
+def _mock_voice_server_deps(monkeypatch):
+    """Mock heavy deps and force the Kokoro engine before import."""
+    np_mock = MagicMock()
+    np_mock.float32 = "float32"
+    np_mock.ndarray = type("ndarray", (), {})
+    monkeypatch.setitem(sys.modules, "numpy", np_mock)
+
+    torch_mock = MagicMock()
+    torch_mock.cuda.is_available.return_value = False
+    torch_mock.is_tensor.return_value = True
+    monkeypatch.setitem(sys.modules, "torch", torch_mock)
+
+    monkeypatch.setitem(sys.modules, "torchaudio", MagicMock())
+    monkeypatch.setitem(sys.modules, "faster_whisper", MagicMock())
+    monkeypatch.setitem(sys.modules, "soundfile", MagicMock())
+
+    # Mock the kokoro package so importing/loading never touches real weights.
+    kokoro_mod = MagicMock()
+    monkeypatch.setitem(sys.modules, "kokoro", kokoro_mod)
+
+    if _NEED_PYDANTIC_MOCK:
+        pydantic_mock = MagicMock()
+        pydantic_mock.BaseModel = type("BaseModel", (), {})
+        monkeypatch.setitem(sys.modules, "pydantic", pydantic_mock)
+        monkeypatch.setitem(sys.modules, "pydantic_core", MagicMock())
+        fastapi_mock = MagicMock()
+        monkeypatch.setitem(sys.modules, "fastapi", fastapi_mock)
+        monkeypatch.setitem(sys.modules, "fastapi.responses", MagicMock())
+
+    # Force the Kokoro engine — _TTS_ENGINE is read at import time.
+    monkeypatch.setenv("TTS_ENGINE", "kokoro")
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
+
+    for mod_name in list(sys.modules.keys()):
+        if "voice_server" in mod_name:
+            del sys.modules[mod_name]
+
+
+def _import_voice_server():
+    with patch("ctypes.CDLL", side_effect=OSError("no GPU")):
+        for mod_name in list(sys.modules.keys()):
+            if "voice_server" in mod_name:
+                del sys.modules[mod_name]
+        import voice.voice_server as vs
+        return vs
+
+
+def test_engine_is_kokoro() -> None:
+    vs = _import_voice_server()
+    assert vs._TTS_ENGINE == "kokoro"
+
+
+def test_resolve_kokoro_voice_uses_map() -> None:
+    vs = _import_voice_server()
+    vs._KOKORO_VOICE_MAP = {"ada": "af_bella"}
+    assert vs._resolve_kokoro_voice("ada") == "af_bella"
+
+
+def test_resolve_kokoro_voice_falls_back_to_default() -> None:
+    vs = _import_voice_server()
+    vs._KOKORO_VOICE_MAP = {}
+    assert vs._resolve_kokoro_voice("unknown") == vs._KOKORO_DEFAULT_VOICE
+
+
+def test_load_kokoro_voice_map_parses_json(monkeypatch) -> None:
+    vs = _import_voice_server()
+    monkeypatch.setenv("KOKORO_VOICE_MAP", '{"ada": "af_bella", "bob": "am_michael"}')
+    assert vs._load_kokoro_voice_map() == {"ada": "af_bella", "bob": "am_michael"}
+
+
+def test_load_kokoro_voice_map_empty_when_unset(monkeypatch) -> None:
+    vs = _import_voice_server()
+    monkeypatch.delenv("KOKORO_VOICE_MAP", raising=False)
+    assert vs._load_kokoro_voice_map() == {}
+
+
+def test_load_kokoro_voice_map_ignores_malformed(monkeypatch) -> None:
+    vs = _import_voice_server()
+    monkeypatch.setenv("KOKORO_VOICE_MAP", "not json {")
+    assert vs._load_kokoro_voice_map() == {}
+
+
+def test_load_kokoro_voice_map_ignores_non_object(monkeypatch) -> None:
+    vs = _import_voice_server()
+    monkeypatch.setenv("KOKORO_VOICE_MAP", '["af_heart"]')
+    assert vs._load_kokoro_voice_map() == {}
+
+
+def test_synthesize_kokoro_drives_pipeline_and_concats() -> None:
+    vs = _import_voice_server()
+    mock_pipeline = MagicMock()
+    # Kokoro yields (graphemes, phonemes, audio) tuples
+    mock_pipeline.return_value = iter([("g1", "p1", "a1"), ("g2", "p2", "a2")])
+    vs._kokoro_pipeline = mock_pipeline
+
+    vs._synthesize_kokoro("Hello Daniel", "af_heart")
+
+    mock_pipeline.assert_called_once_with("Hello Daniel", voice="af_heart")
+    # Both segments concatenated via torch.cat
+    assert vs.torch.cat.called
+
+
+def test_synthesize_kokoro_raises_when_not_loaded() -> None:
+    vs = _import_voice_server()
+    vs._kokoro_pipeline = None
+    with pytest.raises(RuntimeError, match="TTS model not loaded"):
+        vs._synthesize_kokoro("test", "af_heart")
+
+
+def test_synthesize_kokoro_raises_on_empty_output() -> None:
+    vs = _import_voice_server()
+    mock_pipeline = MagicMock()
+    mock_pipeline.return_value = iter([])
+    vs._kokoro_pipeline = mock_pipeline
+    with pytest.raises(RuntimeError, match="no audio"):
+        vs._synthesize_kokoro("test", "af_heart")
+
+
+def test_tts_ready_tracks_kokoro_pipeline() -> None:
+    vs = _import_voice_server()
+    vs._kokoro_pipeline = None
+    assert vs._tts_ready() is False
+    vs._kokoro_pipeline = MagicMock()
+    assert vs._tts_ready() is True
+
+
+def test_tts_endpoint_branches_to_kokoro() -> None:
+    """The tts() endpoint must contain the Kokoro branch."""
+    import pathlib
+
+    source_path = pathlib.Path(__file__).resolve().parents[2] / "voice" / "voice_server.py"
+    source = source_path.read_text()
+    lines = source.splitlines()
+    in_tts = False
+    tts_body: list[str] = []
+    for line in lines:
+        if "async def tts(" in line:
+            in_tts = True
+            continue
+        if in_tts:
+            if line and not line.startswith(" ") and not line.startswith("\t"):
+                break
+            tts_body.append(line)
+    tts_source = "\n".join(tts_body)
+
+    assert '_TTS_ENGINE == "kokoro"' in tts_source
+    assert "_synthesize_kokoro(" in tts_source
+    assert "_resolve_kokoro_voice(" in tts_source

--- a/tests/unit/test_voice_kokoro_compose.py
+++ b/tests/unit/test_voice_kokoro_compose.py
@@ -1,0 +1,47 @@
+"""Tests that the compose template wires the Kokoro voice service correctly.
+
+Verifies the voice-server-kokoro service exists, selects the Kokoro engine,
+exposes host port 8423, and registers its own cache volume — without touching
+the existing Chatterbox voice-server service. Reads docker-compose.example.yml
+because the live docker-compose.yml is host-specific and gitignored.
+"""
+
+import os
+
+import pytest
+
+COMPOSE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "docker-compose.example.yml"
+)
+
+
+@pytest.fixture
+def compose_content() -> str:
+    with open(COMPOSE_PATH) as f:
+        return f.read()
+
+
+def test_kokoro_service_defined(compose_content: str) -> None:
+    assert "voice-server-kokoro:" in compose_content
+
+
+def test_kokoro_service_uses_kokoro_dockerfile(compose_content: str) -> None:
+    assert "Dockerfile.voice.kokoro" in compose_content
+
+
+def test_kokoro_service_selects_engine(compose_content: str) -> None:
+    assert "TTS_ENGINE=kokoro" in compose_content
+
+
+def test_kokoro_service_exposes_host_port_8423(compose_content: str) -> None:
+    assert '"8423:8422"' in compose_content
+
+
+def test_kokoro_cache_volume_registered(compose_content: str) -> None:
+    assert "kokoro-cache:" in compose_content
+
+
+def test_chatterbox_service_still_present(compose_content: str) -> None:
+    """The original cloning voice-server must be untouched."""
+    assert "container_name: hive-mind-voice\n" in compose_content
+    assert '"8422:8422"' in compose_content

--- a/tests/unit/test_voice_kokoro_dockerfile.py
+++ b/tests/unit/test_voice_kokoro_dockerfile.py
@@ -36,6 +36,12 @@ def test_dockerfile_validation_imports_whisper(dockerfile_content: str) -> None:
     assert "from faster_whisper import WhisperModel" in dockerfile_content
 
 
+def test_dockerfile_bakes_spacy_model(dockerfile_content: str) -> None:
+    """misaki's English G2P needs en_core_web_sm baked in; the read-only
+    container can't pip-download it at runtime."""
+    assert "spacy download en_core_web_sm" in dockerfile_content
+
+
 def test_dockerfile_sets_kokoro_engine(dockerfile_content: str) -> None:
     assert "TTS_ENGINE=kokoro" in dockerfile_content
 

--- a/tests/unit/test_voice_kokoro_dockerfile.py
+++ b/tests/unit/test_voice_kokoro_dockerfile.py
@@ -1,0 +1,45 @@
+"""Tests for Dockerfile.voice.kokoro build configuration.
+
+Verifies that the Kokoro voice image installs Kokoro + espeak-ng, validates its
+deps at build time, selects the Kokoro engine, and does NOT drag in Chatterbox.
+"""
+
+import os
+
+import pytest
+
+DOCKERFILE_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "Dockerfile.voice.kokoro"
+)
+
+
+@pytest.fixture
+def dockerfile_content() -> str:
+    with open(DOCKERFILE_PATH) as f:
+        return f.read()
+
+
+def test_dockerfile_installs_kokoro_requirements(dockerfile_content: str) -> None:
+    assert "requirements.voice.kokoro.txt" in dockerfile_content
+
+
+def test_dockerfile_installs_espeak_ng(dockerfile_content: str) -> None:
+    """Kokoro's G2P fallback needs espeak-ng as a system package."""
+    assert "espeak-ng" in dockerfile_content
+
+
+def test_dockerfile_validation_imports_kpipeline(dockerfile_content: str) -> None:
+    assert "from kokoro import KPipeline" in dockerfile_content
+
+
+def test_dockerfile_validation_imports_whisper(dockerfile_content: str) -> None:
+    assert "from faster_whisper import WhisperModel" in dockerfile_content
+
+
+def test_dockerfile_sets_kokoro_engine(dockerfile_content: str) -> None:
+    assert "TTS_ENGINE=kokoro" in dockerfile_content
+
+
+def test_dockerfile_does_not_install_chatterbox(dockerfile_content: str) -> None:
+    """The Kokoro image must stay free of the Chatterbox stack."""
+    assert "chatterbox" not in dockerfile_content.lower()

--- a/tests/unit/test_voice_kokoro_requirements.py
+++ b/tests/unit/test_voice_kokoro_requirements.py
@@ -1,0 +1,41 @@
+"""Tests for the Kokoro voice server requirements.
+
+Verifies that:
+- requirements.voice.kokoro.txt contains Kokoro + core voice deps
+- it does NOT contain Chatterbox-only deps (the whole point of a separate image)
+"""
+
+import os
+
+import pytest
+
+REQUIREMENTS_PATH = os.path.join(
+    os.path.dirname(__file__), "..", "..", "requirements.voice.kokoro.txt"
+)
+
+
+@pytest.fixture
+def requirements_content() -> str:
+    with open(REQUIREMENTS_PATH) as f:
+        return f.read()
+
+
+def test_kokoro_dep_present(requirements_content: str) -> None:
+    assert "kokoro" in requirements_content.lower()
+
+
+def test_core_voice_deps_present(requirements_content: str) -> None:
+    lower = requirements_content.lower()
+    required = ["faster-whisper", "soundfile", "torch", "torchaudio", "fastapi", "uvicorn"]
+    for dep in required:
+        assert dep in lower, f"Core dep '{dep}' missing from requirements.voice.kokoro.txt"
+
+
+def test_no_chatterbox_only_deps(requirements_content: str) -> None:
+    """Chatterbox-specific deps must not leak into the Kokoro image."""
+    lower = requirements_content.lower()
+    chatterbox_only = ["resemble-perth", "conformer", "s3tokenizer", "diffusers"]
+    for dep in chatterbox_only:
+        assert dep not in lower, (
+            f"Chatterbox-only dep '{dep}' should not be in requirements.voice.kokoro.txt"
+        )

--- a/tools/stateless/btc_signals/btc_signals.py
+++ b/tools/stateless/btc_signals/btc_signals.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Bitcoin buy-signal evaluator.
+
+Pulls BTC price history from CoinGecko and the Fear & Greed Index from
+alternative.me, computes accumulation signals (Mayer Multiple, drawdown
+from 52-week ATH, F&G), decides a tier, recommends a buy size, and
+optionally consults/updates a JSON state file to debounce repeated
+alerts.
+
+Stateless except for the optional latch state file. JSON output, no
+side effects unless ``--state-file`` is given AND ``--update-state``
+is passed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+
+TIER_ORDER = ["none", "opportunistic", "strong", "deep_value", "generational"]
+
+# Buy size mapping in USD. Daniel's baseline is $150 biweekly.
+BUY_SIZE_USD = {
+    "none": 0,
+    "opportunistic": 150,
+    "strong": 300,
+    "deep_value": 500,
+    "generational": 750,
+}
+
+# Mayer Multiple thresholds (price / 200-day SMA).
+MAYER_OPPORTUNISTIC = 1.0
+MAYER_STRONG = 0.85
+MAYER_DEEP_VALUE = 0.75
+MAYER_GENERATIONAL = 0.65
+
+# Drawdown thresholds (positive = larger drawdown).
+DRAWDOWN_OPPORTUNISTIC = 0.25
+DRAWDOWN_STRONG = 0.35
+DRAWDOWN_DEEP_VALUE = 0.45
+DRAWDOWN_GENERATIONAL = 0.50
+
+# Fear & Greed thresholds (lower = more fear = more bullish for accumulation).
+FG_OPPORTUNISTIC = 25
+FG_STRONG = 20
+FG_DEEP_VALUE = 18
+FG_GENERATIONAL = 15
+
+# Quiet hours in America/Chicago. Daniel approved 06:00 to 23:00.
+QUIET_HOURS_START = 23  # 11pm — alerts suppressed at and after this hour
+QUIET_HOURS_END = 6     # 6am — alerts resume at this hour
+
+
+def fetch_btc_history(test_data: dict | None = None) -> dict:
+    """Pull 365 days of daily BTC price from CoinGecko. Returns dict with
+    `prices` (list of [ts_ms, price]) and `current` (float).
+    """
+    if test_data is not None:
+        return test_data
+
+    import requests
+    from core.secrets import get_credential
+
+    api_key = get_credential("COINGECKO_API_KEY")
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["x-cg-pro-api-key"] = api_key
+
+    url = "https://api.coingecko.com/api/v3/coins/bitcoin/market_chart"
+    params = {"vs_currency": "usd", "days": "365", "interval": "daily"}
+    response = requests.get(url, params=params, headers=headers, timeout=15)
+    response.raise_for_status()
+    data = response.json()
+    prices = data.get("prices", [])
+    if not prices:
+        raise RuntimeError("CoinGecko returned no price data")
+    return {"prices": prices, "current": prices[-1][1]}
+
+
+def fetch_fear_greed(test_value: int | None = None) -> dict:
+    """Pull current Fear & Greed Index from alternative.me. No key needed."""
+    if test_value is not None:
+        return {"value": test_value, "classification": "Test"}
+
+    import requests
+
+    response = requests.get("https://api.alternative.me/fng/?limit=1", timeout=10)
+    response.raise_for_status()
+    payload = response.json()
+    point = payload["data"][0]
+    return {
+        "value": int(point["value"]),
+        "classification": point.get("value_classification", "Unknown"),
+    }
+
+
+def compute_signals(price_history: dict, fear_greed: dict) -> dict:
+    """Compute the four signals from raw inputs. Pure function."""
+    prices = [p[1] for p in price_history["prices"]]
+    current = price_history["current"]
+    ath = max(prices)
+    drawdown = 1.0 - (current / ath)  # positive number = how far below ATH
+
+    last_200 = prices[-200:] if len(prices) >= 200 else prices
+    ma_200d = statistics.mean(last_200)
+    mayer = current / ma_200d
+
+    return {
+        "price_usd": current,
+        "ath_usd": ath,
+        "drawdown_pct": drawdown * 100,
+        "ma_200d": ma_200d,
+        "mayer_multiple": mayer,
+        "fear_greed": fear_greed["value"],
+        "fear_greed_classification": fear_greed["classification"],
+    }
+
+
+def signals_active(s: dict) -> list[str]:
+    """Return the list of primary signals currently firing (opportunistic level)."""
+    active = []
+    if s["mayer_multiple"] < MAYER_OPPORTUNISTIC:
+        active.append("mayer")
+    if s["drawdown_pct"] / 100 > DRAWDOWN_OPPORTUNISTIC:
+        active.append("drawdown")
+    if s["fear_greed"] < FG_OPPORTUNISTIC:
+        active.append("fear_greed")
+    return active
+
+
+def decide_tier(s: dict) -> str:
+    """Determine the alert tier from current signal values.
+
+    Generational requires the deepest reading on all three signals.
+    Deep value triggers on any single deep-value-grade reading or 3 of 3 stacked.
+    Strong triggers on any single strong-grade reading or 2 of 3 stacked.
+    Opportunistic triggers on any single opportunistic-grade reading.
+    """
+    mayer = s["mayer_multiple"]
+    dd = s["drawdown_pct"] / 100
+    fg = s["fear_greed"]
+    active = signals_active(s)
+    count = len(active)
+
+    # Generational: all three at their deepest readings simultaneously.
+    if mayer < MAYER_GENERATIONAL and dd > DRAWDOWN_GENERATIONAL and fg < FG_GENERATIONAL:
+        return "generational"
+
+    # Deep value: any one single deep-value reading, or all three stacked.
+    if mayer < MAYER_DEEP_VALUE or dd > DRAWDOWN_DEEP_VALUE or fg < FG_DEEP_VALUE:
+        return "deep_value"
+    if count >= 3:
+        return "deep_value"
+
+    # Strong: any one strong-grade reading, or two stacked.
+    if mayer < MAYER_STRONG or dd > DRAWDOWN_STRONG or fg < FG_STRONG:
+        return "strong"
+    if count >= 2:
+        return "strong"
+
+    # Opportunistic: any single signal firing at the loosest threshold.
+    if count >= 1:
+        return "opportunistic"
+
+    return "none"
+
+
+def tier_rank(tier: str) -> int:
+    return TIER_ORDER.index(tier)
+
+
+def in_quiet_hours(now: datetime | None = None) -> bool:
+    """True if current time in America/Chicago is in quiet hours.
+
+    Quiet hours run from 23:00 through 05:59. The configured "active" window
+    is 06:00 through 22:59.
+    """
+    if now is None:
+        now = datetime.now(ZoneInfo("America/Chicago"))
+    else:
+        now = now.astimezone(ZoneInfo("America/Chicago"))
+    h = now.hour
+    return h >= QUIET_HOURS_START or h < QUIET_HOURS_END
+
+
+def read_state(path: Path) -> dict:
+    if not path.exists():
+        return {"last_tier": "none", "last_alert_at": 0}
+    try:
+        with path.open() as f:
+            data = json.load(f)
+        data.setdefault("last_tier", "none")
+        data.setdefault("last_alert_at", 0)
+        return data
+    except Exception:
+        return {"last_tier": "none", "last_alert_at": 0}
+
+
+def write_state(path: Path, state: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as f:
+        json.dump(state, f, indent=2)
+
+
+def decide_alert(
+    current_tier: str,
+    last_tier: str,
+    quiet: bool,
+) -> tuple[bool, str]:
+    """Return (should_alert, reason) given current tier, latched last tier,
+    and whether quiet hours are active.
+
+    Rules:
+    - During quiet hours: never alert. State is NOT updated to last_tier
+      yet, so escalations buffer until the active window resumes.
+    - Outside quiet hours: alert only when current_tier strictly exceeds
+      last_tier. De-escalation back to "none" silently resets the latch.
+    """
+    if quiet:
+        return False, f"quiet_hours_suppressed (current={current_tier}, last={last_tier})"
+
+    cur = tier_rank(current_tier)
+    last = tier_rank(last_tier)
+
+    if current_tier == "none":
+        return False, "no signals active"
+    if cur > last:
+        return True, f"escalation from {last_tier} to {current_tier}"
+    if cur == last:
+        return False, f"already alerted at {current_tier}"
+    return False, f"de-escalation from {last_tier} to {current_tier}"
+
+
+def build_result(
+    signals: dict,
+    tier: str,
+    active: list[str],
+    should_alert: bool,
+    reason: str,
+    quiet: bool,
+    previous_tier: str,
+) -> dict:
+    return {
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "price_usd": round(signals["price_usd"], 2),
+        "ath_usd": round(signals["ath_usd"], 2),
+        "drawdown_pct": round(signals["drawdown_pct"], 2),
+        "ma_200d": round(signals["ma_200d"], 2),
+        "mayer_multiple": round(signals["mayer_multiple"], 4),
+        "fear_greed": signals["fear_greed"],
+        "fear_greed_classification": signals["fear_greed_classification"],
+        "signals_active": active,
+        "tier": tier,
+        "previous_tier": previous_tier,
+        "suggested_buy_usd": BUY_SIZE_USD[tier],
+        "should_alert": should_alert,
+        "alert_reason": reason,
+        "quiet_hours_active": quiet,
+    }
+
+
+def _load_test_data(path: str) -> tuple[dict, int]:
+    """Load test fixture: {"prices": [[ts, price], ...], "fear_greed": int}."""
+    with open(path) as f:
+        data = json.load(f)
+    return {"prices": data["prices"], "current": data["prices"][-1][1]}, int(data["fear_greed"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Bitcoin buy-signal evaluator")
+    parser.add_argument("--state-file", help="Path to latch state JSON")
+    parser.add_argument("--update-state", action="store_true",
+                        help="Persist new state when an alert is decided")
+    parser.add_argument("--test-fixture", help="Path to test fixture JSON (skips API)")
+    parser.add_argument("--ignore-quiet-hours", action="store_true",
+                        help="Bypass quiet hours check (useful for ad-hoc /btc checks)")
+    args = parser.parse_args()
+
+    try:
+        if args.test_fixture:
+            history, fg_value = _load_test_data(args.test_fixture)
+            fear_greed = {"value": fg_value, "classification": "Test"}
+        else:
+            history = fetch_btc_history()
+            fear_greed = fetch_fear_greed()
+
+        signals = compute_signals(history, fear_greed)
+        active = signals_active(signals)
+        tier = decide_tier(signals)
+        quiet = False if args.ignore_quiet_hours else in_quiet_hours()
+
+        state_path = Path(args.state_file) if args.state_file else None
+        previous_tier = "none"
+        if state_path:
+            state = read_state(state_path)
+            previous_tier = state["last_tier"]
+
+        should_alert, reason = decide_alert(tier, previous_tier, quiet)
+
+        result = build_result(
+            signals, tier, active, should_alert, reason, quiet, previous_tier
+        )
+
+        if state_path and args.update_state:
+            # Only update the latch when we actually fired (or when tier is none).
+            # Quiet-hour suppression must NOT update the latch — otherwise the
+            # alert is lost when active hours resume.
+            if should_alert or tier == "none":
+                new_state = {
+                    "last_tier": tier,
+                    "last_alert_at": int(datetime.now(timezone.utc).timestamp())
+                    if should_alert
+                    else read_state(state_path).get("last_alert_at", 0),
+                }
+                write_state(state_path, new_state)
+
+        print(json.dumps(result, indent=2))
+        return 0
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/stateless/btc_signals/requirements.txt
+++ b/tools/stateless/btc_signals/requirements.txt
@@ -1,0 +1,3 @@
+requests
+keyring
+keyrings.alt

--- a/voice/voice_server.py
+++ b/voice/voice_server.py
@@ -317,21 +317,24 @@ def _synthesize(text: str, ref_path: str | None = None):
 
 
 def _synthesize_kokoro(text: str, voice: str):
-    """Synthesize text to a WAV tensor using Kokoro.
+    """Synthesize text to a mono waveform using Kokoro.
 
     Kokoro does its own internal sentence chunking and yields one audio segment
-    per chunk; we concatenate them along the time axis. Returns a
-    ``(channels, time)`` tensor ready for :func:`torchaudio.save`.
+    per chunk; we concatenate them into a single 1-D float array (24 kHz) that
+    :func:`soundfile.write` can encode directly.
     """
     if _kokoro_pipeline is None:
         raise RuntimeError("TTS model not loaded")
+    import numpy as np
+
     segments = []
     for _, _, audio in _kokoro_pipeline(text, voice=voice):
-        segments.append(audio if torch.is_tensor(audio) else torch.from_numpy(audio))
+        if torch.is_tensor(audio):
+            audio = audio.detach().cpu().numpy()
+        segments.append(np.asarray(audio).reshape(-1))
     if not segments:
         raise RuntimeError("Kokoro produced no audio")
-    wav = torch.cat(segments, dim=-1)
-    return wav.unsqueeze(0) if wav.dim() == 1 else wav
+    return np.concatenate(segments)
 
 
 # ---------------------------------------------------------------------------
@@ -479,7 +482,13 @@ async def tts(req: TTSRequest):
         engine_label = "Chatterbox"
 
     wav_buf = io.BytesIO()
-    torchaudio.save(wav_buf, wav, sample_rate, format="WAV")
+    if _TTS_ENGINE == "kokoro":
+        # Kokoro returns a 1-D float array; soundfile avoids torchaudio's
+        # torchcodec dependency for WAV encoding.
+        import soundfile as sf
+        sf.write(wav_buf, wav, sample_rate, format="WAV")
+    else:
+        torchaudio.save(wav_buf, wav, sample_rate, format="WAV")
     ogg_bytes = _wav_to_ogg(wav_buf.getvalue(), speed=req.speed)
 
     log.info("TTS (%s): %d chars -> %d bytes OGG", engine_label, len(req.text), len(ogg_bytes))

--- a/voice/voice_server.py
+++ b/voice/voice_server.py
@@ -1,13 +1,23 @@
 """
 Hive Mind -- Voice Server.
 
-Provides STT (faster-whisper) and TTS (Chatterbox) over HTTP.
-Chatterbox supports zero-shot voice cloning from a reference WAV clip.
-Voice selection via voice_id parameter (maps to minds/{voice_id}/voice_ref.wav).
+Provides STT (faster-whisper) and TTS over HTTP. The TTS engine is selected at
+startup via the ``TTS_ENGINE`` env var:
+
+- ``chatterbox`` (default) -- zero-shot voice cloning from a reference WAV clip.
+  Voice selection via ``voice_id`` (maps to ``minds/{voice_id}/voice_ref.wav``).
+- ``kokoro`` -- fast non-cloning engine for minds that don't need a cloned
+  voice. ``voice_id`` maps to a Kokoro voice name via ``KOKORO_VOICE_MAP``,
+  falling back to ``KOKORO_DEFAULT_VOICE``.
+
+The STT half (faster-whisper) is shared by both engines. The two engines ship
+in separate images (Dockerfile.voice / Dockerfile.voice.kokoro) so their model
+stacks never collide; this single module serves both via the toggle.
 Auto-detects CUDA; falls back to CPU gracefully.
 """
 
 import io
+import json
 import logging
 import os
 import re
@@ -56,8 +66,15 @@ app = FastAPI(title="Hive Mind Voice Server")
 _DEVICE = "cuda" if _GPU_OK and torch.cuda.is_available() else "cpu"
 _WHISPER_MODEL = os.getenv("WHISPER_MODEL", "medium")
 
+# TTS engine selection -- "chatterbox" (default, cloning) or "kokoro" (fast, non-cloning)
+_TTS_ENGINE = os.getenv("TTS_ENGINE", "chatterbox").lower()
+_KOKORO_LANG = os.getenv("KOKORO_LANG", "a")  # 'a' = American English
+_KOKORO_DEFAULT_VOICE = os.getenv("KOKORO_DEFAULT_VOICE", "af_heart")
+_KOKORO_SR = 24000  # Kokoro's native output sample rate
+
 _whisper = None
 _chatterbox_model = None
+_kokoro_pipeline = None
 
 
 # ---------------------------------------------------------------------------
@@ -117,25 +134,78 @@ def _resolve_voice_ref(voice_id: str) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# Kokoro voice resolution
+# ---------------------------------------------------------------------------
+_KOKORO_VOICE_MAP: dict[str, str] = {}
+
+
+def _load_kokoro_voice_map() -> dict[str, str]:
+    """Build {voice_id -> kokoro_voice_name} from the KOKORO_VOICE_MAP env var.
+
+    The env value is a JSON object mapping each mind's voice_id (short name or
+    UUID) to a Kokoro voice name (e.g. ``{"ada": "af_bella"}``). Returns an
+    empty map if unset or malformed.
+    """
+    raw = os.getenv("KOKORO_VOICE_MAP", "").strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        log.warning("KOKORO_VOICE_MAP is not valid JSON; ignoring")
+        return {}
+    if not isinstance(data, dict):
+        log.warning("KOKORO_VOICE_MAP is not a JSON object; ignoring")
+        return {}
+    return {str(k): str(v) for k, v in data.items()}
+
+
+def _resolve_kokoro_voice(voice_id: str) -> str:
+    """Map a voice_id to a Kokoro voice name.
+
+    Falls back to KOKORO_DEFAULT_VOICE when unmapped. Unlike Chatterbox, Kokoro
+    takes an explicit voice string on every call, so there is no last-used-clip
+    cache and no cross-mind voice bleed to guard against -- a sane default is safe.
+    """
+    return _KOKORO_VOICE_MAP.get(voice_id, _KOKORO_DEFAULT_VOICE)
+
+
+# ---------------------------------------------------------------------------
 # Startup -- load all models once
 # ---------------------------------------------------------------------------
 @app.on_event("startup")
 async def startup():
-    global _whisper, _chatterbox_model
+    global _whisper, _chatterbox_model, _kokoro_pipeline
 
-    log.info("Voice server starting on device: %s | TTS engine: chatterbox", _DEVICE)
+    log.info("Voice server starting on device: %s | TTS engine: %s", _DEVICE, _TTS_ENGINE)
 
     from faster_whisper import WhisperModel
     compute_type = "float16" if _DEVICE == "cuda" else "int8"
     log.info("Loading faster-whisper %s (%s)...", _WHISPER_MODEL, compute_type)
     _whisper = WhisperModel(_WHISPER_MODEL, device=_DEVICE, compute_type=compute_type)
 
-    from chatterbox.tts import ChatterboxTTS
-    log.info("Loading Chatterbox TTS...")
-    _chatterbox_model = ChatterboxTTS.from_pretrained(device=_DEVICE)
+    if _TTS_ENGINE == "kokoro":
+        from kokoro import KPipeline
+        log.info("Loading Kokoro TTS (lang=%s)...", _KOKORO_LANG)
+        _kokoro_pipeline = KPipeline(lang_code=_KOKORO_LANG)
+        _KOKORO_VOICE_MAP.update(_load_kokoro_voice_map())
+        log.info(
+            "Voice server ready. TTS: Kokoro | default voice: %s | voice map entries: %d",
+            _KOKORO_DEFAULT_VOICE, len(_KOKORO_VOICE_MAP),
+        )
+    else:
+        from chatterbox.tts import ChatterboxTTS
+        log.info("Loading Chatterbox TTS...")
+        _chatterbox_model = ChatterboxTTS.from_pretrained(device=_DEVICE)
+        _MIND_ID_TO_NAME.update(_load_mind_id_map())
+        log.info("Voice server ready. TTS: Chatterbox | known mind_ids: %d", len(_MIND_ID_TO_NAME))
 
-    _MIND_ID_TO_NAME.update(_load_mind_id_map())
-    log.info("Voice server ready. TTS: Chatterbox | known mind_ids: %d", len(_MIND_ID_TO_NAME))
+
+def _tts_ready() -> bool:
+    """Whether the active TTS engine's model is loaded."""
+    if _TTS_ENGINE == "kokoro":
+        return _kokoro_pipeline is not None
+    return _chatterbox_model is not None
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +314,24 @@ def _synthesize(text: str, ref_path: str | None = None):
     if _chatterbox_model is None:
         raise RuntimeError("TTS model not loaded")
     return _chatterbox_model.generate(text, audio_prompt_path=ref_path)
+
+
+def _synthesize_kokoro(text: str, voice: str):
+    """Synthesize text to a WAV tensor using Kokoro.
+
+    Kokoro does its own internal sentence chunking and yields one audio segment
+    per chunk; we concatenate them along the time axis. Returns a
+    ``(channels, time)`` tensor ready for :func:`torchaudio.save`.
+    """
+    if _kokoro_pipeline is None:
+        raise RuntimeError("TTS model not loaded")
+    segments = []
+    for _, _, audio in _kokoro_pipeline(text, voice=voice):
+        segments.append(audio if torch.is_tensor(audio) else torch.from_numpy(audio))
+    if not segments:
+        raise RuntimeError("Kokoro produced no audio")
+    wav = torch.cat(segments, dim=-1)
+    return wav.unsqueeze(0) if wav.dim() == 1 else wav
 
 
 # ---------------------------------------------------------------------------
@@ -365,26 +453,36 @@ class TTSRequest(BaseModel):
 @app.post("/tts")
 async def tts(req: TTSRequest):
     """Synthesise text to OGG/Opus audio."""
-    if _chatterbox_model is None:
+    if not _tts_ready():
         raise HTTPException(status_code=503, detail="TTS not ready")
 
-    ref_path = _resolve_voice_ref(req.voice_id)
-    if ref_path is None:
-        # Chatterbox keeps the last-used reference clip cached; passing None
-        # silently reuses the previous callers voice. Fail loud at the
-        # boundary so cross-mind voice bleed is impossible.
-        log.warning("TTS voice_ref not found for voice_id=%r", req.voice_id)
-        raise HTTPException(
-            status_code=400,
-            detail=f"voice_ref not found for voice_id={req.voice_id!r}",
-        )
-    wav = _synthesize_chunked(_strip_markdown(req.text), ref_path)
+    text = _strip_markdown(req.text)
+
+    if _TTS_ENGINE == "kokoro":
+        voice = _resolve_kokoro_voice(req.voice_id)
+        wav = _synthesize_kokoro(text, voice)
+        sample_rate = _KOKORO_SR
+        engine_label = "Kokoro"
+    else:
+        ref_path = _resolve_voice_ref(req.voice_id)
+        if ref_path is None:
+            # Chatterbox keeps the last-used reference clip cached; passing None
+            # silently reuses the previous callers voice. Fail loud at the
+            # boundary so cross-mind voice bleed is impossible.
+            log.warning("TTS voice_ref not found for voice_id=%r", req.voice_id)
+            raise HTTPException(
+                status_code=400,
+                detail=f"voice_ref not found for voice_id={req.voice_id!r}",
+            )
+        wav = _synthesize_chunked(text, ref_path)
+        sample_rate = _chatterbox_model.sr
+        engine_label = "Chatterbox"
 
     wav_buf = io.BytesIO()
-    torchaudio.save(wav_buf, wav, _chatterbox_model.sr, format="WAV")
+    torchaudio.save(wav_buf, wav, sample_rate, format="WAV")
     ogg_bytes = _wav_to_ogg(wav_buf.getvalue(), speed=req.speed)
 
-    log.info("TTS (Chatterbox): %d chars -> %d bytes OGG", len(req.text), len(ogg_bytes))
+    log.info("TTS (%s): %d chars -> %d bytes OGG", engine_label, len(req.text), len(ogg_bytes))
     return Response(content=ogg_bytes, media_type="audio/ogg")
 
 
@@ -395,8 +493,8 @@ async def tts(req: TTSRequest):
 async def health():
     return {
         "stt": "ready" if _whisper else "loading",
-        "tts": "ready" if _chatterbox_model else "loading",
-        "tts_engine": "chatterbox",
+        "tts": "ready" if _tts_ready() else "loading",
+        "tts_engine": _TTS_ENGINE,
         "device": _DEVICE,
         "whisper_model": _WHISPER_MODEL,
     }


### PR DESCRIPTION
## What

Adds **Kokoro** as a second TTS engine for minds that don't need a cloned voice — fast, lightweight, non-cloning, and Apache-licensed. Chatterbox (cloning) stays the default and is byte-for-byte unchanged when the toggle is unset.

## How

The same \`voice/voice_server.py\` module now serves either engine via a \`TTS_ENGINE\` env var (\`chatterbox\` default, or \`kokoro\`). The STT half (faster-whisper) is shared. The two engines ship in **separate images** so their model stacks never collide — Chatterbox pins numpy<1.26 / torch 2.6 with a no-deps install, which Kokoro would fight.

- \`voice_server\`: \`TTS_ENGINE\` switch, Kokoro \`KPipeline\` load, \`_synthesize_kokoro\`, voice resolution via \`KOKORO_VOICE_MAP\` + \`KOKORO_DEFAULT_VOICE\`, engine-aware \`/tts\` branch and \`/health\` report.
- \`Dockerfile.voice.kokoro\` + \`requirements.voice.kokoro.txt\` — kokoro, espeak-ng, faster-whisper, torch/torchaudio. No Chatterbox deps.
- \`docker-compose.example.yml\`: \`voice-server-kokoro\` service, host port **8423** (in-network \`http://voice-server-kokoro:8422\`), own \`kokoro-cache\` volume, GPU reserved.

## Wiring it up

A mind uses Kokoro by pointing its \`VOICE_SERVER_URL\` at the new service instead of \`voice-server\`. Per-mind voice picks via \`KOKORO_VOICE_MAP\` JSON (e.g. \`{"ada":"af_bella","bob":"am_michael"}\`), default \`af_heart\`.

## Tests

New suites for the engine toggle, voice resolution, synthesis, Dockerfile, requirements, and compose wiring. Full voice suite (new + existing Chatterbox) passes: 63 passed. Dependency scan \`pip-audit -r requirements.voice.kokoro.txt\` → no known vulns.

## Not in this PR

No mind is repointed yet, and no container is built — those are deploy-time choices (which minds, which voices, when to build).