### PR TITLE
training_capture: add Codex rollout consumer

### DIFF
--- a/core/training_capture_codex.py
+++ b/core/training_capture_codex.py
@@ -1,0 +1,306 @@
+"""Codex CLI rollout → ``TrainingExample``.
+
+The per-harness consumer for the Codex side of the harness fine-tuning
+dataset. It reads a Codex CLI rollout JSONL off disk, parses it into the
+same normalized turn array the Claude consumer produces, and upserts one
+row via :func:`core.training_capture.upsert_example` with
+``harness="codex"``.
+
+Like the Claude consumer this module is pure transcript→row logic: it does
+not fork, load ``.env``, or read a Stop payload. That orchestration lives
+in each Codex mind's own Stop-hook wrapper (Mordecai's lives under
+``.codex/hooks/``). Keeping the parse logic here makes it importable and
+testable against fixture rollouts, and lets every Codex mind reuse one
+consumer.
+
+Rollout shape
+-------------
+A Codex rollout is JSONL where each line is ``{"type": ..., "payload":
+..., "timestamp": ...}``. The line ``type`` is one of:
+
+- ``session_meta`` — one per file; carries the session ``id``, the harness
+  ``cli_version``, and ``base_instructions.text`` (the system prompt).
+- ``turn_context`` — carries the ``model`` for the turn; the last one wins.
+- ``event_msg`` — UI-stream events (token counts, agent_message, etc.).
+  These mirror the response items and are skipped to avoid double-counting.
+- ``response_item`` — the canonical conversation items, mirroring the
+  OpenAI Responses API. ``payload.type`` is one of ``message`` (role
+  ``user`` / ``assistant`` / ``developer``; content is ``input_text`` /
+  ``output_text`` blocks), ``function_call`` (a tool call: ``name``,
+  ``arguments`` JSON string, ``call_id``), ``function_call_output`` (a tool
+  result: ``call_id``, ``output``), or ``reasoning`` (dropped).
+
+Normalization mirrors the Claude consumer exactly so both harnesses land in
+one schema:
+
+    {"role": "user", "content": "..."}
+    {"role": "assistant", "content": "...", "tool_calls": [...]}
+    {"role": "tool", "content": "...", "tool_call_id": "..."}
+
+Each ``tool_calls`` entry is ``{"type": <real tool name>, "input": {...},
+"id": "..."}`` — the Codex tool name kept verbatim (``exec_command``,
+``apply_patch``, ``shell``, an MCP tool, …), with ``arguments`` decoded from
+its JSON string into ``input``. Capture is **fully raw**: tool results are
+stored as emitted and tool identities are preserved, because the model we
+are training is a specialist in driving *this* harness.
+
+The only transforms applied at capture time:
+
+- **Reasoning items are dropped** — encrypted/extended reasoning is pure
+  token bloat for harness fidelity and is never graded, so it is not
+  stored. This is the Codex analog of dropping Claude thinking blocks.
+- **Developer / system messages are skipped from the turn array** — they
+  are harness-injected scaffolding (permissions, apps, skills preambles),
+  not conversational turns. The real system prompt is captured separately
+  from ``session_meta.base_instructions``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+from core.training_capture import (
+    HARNESS_CODEX,
+    TrainingExample,
+    upsert_example,
+)
+
+# The training DB lives next to the other state databases in this repo.
+# Module-relative so it resolves whether a mind runs it bare-metal or a
+# container imports it at a different absolute path. Override with
+# ``TRAINING_DB_PATH`` for tests or an alternate location.
+_DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "data" / "training_examples.db"
+
+# Message roles that are real conversational turns. ``developer`` / ``system``
+# carry harness scaffolding and are excluded from the turn array.
+_TURN_ROLES = frozenset({"user", "assistant"})
+
+
+def default_db_path() -> Path:
+    """Resolve the training DB path, honoring ``TRAINING_DB_PATH``."""
+    override = os.environ.get("TRAINING_DB_PATH")
+    return Path(override) if override else _DEFAULT_DB_PATH
+
+
+def _content_text(content) -> str:
+    """Extract message text from a Codex content value (string or blocks).
+
+    Codex message content is a list of ``{"type": "input_text" |
+    "output_text", "text": ...}`` blocks. A bare string is tolerated.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            c.get("text", "")
+            for c in content
+            if isinstance(c, dict)
+            and c.get("type") in ("input_text", "output_text", "text")
+        ]
+        return "\n".join(p for p in parts if p)
+    return ""
+
+
+def _output_text(output) -> str:
+    """Flatten a ``function_call_output`` payload's ``output`` field.
+
+    Codex emits the tool result either as a bare string or as a dict that
+    wraps the text under ``output`` (sometimes alongside ``metadata``). A
+    dict with no plain ``output`` string is preserved as compact JSON so no
+    signal is lost.
+    """
+    if isinstance(output, str):
+        return output
+    if isinstance(output, dict):
+        inner = output.get("output")
+        if isinstance(inner, str):
+            return inner
+        return json.dumps(output, ensure_ascii=False)
+    if output is None:
+        return ""
+    return str(output)
+
+
+def _parse_arguments(arguments) -> dict:
+    """Decode a ``function_call`` ``arguments`` value into an input dict.
+
+    Codex stores call arguments as a JSON string. A non-decodable or
+    non-object value is preserved verbatim under ``raw`` so the call is
+    never dropped.
+    """
+    if isinstance(arguments, dict):
+        return arguments
+    if isinstance(arguments, str):
+        try:
+            decoded = json.loads(arguments)
+        except Exception:
+            return {"raw": arguments}
+        return decoded if isinstance(decoded, dict) else {"raw": arguments}
+    if arguments is None:
+        return {}
+    return {"raw": str(arguments)}
+
+
+def _append_tool_call(turns: list[dict], call: dict) -> None:
+    """Attach a tool call to the open assistant turn, or open a new one.
+
+    Consecutive ``function_call`` items (an assistant firing several tools
+    before any result) accrue onto the same assistant turn. A call that
+    follows a ``tool`` turn or a ``user`` turn opens a fresh assistant turn
+    with empty content, matching how the model actually stepped.
+    """
+    if turns and turns[-1]["role"] == "assistant":
+        turns[-1].setdefault("tool_calls", []).append(call)
+    else:
+        turns.append({"role": "assistant", "content": "", "tool_calls": [call]})
+
+
+def parse_transcript(transcript_path: str | Path) -> list[dict]:
+    """Parse a Codex rollout JSONL into the normalized turn array.
+
+    Turns are emitted in rollout order. ``response_item`` lines drive the
+    output; ``reasoning`` items and ``developer`` / ``system`` messages are
+    dropped; ``event_msg`` / ``session_meta`` / ``turn_context`` lines are
+    ignored here (metadata is read separately).
+    """
+    path = Path(transcript_path)
+    turns: list[dict] = []
+    try:
+        raw = path.read_text()
+    except Exception:
+        return turns
+
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        if ev.get("type") != "response_item":
+            continue
+        payload = ev.get("payload") or {}
+        ptype = payload.get("type")
+
+        if ptype == "message":
+            role = payload.get("role")
+            if role not in _TURN_ROLES:
+                continue
+            text = _content_text(payload.get("content"))
+            if text:
+                turns.append({"role": role, "content": text})
+            continue
+
+        if ptype == "function_call":
+            _append_tool_call(turns, {
+                "type": payload.get("name", ""),
+                "input": _parse_arguments(payload.get("arguments")),
+                "id": payload.get("call_id", ""),
+            })
+            continue
+
+        if ptype == "function_call_output":
+            turns.append({
+                "role": "tool",
+                "content": _output_text(payload.get("output")),
+                "tool_call_id": payload.get("call_id", ""),
+            })
+            continue
+
+        # reasoning and any other item types are intentionally dropped.
+    return turns
+
+
+def _session_metadata(transcript_path: str | Path) -> dict:
+    """Pull ``source_model``, ``harness_version``, ``system_prompt``.
+
+    ``source_model`` is the last ``turn_context.model`` (the model the
+    session ended on). ``harness_version`` and ``system_prompt`` come from
+    the single ``session_meta`` line.
+    """
+    path = Path(transcript_path)
+    model = None
+    version = None
+    system_prompt = None
+    try:
+        raw = path.read_text()
+    except Exception:
+        return {"source_model": None, "harness_version": None, "system_prompt": None}
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            ev = json.loads(line)
+        except Exception:
+            continue
+        etype = ev.get("type")
+        payload = ev.get("payload") or {}
+        if etype == "turn_context":
+            m = payload.get("model")
+            if m:
+                model = m
+        elif etype == "session_meta":
+            if payload.get("cli_version"):
+                version = payload["cli_version"]
+            instr = payload.get("base_instructions")
+            if isinstance(instr, dict):
+                system_prompt = instr.get("text")
+            elif isinstance(instr, str):
+                system_prompt = instr
+    return {
+        "source_model": model,
+        "harness_version": version,
+        "system_prompt": system_prompt,
+    }
+
+
+def build_example(
+    transcript_path: str | Path,
+    *,
+    session_id: str,
+    mind_id: str | None = None,
+    captured_at: int | None = None,
+) -> TrainingExample | None:
+    """Build a :class:`TrainingExample` from a rollout, or ``None``.
+
+    Returns ``None`` when the rollout yields no turns (nothing to store).
+    """
+    turns = parse_transcript(transcript_path)
+    if not turns:
+        return None
+    meta = _session_metadata(transcript_path)
+    length_chars = sum(len(t.get("content") or "") for t in turns)
+    return TrainingExample.from_turns(
+        session_id=session_id,
+        harness=HARNESS_CODEX,
+        turns=turns,
+        mind_id=mind_id,
+        source_model=meta["source_model"],
+        harness_version=meta["harness_version"],
+        captured_at=captured_at if captured_at is not None else int(time.time()),
+        system_prompt=meta["system_prompt"],
+        length_tokens=length_chars // 4,
+    )
+
+
+def capture_session(
+    transcript_path: str | Path,
+    *,
+    session_id: str,
+    mind_id: str | None = None,
+    db_path: str | Path | None = None,
+) -> bool:
+    """Parse a rollout and upsert one row. Returns ``True`` if written.
+
+    No-op (returns ``False``) when the rollout has no usable turns.
+    """
+    example = build_example(transcript_path, session_id=session_id, mind_id=mind_id)
+    if example is None:
+        return False
+    upsert_example(db_path if db_path is not None else default_db_path(), example)
+    return True

--- a/tests/unit/test_training_capture_codex.py
+++ b/tests/unit/test_training_capture_codex.py
@@ -1,0 +1,228 @@
+"""Unit tests for the Codex CLI rollout consumer.
+
+Covers rollout parsing into the normalized turn array (real tool names kept
+verbatim, arguments decoded into ``input``), reasoning-item dropping,
+developer/system message skipping, ``event_msg`` noise being ignored,
+metadata extraction (model / version / system prompt), and the end-to-end
+``capture_session`` upsert with ``harness="codex"``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from core.training_capture import HARNESS_CODEX, count_examples, get_example
+from core.training_capture_codex import (
+    build_example,
+    capture_session,
+    parse_transcript,
+)
+
+
+def _line(type_, payload) -> str:
+    return json.dumps({"type": type_, "payload": payload})
+
+
+def _item(payload) -> str:
+    return _line("response_item", payload)
+
+
+def _message(role, text) -> str:
+    block_type = "output_text" if role == "assistant" else "input_text"
+    return _item({"type": "message", "role": role,
+                  "content": [{"type": block_type, "text": text}]})
+
+
+def _call(name, args, call_id) -> str:
+    arguments = args if isinstance(args, str) else json.dumps(args)
+    return _item({"type": "function_call", "name": name,
+                  "arguments": arguments, "call_id": call_id})
+
+
+def _output(call_id, output) -> str:
+    return _item({"type": "function_call_output", "call_id": call_id,
+                  "output": output})
+
+
+@pytest.fixture
+def rollout(tmp_path):
+    """A representative rollout: meta + model context, a developer preamble
+    (skipped), real user/assistant turns, single and batched tool calls,
+    tool outputs, a reasoning item (dropped), and event_msg noise."""
+    lines = [
+        _line("session_meta", {
+            "id": "019eda95-codex",
+            "cli_version": "0.135.0",
+            "base_instructions": {"text": "You are Codex, a coding agent."},
+        }),
+        _line("turn_context", {"model": "gpt-5.4"}),
+        _line("event_msg", {"type": "token_count"}),  # noise, ignored
+        # developer scaffolding message — skipped from turns
+        _item({"type": "message", "role": "developer",
+               "content": [{"type": "input_text", "text": "<permissions ...>"}]}),
+        _message("user", "fix the thing"),
+        _message("assistant", "on it"),
+        _call("exec_command", {"cmd": "ls"}, "c1"),
+        _output("c1", "file.txt"),
+        _message("assistant", "now patching"),
+        _call("apply_patch", {"patch": "@@"}, "c2"),
+        _call("mcp__hive-mind-tools__graph_query", {"query": "MATCH (n) RETURN n"}, "c3"),
+        _output("c2", "patched"),
+        # reasoning item must be dropped entirely
+        _item({"type": "reasoning", "summary": [],
+               "encrypted_content": "secret reasoning, must be dropped"}),
+        _message("assistant", "done"),
+    ]
+    p = tmp_path / "rollout-2026-06-18T06-54-27-019eda95.jsonl"
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# parse_transcript
+# ---------------------------------------------------------------------------
+
+def test_parse_roles_in_order(rollout):
+    turns = parse_transcript(rollout)
+    roles = [t["role"] for t in turns]
+    assert roles == [
+        "user",       # "fix the thing"
+        "assistant",  # "on it" + exec_command
+        "tool",       # c1 result
+        "assistant",  # "now patching" + apply_patch + mcp
+        "tool",       # c2 result
+        "assistant",  # "done"
+    ]
+
+
+def test_developer_message_skipped(rollout):
+    turns = parse_transcript(rollout)
+    blob = json.dumps(turns)
+    assert "permissions" not in blob
+    assert turns[0] == {"role": "user", "content": "fix the thing"}
+
+
+def test_reasoning_dropped(rollout):
+    turns = parse_transcript(rollout)
+    assert all("secret reasoning" not in (t.get("content") or "") for t in turns)
+
+
+def test_single_tool_call_attaches_to_assistant_turn(rollout):
+    turns = parse_transcript(rollout)
+    assistant = turns[1]
+    assert assistant["content"] == "on it"
+    assert assistant["tool_calls"] == [
+        {"type": "exec_command", "input": {"cmd": "ls"}, "id": "c1"}
+    ]
+
+
+def test_batched_tool_calls_share_one_turn_with_real_names(rollout):
+    turns = parse_transcript(rollout)
+    batched = turns[3]
+    assert batched["content"] == "now patching"
+    types = [c["type"] for c in batched["tool_calls"]]
+    assert types == ["apply_patch", "mcp__hive-mind-tools__graph_query"]
+    assert batched["tool_calls"][1]["input"]["query"] == "MATCH (n) RETURN n"
+
+
+def test_tool_output_links_call_id(rollout):
+    turns = parse_transcript(rollout)
+    assert turns[2] == {"role": "tool", "content": "file.txt", "tool_call_id": "c1"}
+    assert turns[4] == {"role": "tool", "content": "patched", "tool_call_id": "c2"}
+
+
+def test_event_msg_lines_ignored(rollout):
+    turns = parse_transcript(rollout)
+    assert all(t.get("content") != "token_count" for t in turns)
+
+
+def test_tool_call_without_preceding_message_opens_new_turn(tmp_path):
+    """A model that jumps straight to a tool gets a fresh assistant turn."""
+    lines = [
+        _message("user", "go"),
+        _call("exec_command", {"cmd": "pwd"}, "x1"),
+    ]
+    p = tmp_path / "r.jsonl"
+    p.write_text("\n".join(lines) + "\n")
+    turns = parse_transcript(p)
+    assert turns[1] == {
+        "role": "assistant", "content": "",
+        "tool_calls": [{"type": "exec_command", "input": {"cmd": "pwd"}, "id": "x1"}],
+    }
+
+
+def test_unparseable_arguments_preserved_raw(tmp_path):
+    p = tmp_path / "r.jsonl"
+    p.write_text(_call("shell", "{not valid json", "y1") + "\n")
+    turns = parse_transcript(p)
+    assert turns[0]["tool_calls"][0]["input"] == {"raw": "{not valid json"}
+
+
+def test_dict_output_flattened(tmp_path):
+    p = tmp_path / "r.jsonl"
+    p.write_text(
+        _call("exec_command", {"cmd": "ls"}, "z1") + "\n"
+        + _output("z1", {"output": "wrapped text", "metadata": {"exit": 0}}) + "\n"
+    )
+    turns = parse_transcript(p)
+    tool_turn = next(t for t in turns if t["role"] == "tool")
+    assert tool_turn["content"] == "wrapped text"
+
+
+def test_missing_file_returns_empty(tmp_path):
+    assert parse_transcript(tmp_path / "nope.jsonl") == []
+
+
+# ---------------------------------------------------------------------------
+# build_example
+# ---------------------------------------------------------------------------
+
+def test_build_example_counts_and_metadata(rollout):
+    ex = build_example(rollout, session_id="abc", mind_id="mind-uuid")
+    assert ex is not None
+    assert ex.session_id == "abc"
+    assert ex.mind_id == "mind-uuid"
+    assert ex.harness == HARNESS_CODEX
+    assert ex.source_model == "gpt-5.4"
+    assert ex.harness_version == "0.135.0"
+    assert ex.system_prompt == "You are Codex, a coding agent."
+    assert ex.turn_count == 6
+    assert ex.tool_call_count == 3  # exec_command + apply_patch + mcp
+    assert ex.captured_at is not None
+
+
+def test_build_example_empty_rollout_returns_none(tmp_path):
+    p = tmp_path / "empty.jsonl"
+    p.write_text("")
+    assert build_example(p, session_id="x") is None
+
+
+# ---------------------------------------------------------------------------
+# capture_session
+# ---------------------------------------------------------------------------
+
+def test_capture_session_upserts(rollout, tmp_path):
+    db = tmp_path / "data" / "training_examples.db"
+    assert capture_session(rollout, session_id="abc", mind_id="m", db_path=db) is True
+    assert count_examples(db, harness=HARNESS_CODEX) == 1
+    row = get_example(db, "abc")
+    assert row["harness"] == HARNESS_CODEX
+    assert row["tool_call_count"] == 3
+    assert len(row["turns"]) == 6
+
+
+def test_capture_session_idempotent(rollout, tmp_path):
+    db = tmp_path / "training_examples.db"
+    capture_session(rollout, session_id="abc", db_path=db)
+    capture_session(rollout, session_id="abc", db_path=db)
+    assert count_examples(db) == 1
+
+
+def test_capture_session_noop_on_empty(tmp_path):
+    p = tmp_path / "empty.jsonl"
+    p.write_text("\n")
+    db = tmp_path / "training_examples.db"
+    assert capture_session(p, session_id="x", db_path=db) is False
+    assert not db.exists()


### PR DESCRIPTION
## What

Adds `core/training_capture_codex.py`, the missing Codex-harness consumer for the training fine-tuning dataset.

## Why

The storage layer (`core/training_capture.py`) already defines `HARNESS_CODEX = "codex"` and validates it, but no parser ever existed to turn a Codex `rollout-*.jsonl` into a `TrainingExample`. Every Codex mind's `training_capture` Stop hook imported the **Claude** parser (`training_capture_claude`), which only understands Claude JSONL. Result: the Codex side of `training_examples.db` has always been empty (176 rows, all `claude_code`).

## How

The new consumer mirrors the Claude one's public API (`parse_transcript` / `build_example` / `capture_session`) so a Codex mind's hook wrapper only swaps one import. It maps the Codex rollout shape to the same normalized turn array:

- `response_item` `message` (role user/assistant) → user/assistant turns
- `function_call` → the assistant turn's `tool_calls`, with `arguments` decoded into `input` and the real tool name kept verbatim
- `function_call_output` → `tool` turn keyed by `call_id`
- `reasoning` dropped (Codex analog of Claude thinking blocks)
- `developer`/`system` messages skipped; system prompt taken from `session_meta.base_instructions`; model from the last `turn_context`

## Tests

16 new tests in `tests/unit/test_training_capture_codex.py`, all green; existing 24 training tests still pass. Validated end-to-end against a real Mordecai rollout: 56 turns, 36 tool calls, `harness=codex`, model `gpt-5.4`.

Mordecai's per-mind Stop-hook wrapper (untracked, under `.codex/hooks/`) has been pointed at this consumer as the deploy.