### PR TITLE
training-capture: per-turn grain with interleaved reasoning blocks

### DIFF
--- a/core/training_capture.py
+++ b/core/training_capture.py
@@ -1,26 +1,30 @@
-"""Training-example capture: storage layer.
+"""Training-turn capture: storage layer.
 
-One SQLite table, ``training_examples``, holding raw harness sessions for
+One SQLite table, ``training_turns``, holding raw harness *turns* for
 harness-fidelity fine-tuning. The dataset teaches an open model to *drive*
 the Claude Code and Codex CLI harnesses — tool-call syntax, skill
 invocations, structural delimiters, and the policy of when to reach for
 which tool — not to reproduce a teacher's prose.
 
+The grain is the **turn**: one human message and the assistant's complete
+ordered response to it (thinking, tool calls, tool results, final text) up
+to the next human message. One turn becomes exactly one row; rows reassemble
+into a session by ordering on ``session_id`` then ``turn_index``. See
+``docs/training-capture/data-contract.md`` for the authoritative contract.
+
 Two properties define this layer:
 
 - **Lossless and raw.** No sanitization, no curation, no redaction. The row
-  stores exactly what the harness emitted. Filtering and key-substitution
-  are deliberately deferred to optional export-time passes over this
-  immutable store (see the spark_to_bloom backlog memo
-  ``clawd-harness-finetuning.md``).
-- **Upsert by ``session_id``.** Each Stop-hook fire re-reads the full
-  transcript and upserts one row keyed by ``session_id``. Whatever shape the
-  session has at its final turn is what persists, so the capture path does
-  not depend on a ``SessionEnd`` primitive and cannot race a closing session.
+  stores exactly what the harness emitted, in order, with real tool names
+  kept verbatim. Filtering, anonymization, and reasoning-stripping are
+  deferred to optional export-time passes over this immutable store.
+- **Upsert by ``(session_id, turn_index)``.** Each Stop-hook fire re-reads
+  the full transcript and upserts every turn row. A transcript only ever
+  grows, so turn rows are added or overwritten, never deleted.
 
 This module is intentionally dumb: it persists what it is given. Transcript
-parsing and tool-call normalization live in the per-harness consumers that
-call ``upsert_example``.
+parsing and turn grouping live in the per-harness consumers that call
+``upsert_turns``.
 """
 
 from __future__ import annotations
@@ -36,65 +40,77 @@ HARNESS_CODEX = "codex"
 VALID_HARNESSES = frozenset({HARNESS_CLAUDE_CODE, HARNESS_CODEX})
 
 SCHEMA = """
-CREATE TABLE IF NOT EXISTS training_examples (
+CREATE TABLE IF NOT EXISTS training_turns (
     id                INTEGER PRIMARY KEY,
-    session_id        TEXT NOT NULL UNIQUE,
+    session_id        TEXT NOT NULL,
+    turn_index        INTEGER NOT NULL,
     mind_id           TEXT,
     harness           TEXT NOT NULL,
     source_model      TEXT,
     harness_version   TEXT,
     captured_at       INTEGER,
     system_prompt     TEXT,
-    turns             TEXT,
-    turn_count        INTEGER,
+    user_content      TEXT,
+    assistant_blocks  TEXT,
+    has_reasoning     INTEGER NOT NULL DEFAULT 0,
     tool_call_count   INTEGER,
     length_tokens     INTEGER,
     quality_flag      TEXT NOT NULL DEFAULT 'pending',
     judge_verdict     TEXT,
     judge_confidence  REAL,
-    exclusion_reason  TEXT
+    exclusion_reason  TEXT,
+    UNIQUE(session_id, turn_index)
 );
-CREATE INDEX IF NOT EXISTS idx_training_examples_harness
-    ON training_examples (harness);
-CREATE INDEX IF NOT EXISTS idx_training_examples_source_model
-    ON training_examples (source_model);
+CREATE INDEX IF NOT EXISTS idx_training_turns_harness
+    ON training_turns (harness);
+CREATE INDEX IF NOT EXISTS idx_training_turns_source_model
+    ON training_turns (source_model);
+CREATE INDEX IF NOT EXISTS idx_training_turns_has_reasoning
+    ON training_turns (has_reasoning);
 """
 
 # Columns written on upsert. ``id`` is autoincrement; the judge/exclusion
-# columns are populated by later curation passes, not at capture time.
+# columns are populated by later curation passes, not at capture time, and
+# are preserved across re-capture.
 _UPSERT_COLUMNS = (
     "session_id",
+    "turn_index",
     "mind_id",
     "harness",
     "source_model",
     "harness_version",
     "captured_at",
     "system_prompt",
-    "turns",
-    "turn_count",
+    "user_content",
+    "assistant_blocks",
+    "has_reasoning",
     "tool_call_count",
     "length_tokens",
 )
 
 
 @dataclass
-class TrainingExample:
-    """One captured harness session, ready to persist.
+class TrainingTurn:
+    """One captured harness turn, ready to persist.
 
-    ``turns`` is the normalized turn array (a list of dicts); it is stored as
-    JSON text. ``turn_count`` and ``tool_call_count`` are derived from it by
-    :meth:`from_turns` so they cannot drift from the stored turns.
+    ``assistant_blocks`` is the ordered block array described in the data
+    contract (``thinking`` / ``text`` / ``tool_use`` / ``tool_result``); it
+    is stored as JSON text. ``has_reasoning``, ``tool_call_count``, and
+    ``length_tokens`` are derived from the content by :meth:`from_blocks` so
+    they cannot drift from the stored blocks.
     """
 
     session_id: str
+    turn_index: int
     harness: str
     mind_id: str | None = None
     source_model: str | None = None
     harness_version: str | None = None
     captured_at: int | None = None
     system_prompt: str | None = None
-    turns: list[dict] = field(default_factory=list)
-    turn_count: int = 0
+    user_content: str = ""
+    assistant_blocks: list[dict] = field(default_factory=list)
+    has_reasoning: bool = False
     tool_call_count: int = 0
     length_tokens: int | None = None
 
@@ -106,44 +122,70 @@ class TrainingExample:
             )
 
     @classmethod
-    def from_turns(
+    def from_blocks(
         cls,
         *,
         session_id: str,
+        turn_index: int,
         harness: str,
-        turns: list[dict],
+        user_content: str = "",
+        assistant_blocks: list[dict] | None = None,
         **kwargs,
-    ) -> "TrainingExample":
-        """Build an example, deriving the counts from ``turns``.
+    ) -> "TrainingTurn":
+        """Build a turn, deriving the denormalized fields from the blocks.
 
-        ``turn_count`` is the number of turns. ``tool_call_count`` sums the
-        ``tool_calls`` entries across all turns, which is the metric that
-        matters for prioritizing tool-heavy sessions.
+        ``has_reasoning`` is true when any block is a ``thinking`` block.
+        ``tool_call_count`` is the number of ``tool_use`` blocks.
+        ``length_tokens`` is a rough size estimate (chars / 4) over the
+        ``user_content`` plus the text carried by every block.
         """
-        tool_calls = sum(len(t.get("tool_calls") or []) for t in turns)
+        blocks = assistant_blocks or []
+        has_reasoning = any(b.get("type") == "thinking" for b in blocks)
+        tool_call_count = sum(1 for b in blocks if b.get("type") == "tool_use")
+        length_chars = len(user_content) + sum(
+            _block_text_len(b) for b in blocks
+        )
         return cls(
             session_id=session_id,
+            turn_index=turn_index,
             harness=harness,
-            turns=turns,
-            turn_count=len(turns),
-            tool_call_count=tool_calls,
+            user_content=user_content,
+            assistant_blocks=blocks,
+            has_reasoning=has_reasoning,
+            tool_call_count=tool_call_count,
+            length_tokens=length_chars // 4,
             **kwargs,
         )
 
     def _row_values(self) -> tuple:
         return (
             self.session_id,
+            self.turn_index,
             self.mind_id,
             self.harness,
             self.source_model,
             self.harness_version,
             self.captured_at,
             self.system_prompt,
-            json.dumps(self.turns, ensure_ascii=False),
-            self.turn_count,
+            self.user_content,
+            json.dumps(self.assistant_blocks, ensure_ascii=False),
+            1 if self.has_reasoning else 0,
             self.tool_call_count,
             self.length_tokens,
         )
+
+
+def _block_text_len(block: dict) -> int:
+    """Rough char count of a single assistant block for token estimation."""
+    btype = block.get("type")
+    if btype in ("thinking", "text"):
+        return len(block.get("text") or "")
+    if btype == "tool_use":
+        return len(json.dumps(block.get("input") or {}, ensure_ascii=False))
+    if btype == "tool_result":
+        content = block.get("content")
+        return len(content if isinstance(content, str) else str(content or ""))
+    return 0
 
 
 def connect(db_path: str | Path) -> sqlite3.Connection:
@@ -162,14 +204,14 @@ def init_db(db_path: str | Path) -> None:
         conn.executescript(SCHEMA)
 
 
-def upsert_example(db_path: str | Path, example: TrainingExample) -> None:
-    """Insert or replace a row keyed by ``session_id``.
+def upsert_turn(db_path: str | Path, turn: TrainingTurn) -> None:
+    """Insert or replace one row keyed by ``(session_id, turn_index)``.
 
     On conflict the capture-time columns are overwritten with the latest
     transcript shape while ``id`` is preserved. The curation columns
     (``quality_flag``, ``judge_*``, ``exclusion_reason``) are left untouched
-    so a re-capture of a session does not clobber a verdict already assigned
-    by a later pass.
+    so a re-capture of a turn does not clobber a verdict already assigned by
+    a later pass.
     """
     init_db(db_path)
     placeholders = ", ".join("?" for _ in _UPSERT_COLUMNS)
@@ -177,40 +219,69 @@ def upsert_example(db_path: str | Path, example: TrainingExample) -> None:
     updates = ", ".join(
         f"{col} = excluded.{col}"
         for col in _UPSERT_COLUMNS
-        if col != "session_id"
+        if col not in ("session_id", "turn_index")
     )
     sql = (
-        f"INSERT INTO training_examples ({columns}) VALUES ({placeholders}) "
-        f"ON CONFLICT(session_id) DO UPDATE SET {updates}"
+        f"INSERT INTO training_turns ({columns}) VALUES ({placeholders}) "
+        f"ON CONFLICT(session_id, turn_index) DO UPDATE SET {updates}"
     )
     with connect(db_path) as conn:
-        conn.execute(sql, example._row_values())
+        conn.execute(sql, turn._row_values())
 
 
-def get_example(db_path: str | Path, session_id: str) -> dict | None:
-    """Return one row as a dict (with ``turns`` decoded), or ``None``."""
+def upsert_turns(db_path: str | Path, turns: list[TrainingTurn]) -> None:
+    """Upsert a list of turn rows in one connection."""
+    init_db(db_path)
+    placeholders = ", ".join("?" for _ in _UPSERT_COLUMNS)
+    columns = ", ".join(_UPSERT_COLUMNS)
+    updates = ", ".join(
+        f"{col} = excluded.{col}"
+        for col in _UPSERT_COLUMNS
+        if col not in ("session_id", "turn_index")
+    )
+    sql = (
+        f"INSERT INTO training_turns ({columns}) VALUES ({placeholders}) "
+        f"ON CONFLICT(session_id, turn_index) DO UPDATE SET {updates}"
+    )
     with connect(db_path) as conn:
-        row = conn.execute(
-            "SELECT * FROM training_examples WHERE session_id = ?",
+        conn.executemany(sql, [t._row_values() for t in turns])
+
+
+def get_turns(db_path: str | Path, session_id: str) -> list[dict]:
+    """Return a session's rows ordered by ``turn_index``.
+
+    Each row is a dict with ``assistant_blocks`` JSON-decoded and
+    ``has_reasoning`` coerced to a bool.
+    """
+    with connect(db_path) as conn:
+        rows = conn.execute(
+            "SELECT * FROM training_turns WHERE session_id = ? "
+            "ORDER BY turn_index",
             (session_id,),
-        ).fetchone()
-    if row is None:
-        return None
-    record = dict(row)
-    record["turns"] = json.loads(record["turns"]) if record["turns"] else []
-    return record
+        ).fetchall()
+    records: list[dict] = []
+    for row in rows:
+        record = dict(row)
+        record["assistant_blocks"] = (
+            json.loads(record["assistant_blocks"])
+            if record["assistant_blocks"]
+            else []
+        )
+        record["has_reasoning"] = bool(record["has_reasoning"])
+        records.append(record)
+    return records
 
 
-def count_examples(db_path: str | Path, harness: str | None = None) -> int:
-    """Count rows, optionally filtered by ``harness``."""
+def count_turns(db_path: str | Path, harness: str | None = None) -> int:
+    """Count turn rows, optionally filtered by ``harness``."""
     with connect(db_path) as conn:
         if harness is None:
             row = conn.execute(
-                "SELECT COUNT(*) FROM training_examples"
+                "SELECT COUNT(*) FROM training_turns"
             ).fetchone()
         else:
             row = conn.execute(
-                "SELECT COUNT(*) FROM training_examples WHERE harness = ?",
+                "SELECT COUNT(*) FROM training_turns WHERE harness = ?",
                 (harness,),
             ).fetchone()
     return int(row[0])

--- a/core/training_capture_claude.py
+++ b/core/training_capture_claude.py
@@ -1,35 +1,38 @@
-"""Claude Code transcript → ``TrainingExample``.
+"""Claude Code transcript → per-turn ``TrainingTurn`` rows.
 
 The per-harness consumer for the Claude Code side of the harness
 fine-tuning dataset. It reads a Claude Code session JSONL transcript off
-disk, parses it into the turn array defined in the spec, and upserts one
-row via :func:`core.training_capture.upsert_example`.
+disk, groups it into per-turn rows defined by the data contract, and
+upserts one row per turn via :func:`core.training_capture.upsert_turns`.
 
-This module is pure transcript→row logic. It does not fork, load ``.env``,
+This module is pure transcript→rows logic. It does not fork, load ``.env``,
 or read a Stop payload — that orchestration lives in each mind's own
 Stop-hook wrapper (Skippy's lives under ``~/.claude/hooks/``). Keeping the
 parse logic here makes it importable and testable against fixture
 transcripts, and lets Ada reuse the exact same consumer.
 
-Capture is **fully raw**. Every user turn, assistant turn, tool call, and
-tool result is preserved in order, with tool results stored raw and the
-real tool names kept verbatim — ``Bash``, ``Skill`` with its actual skill
-name, ``mcp__hive-mind-tools__graph_query``, ``Task`` with its actual
-``subagent_type``. The model we are training is a specialist in *this*
-hive mind, so the concrete tool identities are the most valuable signal in
-the data, not noise to be bucketed away. Any anonymization (collapsing
-skill / MCP / sub-agent identifiers to category buckets) is an optional
-export-time transform over this immutable raw store, applied only if a
-more general model is ever wanted — never at capture time.
+A **turn** spans from one human (user) message to the next. A user event
+bearing human text opens a new turn; a user event bearing ``tool_result``
+blocks is *not* a new turn — its results append to the current turn's
+``assistant_blocks``. The block array preserves the assistant's exact
+ordering of ``thinking`` / ``text`` / ``tool_use`` / ``tool_result``.
 
-The only transforms applied at capture time:
+Capture is **fully raw**. Tool names are kept verbatim — ``Bash``,
+``Skill`` with its actual skill name, ``mcp__hive-mind-tools__graph_query``,
+``Task`` with its actual ``subagent_type``. The model we are training is a
+specialist in *this* hive mind, so the concrete tool identities are the most
+valuable signal in the data. Any anonymization is an optional export-time
+transform over this immutable raw store, never applied at capture time.
 
-- **Thinking blocks are dropped** — extended-reasoning content is pure
-  token bloat for harness fidelity and is never graded, so it is not
-  stored.
+The transforms applied at capture time:
+
+- **Readable thinking is kept** — plaintext extended-thinking blocks are
+  captured as ``thinking`` blocks in their real positions.
+- **Encrypted reasoning is dropped** — ``redacted_thinking`` blocks carry
+  no readable signal and are never stored.
 - **Sidechains are skipped** — sub-agent transcripts (``isSidechain``)
-  belong to their own session; the parent session keeps only the sub-agent
-  tool call and its result.
+  belong to their own session; the parent keeps only the sub-agent tool
+  call and its result.
 """
 
 from __future__ import annotations
@@ -41,39 +44,21 @@ from pathlib import Path
 
 from core.training_capture import (
     HARNESS_CLAUDE_CODE,
-    TrainingExample,
-    upsert_example,
+    TrainingTurn,
+    upsert_turns,
 )
 
 # The training DB lives next to the other state databases in this repo.
 # Module-relative so it resolves correctly whether Skippy runs it bare-metal
 # or Ada's container imports it at a different absolute path. Override with
 # ``TRAINING_DB_PATH`` for tests or an alternate location.
-_DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "data" / "training_examples.db"
+_DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "data" / "training_turns.db"
 
 
 def default_db_path() -> Path:
     """Resolve the training DB path, honoring ``TRAINING_DB_PATH``."""
     override = os.environ.get("TRAINING_DB_PATH")
     return Path(override) if override else _DEFAULT_DB_PATH
-
-
-def _content_text(content) -> str:
-    """Extract assistant/user text from a content value (string or blocks).
-
-    Thinking blocks are skipped. Tool-use / tool-result blocks are handled
-    by the caller, not here.
-    """
-    if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        parts = [
-            c.get("text", "")
-            for c in content
-            if isinstance(c, dict) and c.get("type") == "text"
-        ]
-        return "\n".join(p for p in parts if p)
-    return ""
 
 
 def _tool_result_text(content) -> str:
@@ -93,26 +78,48 @@ def _tool_result_text(content) -> str:
     return ""
 
 
-def parse_transcript(transcript_path: str | Path) -> list[dict]:
-    """Parse a Claude Code JSONL transcript into the raw turn array.
+class _TurnAccumulator:
+    """Groups transcript events into per-turn ``(user_content, blocks)``.
 
-    Each turn is one of::
+    A new turn opens only on a genuine human user message. Assistant blocks
+    and tool results append to the current turn. Blocks that arrive before
+    the first human message attach to a leading turn with empty
+    ``user_content``.
+    """
 
-        {"role": "user", "content": "..."}
-        {"role": "assistant", "content": "...", "tool_calls": [...]}
-        {"role": "tool", "content": "...", "tool_call_id": "..."}
+    def __init__(self) -> None:
+        self._turns: list[tuple[str, list[dict]]] = []
 
-    Each ``tool_calls`` entry is ``{"type": <raw tool name>, "input": {...},
-    "id": "..."}`` — the real tool name, kept verbatim. Turns are emitted in
-    transcript order. Sidechain (sub-agent) events and non user/assistant
-    events are skipped. Thinking blocks are dropped.
+    def _ensure_current(self) -> list[dict]:
+        if not self._turns:
+            self._turns.append(("", []))
+        return self._turns[-1][1]
+
+    def start_turn(self, user_content: str) -> None:
+        self._turns.append((user_content, []))
+
+    def add_block(self, block: dict) -> None:
+        self._ensure_current().append(block)
+
+    @property
+    def turns(self) -> list[tuple[str, list[dict]]]:
+        return self._turns
+
+
+def _parse_grouped(transcript_path: str | Path) -> list[tuple[str, list[dict]]]:
+    """Group a Claude Code JSONL transcript into per-turn rows.
+
+    Returns a list of ``(user_content, assistant_blocks)`` tuples in
+    transcript order. Sidechain events and non user/assistant events are
+    skipped. ``redacted_thinking`` blocks are dropped; readable ``thinking``
+    blocks are kept in position.
     """
     path = Path(transcript_path)
-    turns: list[dict] = []
+    acc = _TurnAccumulator()
     try:
         raw = path.read_text()
-    except Exception:
-        return turns
+    except OSError:
+        return []
 
     for line in raw.splitlines():
         line = line.strip()
@@ -120,7 +127,7 @@ def parse_transcript(transcript_path: str | Path) -> list[dict]:
             continue
         try:
             ev = json.loads(line)
-        except Exception:
+        except json.JSONDecodeError:
             continue
         if ev.get("type") not in ("user", "assistant"):
             continue
@@ -131,49 +138,53 @@ def parse_transcript(transcript_path: str | Path) -> list[dict]:
         content = msg.get("content")
 
         if role == "assistant":
-            text = _content_text(content)
-            tool_calls = []
+            if isinstance(content, str):
+                if content:
+                    acc.add_block({"type": "text", "text": content})
+                continue
             if isinstance(content, list):
                 for c in content:
-                    if isinstance(c, dict) and c.get("type") == "tool_use":
-                        tool_calls.append({
-                            "type": c.get("name", ""),
+                    if not isinstance(c, dict):
+                        continue
+                    ctype = c.get("type")
+                    if ctype == "thinking":
+                        text = c.get("thinking") or ""
+                        if text:
+                            acc.add_block({"type": "thinking", "text": text})
+                    elif ctype == "redacted_thinking":
+                        continue  # encrypted; no readable signal
+                    elif ctype == "text":
+                        if c.get("text"):
+                            acc.add_block({"type": "text", "text": c["text"]})
+                    elif ctype == "tool_use":
+                        acc.add_block({
+                            "type": "tool_use",
+                            "name": c.get("name", ""),
                             "input": c.get("input") or {},
                             "id": c.get("id", ""),
                         })
-            if not text and not tool_calls:
-                continue
-            turn: dict = {"role": "assistant", "content": text}
-            if tool_calls:
-                turn["tool_calls"] = tool_calls
-            turns.append(turn)
             continue
 
-        # role == "user": may carry a plain message, tool results, or both.
+        # role == "user": human text opens a new turn; tool_result blocks
+        # append to the current turn.
         if isinstance(content, str):
             if content:
-                turns.append({"role": "user", "content": content})
+                acc.start_turn(content)
             continue
         if isinstance(content, list):
-            pending_text: list[str] = []
             for c in content:
                 if not isinstance(c, dict):
                     continue
                 ctype = c.get("type")
                 if ctype == "tool_result":
-                    if pending_text:
-                        turns.append({"role": "user", "content": "\n".join(pending_text)})
-                        pending_text = []
-                    turns.append({
-                        "role": "tool",
+                    acc.add_block({
+                        "type": "tool_result",
                         "content": _tool_result_text(c.get("content")),
                         "tool_call_id": c.get("tool_use_id", ""),
                     })
                 elif ctype == "text" and c.get("text"):
-                    pending_text.append(c["text"])
-            if pending_text:
-                turns.append({"role": "user", "content": "\n".join(pending_text)})
-    return turns
+                    acc.start_turn(c["text"])
+    return acc.turns
 
 
 def _session_metadata(transcript_path: str | Path) -> dict:
@@ -187,7 +198,7 @@ def _session_metadata(transcript_path: str | Path) -> dict:
     version = None
     try:
         raw = path.read_text()
-    except Exception:
+    except OSError:
         return {"source_model": None, "harness_version": None}
     for line in raw.splitlines():
         line = line.strip()
@@ -195,7 +206,7 @@ def _session_metadata(transcript_path: str | Path) -> dict:
             continue
         try:
             ev = json.loads(line)
-        except Exception:
+        except json.JSONDecodeError:
             continue
         if ev.get("version"):
             version = ev["version"]
@@ -206,33 +217,39 @@ def _session_metadata(transcript_path: str | Path) -> dict:
     return {"source_model": model, "harness_version": version}
 
 
-def build_example(
+def build_turns(
     transcript_path: str | Path,
     *,
     session_id: str,
     mind_id: str | None = None,
     captured_at: int | None = None,
-) -> TrainingExample | None:
-    """Build a :class:`TrainingExample` from a transcript, or ``None``.
+) -> list[TrainingTurn]:
+    """Build the list of :class:`TrainingTurn` rows from a transcript.
 
-    Returns ``None`` when the transcript yields no turns (nothing to store).
+    Returns an empty list when the transcript yields no turns (nothing to
+    store). The ``system_prompt`` (Claude transcripts carry none here) is
+    denormalized onto every row of the session.
     """
-    turns = parse_transcript(transcript_path)
-    if not turns:
-        return None
+    grouped = _parse_grouped(transcript_path)
+    if not grouped:
+        return []
     meta = _session_metadata(transcript_path)
-    length_chars = sum(len(t.get("content") or "") for t in turns)
-    return TrainingExample.from_turns(
-        session_id=session_id,
-        harness=HARNESS_CLAUDE_CODE,
-        turns=turns,
-        mind_id=mind_id,
-        source_model=meta["source_model"],
-        harness_version=meta["harness_version"],
-        captured_at=captured_at if captured_at is not None else int(time.time()),
-        system_prompt=None,
-        length_tokens=length_chars // 4,
-    )
+    stamp = captured_at if captured_at is not None else int(time.time())
+    return [
+        TrainingTurn.from_blocks(
+            session_id=session_id,
+            turn_index=idx,
+            harness=HARNESS_CLAUDE_CODE,
+            user_content=user_content,
+            assistant_blocks=blocks,
+            mind_id=mind_id,
+            source_model=meta["source_model"],
+            harness_version=meta["harness_version"],
+            captured_at=stamp,
+            system_prompt=None,
+        )
+        for idx, (user_content, blocks) in enumerate(grouped)
+    ]
 
 
 def capture_session(
@@ -242,12 +259,12 @@ def capture_session(
     mind_id: str | None = None,
     db_path: str | Path | None = None,
 ) -> bool:
-    """Parse a transcript and upsert one row. Returns ``True`` if written.
+    """Parse a transcript and upsert its turn rows. ``True`` if any written.
 
     No-op (returns ``False``) when the transcript has no usable turns.
     """
-    example = build_example(transcript_path, session_id=session_id, mind_id=mind_id)
-    if example is None:
+    turns = build_turns(transcript_path, session_id=session_id, mind_id=mind_id)
+    if not turns:
         return False
-    upsert_example(db_path if db_path is not None else default_db_path(), example)
+    upsert_turns(db_path if db_path is not None else default_db_path(), turns)
     return True

--- a/core/training_capture_codex.py
+++ b/core/training_capture_codex.py
@@ -1,12 +1,11 @@
-"""Codex CLI rollout → ``TrainingExample``.
+"""Codex CLI rollout → per-turn ``TrainingTurn`` rows.
 
 The per-harness consumer for the Codex side of the harness fine-tuning
-dataset. It reads a Codex CLI rollout JSONL off disk, parses it into the
-same normalized turn array the Claude consumer produces, and upserts one
-row via :func:`core.training_capture.upsert_example` with
-``harness="codex"``.
+dataset. It reads a Codex CLI rollout JSONL off disk, groups it into the
+same per-turn rows the Claude consumer produces, and upserts one row per
+turn via :func:`core.training_capture.upsert_turns` with ``harness="codex"``.
 
-Like the Claude consumer this module is pure transcript→row logic: it does
+Like the Claude consumer this module is pure transcript→rows logic: it does
 not fork, load ``.env``, or read a Stop payload. That orchestration lives
 in each Codex mind's own Stop-hook wrapper (Mordecai's lives under
 ``.codex/hooks/``). Keeping the parse logic here makes it importable and
@@ -30,29 +29,26 @@ A Codex rollout is JSONL where each line is ``{"type": ..., "payload":
   ``arguments`` JSON string, ``call_id``), ``function_call_output`` (a tool
   result: ``call_id``, ``output``), or ``reasoning`` (dropped).
 
-Normalization mirrors the Claude consumer exactly so both harnesses land in
-one schema:
+Grain mirrors the Claude consumer: a turn spans from one human (user)
+message to the next. A ``user`` message opens a new turn; ``assistant``
+text, ``function_call``, and ``function_call_output`` items append to the
+current turn's ``assistant_blocks`` in order.
 
-    {"role": "user", "content": "..."}
-    {"role": "assistant", "content": "...", "tool_calls": [...]}
-    {"role": "tool", "content": "...", "tool_call_id": "..."}
+Each ``tool_use`` block is ``{"type": "tool_use", "name": <real tool name>,
+"input": {...}, "id": "..."}`` — the Codex tool name kept verbatim
+(``exec_command``, ``apply_patch``, ``shell``, an MCP tool, …), with
+``arguments`` decoded from its JSON string into ``input``. Capture is
+**fully raw**: tool results are stored as emitted and tool identities are
+preserved, because the model we are training is a specialist in driving
+*this* harness.
 
-Each ``tool_calls`` entry is ``{"type": <real tool name>, "input": {...},
-"id": "..."}`` — the Codex tool name kept verbatim (``exec_command``,
-``apply_patch``, ``shell``, an MCP tool, …), with ``arguments`` decoded from
-its JSON string into ``input``. Capture is **fully raw**: tool results are
-stored as emitted and tool identities are preserved, because the model we
-are training is a specialist in driving *this* harness.
+The transforms applied at capture time:
 
-The only transforms applied at capture time:
-
-- **Reasoning items are dropped** — encrypted/extended reasoning is pure
-  token bloat for harness fidelity and is never graded, so it is not
-  stored. This is the Codex analog of dropping Claude thinking blocks.
-- **Developer / system messages are skipped from the turn array** — they
-  are harness-injected scaffolding (permissions, apps, skills preambles),
-  not conversational turns. The real system prompt is captured separately
-  from ``session_meta.base_instructions``.
+- **Reasoning items are dropped** — Codex exposes no readable reasoning, so
+  Codex rows always carry ``has_reasoning = 0``.
+- **Developer / system messages are skipped from the turn body** — they are
+  harness-injected scaffolding. The real system prompt is captured
+  separately from ``session_meta.base_instructions``.
 """
 
 from __future__ import annotations
@@ -64,18 +60,18 @@ from pathlib import Path
 
 from core.training_capture import (
     HARNESS_CODEX,
-    TrainingExample,
-    upsert_example,
+    TrainingTurn,
+    upsert_turns,
 )
 
 # The training DB lives next to the other state databases in this repo.
 # Module-relative so it resolves whether a mind runs it bare-metal or a
 # container imports it at a different absolute path. Override with
 # ``TRAINING_DB_PATH`` for tests or an alternate location.
-_DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "data" / "training_examples.db"
+_DEFAULT_DB_PATH = Path(__file__).resolve().parent.parent / "data" / "training_turns.db"
 
 # Message roles that are real conversational turns. ``developer`` / ``system``
-# carry harness scaffolding and are excluded from the turn array.
+# carry harness scaffolding and are excluded from the turn body.
 _TURN_ROLES = frozenset({"user", "assistant"})
 
 
@@ -136,7 +132,7 @@ def _parse_arguments(arguments) -> dict:
     if isinstance(arguments, str):
         try:
             decoded = json.loads(arguments)
-        except Exception:
+        except json.JSONDecodeError:
             return {"raw": arguments}
         return decoded if isinstance(decoded, dict) else {"raw": arguments}
     if arguments is None:
@@ -144,34 +140,47 @@ def _parse_arguments(arguments) -> dict:
     return {"raw": str(arguments)}
 
 
-def _append_tool_call(turns: list[dict], call: dict) -> None:
-    """Attach a tool call to the open assistant turn, or open a new one.
+class _TurnAccumulator:
+    """Groups rollout items into per-turn ``(user_content, blocks)``.
 
-    Consecutive ``function_call`` items (an assistant firing several tools
-    before any result) accrue onto the same assistant turn. A call that
-    follows a ``tool`` turn or a ``user`` turn opens a fresh assistant turn
-    with empty content, matching how the model actually stepped.
+    A new turn opens only on a ``user`` message. Assistant text, tool calls,
+    and tool results append to the current turn. Items that arrive before the
+    first user message attach to a leading turn with empty ``user_content``.
     """
-    if turns and turns[-1]["role"] == "assistant":
-        turns[-1].setdefault("tool_calls", []).append(call)
-    else:
-        turns.append({"role": "assistant", "content": "", "tool_calls": [call]})
+
+    def __init__(self) -> None:
+        self._turns: list[tuple[str, list[dict]]] = []
+
+    def _ensure_current(self) -> list[dict]:
+        if not self._turns:
+            self._turns.append(("", []))
+        return self._turns[-1][1]
+
+    def start_turn(self, user_content: str) -> None:
+        self._turns.append((user_content, []))
+
+    def add_block(self, block: dict) -> None:
+        self._ensure_current().append(block)
+
+    @property
+    def turns(self) -> list[tuple[str, list[dict]]]:
+        return self._turns
 
 
-def parse_transcript(transcript_path: str | Path) -> list[dict]:
-    """Parse a Codex rollout JSONL into the normalized turn array.
+def _parse_grouped(transcript_path: str | Path) -> list[tuple[str, list[dict]]]:
+    """Group a Codex rollout JSONL into per-turn rows.
 
-    Turns are emitted in rollout order. ``response_item`` lines drive the
-    output; ``reasoning`` items and ``developer`` / ``system`` messages are
+    Returns a list of ``(user_content, assistant_blocks)`` tuples in rollout
+    order. ``reasoning`` items and ``developer`` / ``system`` messages are
     dropped; ``event_msg`` / ``session_meta`` / ``turn_context`` lines are
     ignored here (metadata is read separately).
     """
     path = Path(transcript_path)
-    turns: list[dict] = []
+    acc = _TurnAccumulator()
     try:
         raw = path.read_text()
-    except Exception:
-        return turns
+    except OSError:
+        return []
 
     for line in raw.splitlines():
         line = line.strip()
@@ -179,7 +188,7 @@ def parse_transcript(transcript_path: str | Path) -> list[dict]:
             continue
         try:
             ev = json.loads(line)
-        except Exception:
+        except json.JSONDecodeError:
             continue
         if ev.get("type") != "response_item":
             continue
@@ -191,28 +200,33 @@ def parse_transcript(transcript_path: str | Path) -> list[dict]:
             if role not in _TURN_ROLES:
                 continue
             text = _content_text(payload.get("content"))
-            if text:
-                turns.append({"role": role, "content": text})
+            if role == "user":
+                if text:
+                    acc.start_turn(text)
+            else:  # assistant
+                if text:
+                    acc.add_block({"type": "text", "text": text})
             continue
 
         if ptype == "function_call":
-            _append_tool_call(turns, {
-                "type": payload.get("name", ""),
+            acc.add_block({
+                "type": "tool_use",
+                "name": payload.get("name", ""),
                 "input": _parse_arguments(payload.get("arguments")),
                 "id": payload.get("call_id", ""),
             })
             continue
 
         if ptype == "function_call_output":
-            turns.append({
-                "role": "tool",
+            acc.add_block({
+                "type": "tool_result",
                 "content": _output_text(payload.get("output")),
                 "tool_call_id": payload.get("call_id", ""),
             })
             continue
 
         # reasoning and any other item types are intentionally dropped.
-    return turns
+    return acc.turns
 
 
 def _session_metadata(transcript_path: str | Path) -> dict:
@@ -228,7 +242,7 @@ def _session_metadata(transcript_path: str | Path) -> dict:
     system_prompt = None
     try:
         raw = path.read_text()
-    except Exception:
+    except OSError:
         return {"source_model": None, "harness_version": None, "system_prompt": None}
     for line in raw.splitlines():
         line = line.strip()
@@ -236,7 +250,7 @@ def _session_metadata(transcript_path: str | Path) -> dict:
             continue
         try:
             ev = json.loads(line)
-        except Exception:
+        except json.JSONDecodeError:
             continue
         etype = ev.get("type")
         payload = ev.get("payload") or {}
@@ -259,33 +273,39 @@ def _session_metadata(transcript_path: str | Path) -> dict:
     }
 
 
-def build_example(
+def build_turns(
     transcript_path: str | Path,
     *,
     session_id: str,
     mind_id: str | None = None,
     captured_at: int | None = None,
-) -> TrainingExample | None:
-    """Build a :class:`TrainingExample` from a rollout, or ``None``.
+) -> list[TrainingTurn]:
+    """Build the list of :class:`TrainingTurn` rows from a rollout.
 
-    Returns ``None`` when the rollout yields no turns (nothing to store).
+    Returns an empty list when the rollout yields no turns (nothing to
+    store). The ``system_prompt`` from ``session_meta`` is denormalized onto
+    every row of the session.
     """
-    turns = parse_transcript(transcript_path)
-    if not turns:
-        return None
+    grouped = _parse_grouped(transcript_path)
+    if not grouped:
+        return []
     meta = _session_metadata(transcript_path)
-    length_chars = sum(len(t.get("content") or "") for t in turns)
-    return TrainingExample.from_turns(
-        session_id=session_id,
-        harness=HARNESS_CODEX,
-        turns=turns,
-        mind_id=mind_id,
-        source_model=meta["source_model"],
-        harness_version=meta["harness_version"],
-        captured_at=captured_at if captured_at is not None else int(time.time()),
-        system_prompt=meta["system_prompt"],
-        length_tokens=length_chars // 4,
-    )
+    stamp = captured_at if captured_at is not None else int(time.time())
+    return [
+        TrainingTurn.from_blocks(
+            session_id=session_id,
+            turn_index=idx,
+            harness=HARNESS_CODEX,
+            user_content=user_content,
+            assistant_blocks=blocks,
+            mind_id=mind_id,
+            source_model=meta["source_model"],
+            harness_version=meta["harness_version"],
+            captured_at=stamp,
+            system_prompt=meta["system_prompt"],
+        )
+        for idx, (user_content, blocks) in enumerate(grouped)
+    ]
 
 
 def capture_session(
@@ -295,12 +315,12 @@ def capture_session(
     mind_id: str | None = None,
     db_path: str | Path | None = None,
 ) -> bool:
-    """Parse a rollout and upsert one row. Returns ``True`` if written.
+    """Parse a rollout and upsert its turn rows. ``True`` if any written.
 
     No-op (returns ``False``) when the rollout has no usable turns.
     """
-    example = build_example(transcript_path, session_id=session_id, mind_id=mind_id)
-    if example is None:
+    turns = build_turns(transcript_path, session_id=session_id, mind_id=mind_id)
+    if not turns:
         return False
-    upsert_example(db_path if db_path is not None else default_db_path(), example)
+    upsert_turns(db_path if db_path is not None else default_db_path(), turns)
     return True

--- a/docs/training-capture/data-contract.md
+++ b/docs/training-capture/data-contract.md
@@ -1,0 +1,173 @@
+# Training-capture data contract
+
+This document is the authoritative description of the `training_turns` table:
+what every row holds, how the captured turns are structured, and the exact
+procedures for turning the raw store into training sets for both reasoning
+and non-reasoning models. It lives next to the code that writes the table
+(`core/training_capture.py`, `core/training_capture_claude.py`,
+`core/training_capture_codex.py`) so the rules and the data never drift apart.
+
+If you are about to write an export pipeline, a curation pass, or a
+synthetic-reasoning generator, read this file first. Everything you need to
+reconstruct a session and place reasoning correctly is specified here.
+
+## What the dataset is for
+
+The dataset teaches an open model to *drive* the Claude Code and Codex CLI
+harnesses — tool-call syntax, skill invocations, structural delimiters, and
+the policy of when to reach for which tool. Capture is **lossless and raw**:
+the row stores what the harness emitted, in order, with real tool names kept
+verbatim. Filtering, anonymization, and reasoning-stripping are deferred to
+optional export-time passes over this immutable store, never applied at
+capture time.
+
+## Grain: one row per turn
+
+A **turn** spans from one human (user) message to the next. One turn becomes
+exactly one row. A row carries:
+
+- the user prompt that opened the turn, and
+- the assistant's complete ordered response to it — its thinking, its tool
+  calls, the results of those tool calls, and its final text — up to the
+  next human message.
+
+Tool calls and their results live **inside** the turn they belong to. A
+single turn routinely contains many tool calls (grep, read, edit, …), and
+the assistant may reason, act, observe results, then reason again before
+answering. That interleaving is preserved exactly (see *Assistant block
+sequence* below).
+
+Rows reassemble into a full session by ordering on `session_id` then
+`turn_index`. The grain is the turn; the training unit at export time may be
+a single turn or a whole reassembled session, depending on the recipe.
+
+## Schema
+
+Table `training_turns`, keyed for upsert on `(session_id, turn_index)`:
+
+| column            | type             | meaning |
+|-------------------|------------------|---------|
+| `id`              | INTEGER PK       | autoincrement surrogate |
+| `session_id`      | TEXT NOT NULL    | the harness session this turn belongs to |
+| `turn_index`      | INTEGER NOT NULL | 0-based position of the turn within the session; the ordering key |
+| `mind_id`         | TEXT             | the mind that produced the turn |
+| `harness`         | TEXT NOT NULL    | `claude_code` or `codex` |
+| `source_model`    | TEXT             | model the session ended on |
+| `harness_version` | TEXT             | CLI version |
+| `captured_at`     | INTEGER          | unix seconds at capture |
+| `system_prompt`   | TEXT             | session system prompt (denormalized onto each row; same for every row of a session) |
+| `user_content`    | TEXT             | the human prompt that opened this turn |
+| `assistant_blocks`| TEXT (JSON)      | the assistant's ordered response, as the block array described below |
+| `has_reasoning`   | INTEGER (0/1)    | 1 if `assistant_blocks` contains any `thinking` block; the cheap filter that avoids scanning the JSON |
+| `tool_call_count` | INTEGER          | number of `tool_use` blocks in this turn |
+| `length_tokens`   | INTEGER          | rough size estimate (chars / 4) |
+| `quality_flag`    | TEXT             | curation, default `pending`; preserved across re-capture |
+| `judge_verdict`   | TEXT             | curation; preserved across re-capture |
+| `judge_confidence`| REAL             | curation; preserved across re-capture |
+| `exclusion_reason`| TEXT             | curation; preserved across re-capture |
+
+`UNIQUE(session_id, turn_index)`. Indexes on `harness`, `source_model`, and
+`has_reasoning`.
+
+`has_reasoning` is intentionally **not** redundant with the JSON. It is the
+denormalized index that lets a training-set query select reasoning rows or
+non-reasoning rows with plain SQL — `WHERE has_reasoning = 1` — without ever
+opening `assistant_blocks`.
+
+## Assistant block sequence
+
+`assistant_blocks` is a JSON array of typed blocks in the exact order the
+assistant produced them. Block types:
+
+```json
+{"type": "thinking", "text": "..."}
+{"type": "text", "text": "..."}
+{"type": "tool_use", "name": "<real tool name>", "input": {...}, "id": "..."}
+{"type": "tool_result", "content": "...", "tool_call_id": "..."}
+```
+
+The ordering of the array is load-bearing. It is the only thing that records
+*where* each reasoning blob sits relative to the actions it produced. A
+reasoning blob owns the run of actions from its position up to the next
+`thinking` block (or to the end of the turn). The action that follows a
+reasoning block is the anchor for that reasoning — never a placeholder tag.
+
+There is never an empty `thinking` block. Reasoning is present in its real
+position or entirely absent. An empty reasoning shell trains a reasoning
+model to open a thought and emit nothing, which is the one actively harmful
+representation; we never write it.
+
+## Capture-time transforms
+
+Only these transforms are applied when a transcript is parsed into rows.
+Everything else is preserved verbatim.
+
+- **Readable thinking is kept.** Claude's plaintext extended-thinking blocks
+  are captured as `thinking` blocks in their real positions.
+- **Encrypted reasoning is dropped.** Claude `redacted_thinking` (encrypted)
+  and Codex `reasoning` items (encrypted) carry no readable signal and are
+  never stored. Dropping them does not distort the transcript: the assistant
+  message and its tool calls fall adjacent and read as a clean
+  user → assistant → tool flow.
+- **Sidechains are skipped** (Claude). Sub-agent transcripts belong to their
+  own session; the parent keeps only the sub-agent tool call and its result.
+- **Developer / system messages are skipped from the turn body** (Codex).
+  They are harness scaffolding; the real system prompt is captured into the
+  `system_prompt` column from `session_meta.base_instructions`.
+
+Consequence: Codex rows always have `has_reasoning = 0` today (Codex exposes
+no readable reasoning). Claude rows have `has_reasoning = 1` on any turn
+where readable thinking survived.
+
+## Idempotency
+
+Each Stop-hook fire re-reads the full transcript and upserts every turn row
+by `(session_id, turn_index)`. A transcript only ever grows, so turn rows
+are added or overwritten, never deleted. On conflict the capture-time
+columns are overwritten with the latest shape while the curation columns
+(`quality_flag`, `judge_*`, `exclusion_reason`) are preserved, so a
+re-capture never clobbers a verdict.
+
+## Reconstruction and export recipes
+
+The raw store keeps thinking in place; stripping it is an export decision,
+so a turn's position is never lost.
+
+**Non-reasoning model.** Render each turn dropping every `thinking` block.
+The remaining `text`, `tool_use`, and `tool_result` blocks stay in order and
+read as a clean action sequence. No placeholder is left behind.
+
+**Reasoning model.** Render each turn with `thinking` blocks inline, each in
+front of the action group it produced, in whatever thinking format the target
+model expects. Select the rows with `WHERE has_reasoning = 1` when you want
+only turns that carry real reasoning.
+
+**Reassembling a session.** Order rows by `turn_index` within a `session_id`.
+Each row contributes its `user_content` followed by its rendered
+`assistant_blocks`.
+
+## Adding synthetic reasoning (Codex, or any non-reasoning turn)
+
+Codex turns have no reasoning. To generate it later, the turn row is the
+anchor and the `tool_use` blocks are the insertion points — no placeholder
+is needed because position is determined by the action that follows.
+
+Procedure for one turn row:
+
+1. Split the `assistant_blocks` array into action groups. An action group is
+   a run of `tool_use` / `tool_result` blocks (and any trailing `text`) that
+   should share one rationale. The simplest grouping is one group per
+   `tool_use` plus one for the final `text`; a coarser grouping (one
+   rationale for a parallel batch of calls) is equally valid because the
+   schema does not constrain it.
+2. For each group, give the generating model the `user_content`, the prior
+   results in this turn, and the action(s) in the group, and ask it for the
+   reasoning that would have produced that action.
+3. Insert the generated text as a `thinking` block immediately **before** the
+   group it explains. Repeat for each group, so a turn with three action
+   groups receives up to three `thinking` blocks, each in its correct slot.
+4. Set `has_reasoning = 1` on the row.
+
+Because every action keeps its ordinal position, the generated reasoning
+lands exactly where the original reasoning would have been, and the chunking
+choice in step 1 is free to change without altering the storage format.

--- a/scripts/migrations/2026-06-18-training-examples-to-turns.py
+++ b/scripts/migrations/2026-06-18-training-examples-to-turns.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""One-shot migration: ``training_examples`` (session grain) → ``training_turns``.
+
+Converts the historical session-grain training DB into the per-turn schema
+defined in ``docs/training-capture/data-contract.md``.
+
+The runtime moved its database file from ``data/training_examples.db`` to
+``data/training_turns.db`` when the grain changed, so this migration is
+**file-to-file**: it reads the old file's ``training_examples`` table, writes
+per-turn rows into the new file's ``training_turns`` table, and then removes
+the superseded old file. (If source and destination resolve to the same
+file, it migrates in place and drops the old table instead.)
+
+Each old row carries a flat ``turns`` JSON array (thinking already absent in
+historical data). We walk that array and group it into per-turn rows:
+
+  - a ``role == "user"`` entry starts a new turn (its content becomes
+    ``user_content``);
+  - ``role == "assistant"`` entries contribute a ``text`` block (when there
+    is content) followed by a ``tool_use`` block per ``tool_calls`` entry;
+  - ``role == "tool"`` entries contribute a ``tool_result`` block;
+  - entries before the first user entry attach to a leading turn with empty
+    ``user_content``.
+
+All migrated rows get ``has_reasoning = 0`` (old data never captured
+thinking). ``session_id``, ``mind_id``, ``harness``, ``source_model``,
+``harness_version``, ``captured_at``, ``system_prompt`` and the curation
+columns (``quality_flag``, ``judge_verdict``, ``judge_confidence``,
+``exclusion_reason``) are carried over.
+
+The migration is idempotent: once the old file is gone (or holds no
+``training_examples`` table), it no-ops.
+
+Usage::
+
+    python scripts/migrations/2026-06-18-training-examples-to-turns.py \
+        --src data/training_examples.db --dest data/training_turns.db
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+# Import the storage layer so the new table's schema stays single-sourced.
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from core.training_capture import (  # noqa: E402
+    SCHEMA,
+    TrainingTurn,
+    connect,
+)
+
+_CURATION_COLUMNS = (
+    "quality_flag",
+    "judge_verdict",
+    "judge_confidence",
+    "exclusion_reason",
+)
+
+
+def _default_dest() -> Path:
+    """The runtime's training DB path, honoring ``TRAINING_DB_PATH``."""
+    override = os.environ.get("TRAINING_DB_PATH")
+    return Path(override) if override else _REPO_ROOT / "data" / "training_turns.db"
+
+
+def _has_table(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+        (name,),
+    ).fetchone()
+    return row is not None
+
+
+def _group_old_turns(old_turns: list[dict]) -> list[tuple[str, list[dict]]]:
+    """Group an old flat ``turns`` array into ``(user_content, blocks)``."""
+    grouped: list[tuple[str, list[dict]]] = []
+
+    def ensure_current() -> list[dict]:
+        if not grouped:
+            grouped.append(("", []))
+        return grouped[-1][1]
+
+    for entry in old_turns:
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role")
+        content = entry.get("content") or ""
+        if role == "user":
+            grouped.append((content, []))
+        elif role == "assistant":
+            blocks = ensure_current()
+            if content:
+                blocks.append({"type": "text", "text": content})
+            for call in entry.get("tool_calls") or []:
+                if not isinstance(call, dict):
+                    continue
+                blocks.append({
+                    "type": "tool_use",
+                    "name": call.get("type", ""),
+                    "input": call.get("input") or {},
+                    "id": call.get("id", ""),
+                })
+        elif role == "tool":
+            ensure_current().append({
+                "type": "tool_result",
+                "content": content,
+                "tool_call_id": entry.get("tool_call_id", ""),
+            })
+    return grouped
+
+
+def _insert_turn(dest: sqlite3.Connection, old: dict, idx: int,
+                 user_content: str, blocks: list[dict]) -> None:
+    turn = TrainingTurn.from_blocks(
+        session_id=old["session_id"],
+        turn_index=idx,
+        harness=old["harness"],
+        user_content=user_content,
+        assistant_blocks=blocks,
+        mind_id=old.get("mind_id"),
+        source_model=old.get("source_model"),
+        harness_version=old.get("harness_version"),
+        captured_at=old.get("captured_at"),
+        system_prompt=old.get("system_prompt"),
+    )
+    # Old data never captured thinking.
+    turn.has_reasoning = False
+    values = turn._row_values() + (
+        old.get("quality_flag") or "pending",
+        old.get("judge_verdict"),
+        old.get("judge_confidence"),
+        old.get("exclusion_reason"),
+    )
+    dest.execute(
+        "INSERT INTO training_turns ("
+        "session_id, turn_index, mind_id, harness, source_model, "
+        "harness_version, captured_at, system_prompt, user_content, "
+        "assistant_blocks, has_reasoning, tool_call_count, "
+        "length_tokens, quality_flag, judge_verdict, "
+        "judge_confidence, exclusion_reason"
+        ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?) "
+        "ON CONFLICT(session_id, turn_index) DO NOTHING",
+        values,
+    )
+
+
+def migrate(src_path: str | Path, dest_path: str | Path | None = None) -> int:
+    """Migrate ``training_examples`` → ``training_turns``. Returns rows written.
+
+    Reads the ``training_examples`` table from ``src_path`` and writes per-turn
+    rows into the ``training_turns`` table at ``dest_path`` (defaulting to the
+    runtime DB). When the two paths differ the old file is removed on success;
+    when they are the same file the old table is dropped. No-op (returns 0)
+    when there is nothing to migrate.
+    """
+    src = Path(src_path)
+    dest = Path(dest_path) if dest_path is not None else _default_dest()
+    same_file = src.exists() and dest.exists() and src.resolve() == dest.resolve()
+
+    if not src.exists():
+        print(f"no DB at {src}; nothing to migrate")
+        return 0
+
+    with connect(src) as src_conn:
+        if not _has_table(src_conn, "training_examples"):
+            print("training_examples table absent; already migrated, no-op")
+            return 0
+        old_rows = [dict(r) for r in src_conn.execute("SELECT * FROM training_examples")]
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with connect(dest) as dest_conn:
+        dest_conn.executescript(SCHEMA)
+        written = 0
+        for old in old_rows:
+            raw = old.get("turns")
+            old_turns = json.loads(raw) if raw else []
+            for idx, (user_content, blocks) in enumerate(_group_old_turns(old_turns)):
+                _insert_turn(dest_conn, old, idx, user_content, blocks)
+                written += 1
+        dest_conn.commit()
+
+    # Retire the superseded store. Distinct files: remove the old file whole.
+    # Same file: drop the old table (the new table already lives alongside).
+    if same_file:
+        with connect(dest) as conn:
+            conn.execute("DROP TABLE training_examples")
+            conn.commit()
+    else:
+        src.unlink()
+
+    print(f"migrated {written} turn rows from {len(old_rows)} sessions "
+          f"into {dest}; retired {src}")
+    return written
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--src",
+        required=True,
+        help="path to the old training_examples DB to read",
+    )
+    parser.add_argument(
+        "--dest",
+        default=None,
+        help="path to the new training_turns DB to write "
+             "(default: the runtime DB / $TRAINING_DB_PATH)",
+    )
+    args = parser.parse_args()
+    migrate(args.src, args.dest)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_training_capture.py
+++ b/tests/unit/test_training_capture.py
@@ -1,8 +1,9 @@
-"""Unit tests for the training-example storage layer.
+"""Unit tests for the training-turn storage layer.
 
-Covers schema creation, upsert-by-session_id idempotency, count derivation
-from turns, harness validation, and that re-capture preserves curation
-columns assigned by a later pass.
+Covers schema creation, upsert-by-(session_id, turn_index) idempotency,
+derivation of has_reasoning / tool_call_count / length_tokens from blocks,
+harness validation, ordered retrieval, and that re-capture preserves
+curation columns assigned by a later pass.
 """
 
 from __future__ import annotations
@@ -14,33 +15,40 @@ import pytest
 from core.training_capture import (
     HARNESS_CLAUDE_CODE,
     HARNESS_CODEX,
-    TrainingExample,
+    TrainingTurn,
     connect,
-    count_examples,
-    get_example,
+    count_turns,
+    get_turns,
     init_db,
-    upsert_example,
+    upsert_turn,
+    upsert_turns,
 )
 
 
 @pytest.fixture
 def db_path(tmp_path):
-    return tmp_path / "nested" / "training_examples.db"
+    return tmp_path / "nested" / "training_turns.db"
 
 
-def _turns():
+def _blocks():
     return [
-        {"role": "user", "content": "do the thing"},
-        {
-            "role": "assistant",
-            "content": "on it",
-            "tool_calls": [
-                {"type": "Bash", "input": {"command": "ls"}},
-                {"type": "Read", "input": {"path": "x"}},
-            ],
-        },
-        {"role": "tool", "content": "result", "tool_call_id": "t1"},
+        {"type": "thinking", "text": "let me think"},
+        {"type": "text", "text": "on it"},
+        {"type": "tool_use", "name": "Bash", "input": {"command": "ls"}, "id": "t1"},
+        {"type": "tool_result", "content": "file.txt", "tool_call_id": "t1"},
+        {"type": "tool_use", "name": "Read", "input": {"path": "x"}, "id": "t2"},
     ]
+
+
+def _turn(session_id="s1", turn_index=0, harness=HARNESS_CLAUDE_CODE, **kwargs):
+    return TrainingTurn.from_blocks(
+        session_id=session_id,
+        turn_index=turn_index,
+        harness=harness,
+        user_content="do the thing",
+        assistant_blocks=_blocks(),
+        **kwargs,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -58,186 +66,195 @@ def test_init_db_creates_table_and_parent_dir(db_path):
                 "SELECT name FROM sqlite_master WHERE type='table'"
             )
         }
-    assert "training_examples" in names
+    assert "training_turns" in names
 
 
 def test_init_db_is_idempotent(db_path):
     init_db(db_path)
     init_db(db_path)  # must not raise
-    assert count_examples(db_path) == 0
+    assert count_turns(db_path) == 0
+
+
+def test_schema_has_has_reasoning_index(db_path):
+    init_db(db_path)
+    with connect(db_path) as conn:
+        idx = {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index'"
+            )
+        }
+    assert "idx_training_turns_has_reasoning" in idx
 
 
 # ---------------------------------------------------------------------------
-# from_turns derivation
+# from_blocks derivation
 # ---------------------------------------------------------------------------
 
-def test_from_turns_derives_counts():
-    ex = TrainingExample.from_turns(
-        session_id="s1", harness=HARNESS_CLAUDE_CODE, turns=_turns()
-    )
-    assert ex.turn_count == 3
-    assert ex.tool_call_count == 2
+def test_from_blocks_derives_has_reasoning_and_counts():
+    turn = _turn()
+    assert turn.has_reasoning is True
+    assert turn.tool_call_count == 2
+    assert turn.length_tokens is not None and turn.length_tokens > 0
 
 
-def test_from_turns_handles_missing_tool_calls():
-    turns = [{"role": "user", "content": "hi"}]
-    ex = TrainingExample.from_turns(
-        session_id="s1", harness=HARNESS_CODEX, turns=turns
+def test_from_blocks_no_thinking_has_reasoning_false():
+    turn = TrainingTurn.from_blocks(
+        session_id="s1",
+        turn_index=0,
+        harness=HARNESS_CODEX,
+        user_content="hi",
+        assistant_blocks=[{"type": "text", "text": "hello"}],
     )
-    assert ex.turn_count == 1
-    assert ex.tool_call_count == 0
+    assert turn.has_reasoning is False
+    assert turn.tool_call_count == 0
+
+
+def test_from_blocks_handles_empty_blocks():
+    turn = TrainingTurn.from_blocks(
+        session_id="s1", turn_index=0, harness=HARNESS_CODEX, user_content="hi"
+    )
+    assert turn.has_reasoning is False
+    assert turn.tool_call_count == 0
+    assert turn.assistant_blocks == []
 
 
 def test_invalid_harness_rejected():
     with pytest.raises(ValueError):
-        TrainingExample(session_id="s1", harness="bashrc")
+        TrainingTurn(session_id="s1", turn_index=0, harness="bashrc")
 
 
 # ---------------------------------------------------------------------------
 # upsert / get
 # ---------------------------------------------------------------------------
 
-def test_upsert_then_get_roundtrips(db_path):
-    ex = TrainingExample.from_turns(
-        session_id="s1",
-        harness=HARNESS_CLAUDE_CODE,
-        turns=_turns(),
+def test_upsert_turn_then_get_roundtrips(db_path):
+    turn = _turn(
         mind_id="14cb820b",
         source_model="claude-opus-4-7",
         harness_version="1.0.0",
         captured_at=1781649576,
         system_prompt="you are skippy",
-        length_tokens=42,
     )
-    upsert_example(db_path, ex)
+    upsert_turn(db_path, turn)
 
-    got = get_example(db_path, "s1")
-    assert got is not None
+    rows = get_turns(db_path, "s1")
+    assert len(rows) == 1
+    got = rows[0]
     assert got["session_id"] == "s1"
+    assert got["turn_index"] == 0
     assert got["harness"] == HARNESS_CLAUDE_CODE
     assert got["mind_id"] == "14cb820b"
     assert got["source_model"] == "claude-opus-4-7"
-    assert got["turn_count"] == 3
+    assert got["system_prompt"] == "you are skippy"
+    assert got["user_content"] == "do the thing"
     assert got["tool_call_count"] == 2
-    assert got["length_tokens"] == 42
+    assert got["has_reasoning"] is True
     assert got["quality_flag"] == "pending"
-    assert got["turns"] == _turns()
+    assert got["assistant_blocks"] == _blocks()
 
 
-def test_get_missing_returns_none(db_path):
+def test_get_missing_returns_empty(db_path):
     init_db(db_path)
-    assert get_example(db_path, "nope") is None
+    assert get_turns(db_path, "nope") == []
 
 
 def test_upsert_creates_db_if_absent(db_path):
     # No explicit init_db — upsert must stand up the schema itself.
-    ex = TrainingExample.from_turns(
-        session_id="s1", harness=HARNESS_CODEX, turns=_turns()
-    )
-    upsert_example(db_path, ex)
-    assert count_examples(db_path) == 1
+    upsert_turn(db_path, _turn(harness=HARNESS_CODEX))
+    assert count_turns(db_path) == 1
 
 
-def test_upsert_is_idempotent_by_session_id(db_path):
-    ex = TrainingExample.from_turns(
-        session_id="s1", harness=HARNESS_CLAUDE_CODE, turns=_turns()
-    )
-    upsert_example(db_path, ex)
-    upsert_example(db_path, ex)
-    assert count_examples(db_path) == 1
+def test_upsert_turns_writes_multiple_rows_ordered(db_path):
+    turns = [
+        _turn(turn_index=2),
+        _turn(turn_index=0),
+        _turn(turn_index=1),
+    ]
+    upsert_turns(db_path, turns)
+    rows = get_turns(db_path, "s1")
+    assert [r["turn_index"] for r in rows] == [0, 1, 2]
+    assert count_turns(db_path) == 3
+
+
+def test_upsert_is_idempotent_by_session_and_index(db_path):
+    upsert_turn(db_path, _turn())
+    upsert_turn(db_path, _turn())
+    assert count_turns(db_path) == 1
 
 
 def test_upsert_overwrites_capture_columns_and_preserves_id(db_path):
-    first = TrainingExample.from_turns(
+    first = TrainingTurn.from_blocks(
         session_id="s1",
+        turn_index=0,
         harness=HARNESS_CLAUDE_CODE,
-        turns=_turns()[:1],
+        user_content="do the thing",
+        assistant_blocks=[{"type": "text", "text": "on it"}],
         source_model="claude-sonnet-4-6",
     )
-    upsert_example(db_path, first)
+    upsert_turn(db_path, first)
     with connect(db_path) as conn:
         original_id = conn.execute(
-            "SELECT id FROM training_examples WHERE session_id='s1'"
+            "SELECT id FROM training_turns WHERE session_id='s1' AND turn_index=0"
         ).fetchone()[0]
 
-    grown = TrainingExample.from_turns(
-        session_id="s1",
-        harness=HARNESS_CLAUDE_CODE,
-        turns=_turns(),
-        source_model="claude-opus-4-7",
-    )
-    upsert_example(db_path, grown)
+    grown = _turn(source_model="claude-opus-4-7")
+    upsert_turn(db_path, grown)
 
-    got = get_example(db_path, "s1")
-    assert count_examples(db_path) == 1
-    assert got["turn_count"] == 3
-    assert got["tool_call_count"] == 2
-    assert got["source_model"] == "claude-opus-4-7"
+    rows = get_turns(db_path, "s1")
+    assert count_turns(db_path) == 1
+    assert rows[0]["tool_call_count"] == 2
+    assert rows[0]["source_model"] == "claude-opus-4-7"
     with connect(db_path) as conn:
         new_id = conn.execute(
-            "SELECT id FROM training_examples WHERE session_id='s1'"
+            "SELECT id FROM training_turns WHERE session_id='s1' AND turn_index=0"
         ).fetchone()[0]
     assert new_id == original_id
 
 
 def test_recapture_preserves_curation_columns(db_path):
-    ex = TrainingExample.from_turns(
-        session_id="s1", harness=HARNESS_CLAUDE_CODE, turns=_turns()
-    )
-    upsert_example(db_path, ex)
+    upsert_turn(db_path, _turn())
     # A later curation pass assigns a verdict.
     with connect(db_path) as conn:
         conn.execute(
-            "UPDATE training_examples SET quality_flag='clean', "
-            "judge_confidence=0.9 WHERE session_id='s1'"
+            "UPDATE training_turns SET quality_flag='clean', "
+            "judge_confidence=0.9 WHERE session_id='s1' AND turn_index=0"
         )
         conn.commit()
 
-    # Re-capture of the same session must not clobber the verdict.
-    upsert_example(db_path, ex)
-    got = get_example(db_path, "s1")
-    assert got["quality_flag"] == "clean"
-    assert got["judge_confidence"] == 0.9
+    # Re-capture of the same turn must not clobber the verdict.
+    upsert_turn(db_path, _turn())
+    rows = get_turns(db_path, "s1")
+    assert rows[0]["quality_flag"] == "clean"
+    assert rows[0]["judge_confidence"] == 0.9
+
+
+def test_distinct_sessions_share_turn_index(db_path):
+    upsert_turn(db_path, _turn(session_id="a", turn_index=0))
+    upsert_turn(db_path, _turn(session_id="b", turn_index=0))
+    assert count_turns(db_path) == 2
 
 
 # ---------------------------------------------------------------------------
-# count filtering
+# count filtering / storage encoding
 # ---------------------------------------------------------------------------
 
 def test_count_filters_by_harness(db_path):
-    upsert_example(
-        db_path,
-        TrainingExample.from_turns(
-            session_id="a", harness=HARNESS_CLAUDE_CODE, turns=_turns()
-        ),
-    )
-    upsert_example(
-        db_path,
-        TrainingExample.from_turns(
-            session_id="b", harness=HARNESS_CLAUDE_CODE, turns=_turns()
-        ),
-    )
-    upsert_example(
-        db_path,
-        TrainingExample.from_turns(
-            session_id="c", harness=HARNESS_CODEX, turns=_turns()
-        ),
-    )
-    assert count_examples(db_path) == 3
-    assert count_examples(db_path, harness=HARNESS_CLAUDE_CODE) == 2
-    assert count_examples(db_path, harness=HARNESS_CODEX) == 1
+    upsert_turn(db_path, _turn(session_id="a", harness=HARNESS_CLAUDE_CODE))
+    upsert_turn(db_path, _turn(session_id="b", harness=HARNESS_CLAUDE_CODE))
+    upsert_turn(db_path, _turn(session_id="c", harness=HARNESS_CODEX))
+    assert count_turns(db_path) == 3
+    assert count_turns(db_path, harness=HARNESS_CLAUDE_CODE) == 2
+    assert count_turns(db_path, harness=HARNESS_CODEX) == 1
 
 
-def test_turns_stored_as_json_text(db_path):
-    upsert_example(
-        db_path,
-        TrainingExample.from_turns(
-            session_id="s1", harness=HARNESS_CODEX, turns=_turns()
-        ),
-    )
+def test_blocks_stored_as_json_text_and_has_reasoning_as_int(db_path):
+    upsert_turn(db_path, _turn(harness=HARNESS_CODEX))
     with connect(db_path) as conn:
-        raw = conn.execute(
-            "SELECT turns FROM training_examples WHERE session_id='s1'"
-        ).fetchone()[0]
+        raw, hr = conn.execute(
+            "SELECT assistant_blocks, has_reasoning FROM training_turns "
+            "WHERE session_id='s1'"
+        ).fetchone()
     assert isinstance(raw, str)
-    assert json.loads(raw) == _turns()
+    assert json.loads(raw) == _blocks()
+    assert hr == 1

--- a/tests/unit/test_training_capture_claude.py
+++ b/tests/unit/test_training_capture_claude.py
@@ -1,8 +1,10 @@
 """Unit tests for the Claude Code transcript consumer.
 
-Covers transcript parsing into the raw turn array (real tool names kept
-verbatim), thinking-block dropping, sidechain skipping, metadata
-extraction, and the end-to-end ``capture_session`` upsert.
+Covers grouping the flat transcript into per-turn rows, the assistant block
+sequence (thinking / text / tool_use / tool_result in order), keeping
+readable thinking, dropping redacted_thinking, tool results appending to the
+current turn (not starting one), sidechain skipping, metadata extraction,
+and the end-to-end ``capture_session`` upsert.
 """
 
 from __future__ import annotations
@@ -11,11 +13,11 @@ import json
 
 import pytest
 
-from core.training_capture import HARNESS_CLAUDE_CODE, count_examples, get_example
+from core.training_capture import HARNESS_CLAUDE_CODE, count_turns, get_turns
 from core.training_capture_claude import (
-    build_example,
+    build_turns,
     capture_session,
-    parse_transcript,
+    _parse_grouped,
 )
 
 
@@ -43,16 +45,19 @@ def _user(content, *, version="2.1.179", sidechain=False):
 
 @pytest.fixture
 def transcript(tmp_path):
-    """A representative session: text, thinking, primitive + skill + agent +
-    mcp tool calls, a tool result, a sidechain event, and noise lines."""
+    """A representative session: text, readable thinking, redacted thinking,
+    primitive + skill + agent + mcp tool calls, tool results, a sidechain,
+    and noise lines. Two human turns."""
     lines = [
         _ev(type="summary", summary="ignored"),
         _user("fix the thing"),
         _assistant([
-            {"type": "thinking", "thinking": "secret reasoning, must be dropped"},
+            {"type": "thinking", "thinking": "readable reasoning, keep me"},
+            {"type": "redacted_thinking", "data": "ENCRYPTED-BLOB"},
             {"type": "text", "text": "on it"},
             {"type": "tool_use", "id": "t1", "name": "Bash", "input": {"command": "ls"}},
         ]),
+        # tool_result is NOT a new turn — appends to the current turn.
         _user([
             {"type": "tool_result", "tool_use_id": "t1", "content": "file.txt"},
         ]),
@@ -69,9 +74,12 @@ def transcript(tmp_path):
             {"type": "tool_result", "tool_use_id": "t2",
              "content": [{"type": "text", "text": "card list"}]},
         ]),
-        # sidechain (sub-agent) turns must be skipped entirely
+        # sidechain (sub-agent) events must be skipped entirely
         _assistant([{"type": "text", "text": "subagent internal chatter"}], sidechain=True),
         _user("subagent internal prompt", sidechain=True),
+        _assistant([{"type": "text", "text": "interim"}]),
+        # second human turn
+        _user("now ship it"),
         _assistant([{"type": "text", "text": "done"}]),
     ]
     p = tmp_path / "session-abc.jsonl"
@@ -80,82 +88,119 @@ def transcript(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# parse_transcript
+# turn grouping
 # ---------------------------------------------------------------------------
 
-def test_parse_roles_in_order(transcript):
-    turns = parse_transcript(transcript)
-    roles = [t["role"] for t in turns]
-    assert roles == [
-        "user",       # "fix the thing"
-        "assistant",  # "on it" + Bash
-        "tool",       # t1 result
-        "assistant",  # Skill + mcp + Task
-        "tool",       # t2 result
-        "assistant",  # "done"
+def test_groups_into_two_human_turns(transcript):
+    grouped = _parse_grouped(transcript)
+    assert len(grouped) == 2
+    assert grouped[0][0] == "fix the thing"
+    assert grouped[1][0] == "now ship it"
+
+
+def test_tool_result_does_not_start_a_new_turn(transcript):
+    grouped = _parse_grouped(transcript)
+    # All actions before "now ship it" belong to the first turn.
+    block_types = [b["type"] for b in grouped[0][1]]
+    assert block_types == [
+        "thinking",     # readable, kept (redacted dropped)
+        "text",         # "on it"
+        "tool_use",     # Bash
+        "tool_result",  # t1
+        "tool_use",     # Skill
+        "tool_use",     # mcp
+        "tool_use",     # Task
+        "tool_result",  # t2
+        "text",         # "interim"
     ]
 
 
-def test_thinking_blocks_dropped(transcript):
-    turns = parse_transcript(transcript)
-    assert all("secret reasoning" not in (t.get("content") or "") for t in turns)
-    assert turns[1]["content"] == "on it"
+def test_readable_thinking_kept_redacted_dropped(transcript):
+    grouped = _parse_grouped(transcript)
+    blocks = grouped[0][1]
+    thinking = [b for b in blocks if b["type"] == "thinking"]
+    assert thinking == [{"type": "thinking", "text": "readable reasoning, keep me"}]
+    blob = json.dumps(grouped)
+    assert "ENCRYPTED-BLOB" not in blob
 
 
 def test_sidechain_skipped(transcript):
-    turns = parse_transcript(transcript)
-    blob = json.dumps(turns)
+    grouped = _parse_grouped(transcript)
+    blob = json.dumps(grouped)
     assert "subagent internal" not in blob
 
 
-def test_tool_calls_kept_raw_in_turn(transcript):
-    turns = parse_transcript(transcript)
-    # First assistant turn: a single Bash call, name and input verbatim.
-    bash_turn = turns[1]
-    assert bash_turn["tool_calls"] == [
-        {"type": "Bash", "input": {"command": "ls"}, "id": "t1"}
-    ]
-    # Second assistant turn: Skill / MCP / Task with real identities kept.
-    skill_turn = turns[3]
-    types = [c["type"] for c in skill_turn["tool_calls"]]
-    assert types == ["Skill", "mcp__hive-mind-tools__graph_query", "Task"]
-    assert skill_turn["tool_calls"][0]["input"]["skill"] == "hivemind:planka"
-    assert skill_turn["tool_calls"][2]["input"]["subagent_type"] == "Explore"
+def test_tool_use_blocks_kept_raw(transcript):
+    grouped = _parse_grouped(transcript)
+    blocks = grouped[0][1]
+    tool_uses = [b for b in blocks if b["type"] == "tool_use"]
+    names = [b["name"] for b in tool_uses]
+    assert names == ["Bash", "Skill", "mcp__hive-mind-tools__graph_query", "Task"]
+    assert tool_uses[0] == {
+        "type": "tool_use", "name": "Bash", "input": {"command": "ls"}, "id": "t1"
+    }
+    assert tool_uses[1]["input"]["skill"] == "hivemind:planka"
+    assert tool_uses[3]["input"]["subagent_type"] == "Explore"
 
 
 def test_tool_result_links_id_and_flattens_blocks(transcript):
-    turns = parse_transcript(transcript)
-    assert turns[2] == {"role": "tool", "content": "file.txt", "tool_call_id": "t1"}
-    assert turns[4]["role"] == "tool"
-    assert turns[4]["content"] == "card list"
-    assert turns[4]["tool_call_id"] == "t2"
+    grouped = _parse_grouped(transcript)
+    blocks = grouped[0][1]
+    results = [b for b in blocks if b["type"] == "tool_result"]
+    assert results[0] == {
+        "type": "tool_result", "content": "file.txt", "tool_call_id": "t1"
+    }
+    assert results[1] == {
+        "type": "tool_result", "content": "card list", "tool_call_id": "t2"
+    }
+
+
+def test_leading_blocks_attach_to_empty_user_turn(tmp_path):
+    """Tool results / assistant blocks before the first human message attach
+    to a leading turn with empty user_content."""
+    lines = [
+        _assistant([{"type": "text", "text": "preamble"}]),
+        _user("real prompt"),
+        _assistant([{"type": "text", "text": "reply"}]),
+    ]
+    p = tmp_path / "lead.jsonl"
+    p.write_text("\n".join(lines) + "\n")
+    grouped = _parse_grouped(p)
+    assert grouped[0][0] == ""
+    assert grouped[0][1] == [{"type": "text", "text": "preamble"}]
+    assert grouped[1][0] == "real prompt"
 
 
 def test_missing_file_returns_empty(tmp_path):
-    assert parse_transcript(tmp_path / "nope.jsonl") == []
+    assert _parse_grouped(tmp_path / "nope.jsonl") == []
 
 
 # ---------------------------------------------------------------------------
-# build_example
+# build_turns
 # ---------------------------------------------------------------------------
 
-def test_build_example_counts_and_metadata(transcript):
-    ex = build_example(transcript, session_id="abc", mind_id="mind-uuid")
-    assert ex is not None
-    assert ex.session_id == "abc"
-    assert ex.mind_id == "mind-uuid"
-    assert ex.harness == HARNESS_CLAUDE_CODE
-    assert ex.source_model == "claude-opus-4-8"
-    assert ex.harness_version == "2.1.179"
-    assert ex.turn_count == 6
-    assert ex.tool_call_count == 4  # Bash + Skill + mcp + Task
-    assert ex.captured_at is not None
+def test_build_turns_metadata_and_indices(transcript):
+    turns = build_turns(transcript, session_id="abc", mind_id="mind-uuid")
+    assert len(turns) == 2
+    assert [t.turn_index for t in turns] == [0, 1]
+    first = turns[0]
+    assert first.session_id == "abc"
+    assert first.mind_id == "mind-uuid"
+    assert first.harness == HARNESS_CLAUDE_CODE
+    assert first.source_model == "claude-opus-4-8"
+    assert first.harness_version == "2.1.179"
+    assert first.has_reasoning is True
+    assert first.tool_call_count == 4  # Bash + Skill + mcp + Task
+    assert first.captured_at is not None
+    # second turn carries no reasoning
+    assert turns[1].has_reasoning is False
+    assert turns[1].tool_call_count == 0
 
 
-def test_build_example_empty_transcript_returns_none(tmp_path):
+def test_build_turns_empty_transcript_returns_empty(tmp_path):
     p = tmp_path / "empty.jsonl"
     p.write_text("")
-    assert build_example(p, session_id="x") is None
+    assert build_turns(p, session_id="x") == []
 
 
 # ---------------------------------------------------------------------------
@@ -163,25 +208,26 @@ def test_build_example_empty_transcript_returns_none(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_capture_session_upserts(transcript, tmp_path):
-    db = tmp_path / "data" / "training_examples.db"
+    db = tmp_path / "data" / "training_turns.db"
     assert capture_session(transcript, session_id="abc", mind_id="m", db_path=db) is True
-    assert count_examples(db, harness=HARNESS_CLAUDE_CODE) == 1
-    row = get_example(db, "abc")
-    assert row["tool_call_count"] == 4
-    assert len(row["turns"]) == 6
+    assert count_turns(db, harness=HARNESS_CLAUDE_CODE) == 2
+    rows = get_turns(db, "abc")
+    assert rows[0]["tool_call_count"] == 4
+    assert rows[0]["has_reasoning"] is True
+    assert rows[1]["user_content"] == "now ship it"
 
 
 def test_capture_session_idempotent(transcript, tmp_path):
-    db = tmp_path / "training_examples.db"
+    db = tmp_path / "training_turns.db"
     capture_session(transcript, session_id="abc", db_path=db)
     capture_session(transcript, session_id="abc", db_path=db)
-    assert count_examples(db) == 1
+    assert count_turns(db) == 2
 
 
 def test_capture_session_noop_on_empty(tmp_path):
     p = tmp_path / "empty.jsonl"
     p.write_text("\n")
-    db = tmp_path / "training_examples.db"
+    db = tmp_path / "training_turns.db"
     # A no-op capture writes nothing — not even an empty DB file.
     assert capture_session(p, session_id="x", db_path=db) is False
     assert not db.exists()

--- a/tests/unit/test_training_capture_codex.py
+++ b/tests/unit/test_training_capture_codex.py
@@ -1,10 +1,11 @@
 """Unit tests for the Codex CLI rollout consumer.
 
-Covers rollout parsing into the normalized turn array (real tool names kept
-verbatim, arguments decoded into ``input``), reasoning-item dropping,
-developer/system message skipping, ``event_msg`` noise being ignored,
-metadata extraction (model / version / system prompt), and the end-to-end
-``capture_session`` upsert with ``harness="codex"``.
+Covers grouping the rollout into per-turn rows, the assistant block sequence
+(text / tool_use / tool_result in order, arguments decoded into ``input``),
+reasoning-item dropping (has_reasoning always False), developer/system
+message skipping, ``event_msg`` noise being ignored, metadata extraction
+(model / version / system prompt), and the end-to-end ``capture_session``
+upsert with ``harness="codex"``.
 """
 
 from __future__ import annotations
@@ -13,11 +14,11 @@ import json
 
 import pytest
 
-from core.training_capture import HARNESS_CODEX, count_examples, get_example
+from core.training_capture import HARNESS_CODEX, count_turns, get_turns
 from core.training_capture_codex import (
-    build_example,
+    build_turns,
     capture_session,
-    parse_transcript,
+    _parse_grouped,
 )
 
 
@@ -50,7 +51,8 @@ def _output(call_id, output) -> str:
 def rollout(tmp_path):
     """A representative rollout: meta + model context, a developer preamble
     (skipped), real user/assistant turns, single and batched tool calls,
-    tool outputs, a reasoning item (dropped), and event_msg noise."""
+    tool outputs, a reasoning item (dropped), and event_msg noise. Two human
+    turns."""
     lines = [
         _line("session_meta", {
             "id": "019eda95-codex",
@@ -73,6 +75,8 @@ def rollout(tmp_path):
         # reasoning item must be dropped entirely
         _item({"type": "reasoning", "summary": [],
                "encrypted_content": "secret reasoning, must be dropped"}),
+        # second human turn
+        _message("user", "now ship it"),
         _message("assistant", "done"),
     ]
     p = tmp_path / "rollout-2026-06-18T06-54-27-019eda95.jsonl"
@@ -81,122 +85,140 @@ def rollout(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# parse_transcript
+# turn grouping
 # ---------------------------------------------------------------------------
 
-def test_parse_roles_in_order(rollout):
-    turns = parse_transcript(rollout)
-    roles = [t["role"] for t in turns]
-    assert roles == [
-        "user",       # "fix the thing"
-        "assistant",  # "on it" + exec_command
-        "tool",       # c1 result
-        "assistant",  # "now patching" + apply_patch + mcp
-        "tool",       # c2 result
-        "assistant",  # "done"
+def test_groups_into_two_human_turns(rollout):
+    grouped = _parse_grouped(rollout)
+    assert len(grouped) == 2
+    assert grouped[0][0] == "fix the thing"
+    assert grouped[1][0] == "now ship it"
+
+
+def test_first_turn_block_sequence(rollout):
+    grouped = _parse_grouped(rollout)
+    block_types = [b["type"] for b in grouped[0][1]]
+    assert block_types == [
+        "text",         # "on it"
+        "tool_use",     # exec_command
+        "tool_result",  # c1
+        "text",         # "now patching"
+        "tool_use",     # apply_patch
+        "tool_use",     # mcp
+        "tool_result",  # c2
     ]
 
 
 def test_developer_message_skipped(rollout):
-    turns = parse_transcript(rollout)
-    blob = json.dumps(turns)
+    grouped = _parse_grouped(rollout)
+    blob = json.dumps(grouped)
     assert "permissions" not in blob
-    assert turns[0] == {"role": "user", "content": "fix the thing"}
 
 
 def test_reasoning_dropped(rollout):
-    turns = parse_transcript(rollout)
-    assert all("secret reasoning" not in (t.get("content") or "") for t in turns)
+    grouped = _parse_grouped(rollout)
+    blob = json.dumps(grouped)
+    assert "secret reasoning" not in blob
 
 
-def test_single_tool_call_attaches_to_assistant_turn(rollout):
-    turns = parse_transcript(rollout)
-    assistant = turns[1]
-    assert assistant["content"] == "on it"
-    assert assistant["tool_calls"] == [
-        {"type": "exec_command", "input": {"cmd": "ls"}, "id": "c1"}
-    ]
+def test_tool_use_blocks_decoded_and_named(rollout):
+    grouped = _parse_grouped(rollout)
+    tool_uses = [b for b in grouped[0][1] if b["type"] == "tool_use"]
+    names = [b["name"] for b in tool_uses]
+    assert names == ["exec_command", "apply_patch", "mcp__hive-mind-tools__graph_query"]
+    assert tool_uses[0] == {
+        "type": "tool_use", "name": "exec_command", "input": {"cmd": "ls"}, "id": "c1"
+    }
+    assert tool_uses[2]["input"]["query"] == "MATCH (n) RETURN n"
 
 
-def test_batched_tool_calls_share_one_turn_with_real_names(rollout):
-    turns = parse_transcript(rollout)
-    batched = turns[3]
-    assert batched["content"] == "now patching"
-    types = [c["type"] for c in batched["tool_calls"]]
-    assert types == ["apply_patch", "mcp__hive-mind-tools__graph_query"]
-    assert batched["tool_calls"][1]["input"]["query"] == "MATCH (n) RETURN n"
-
-
-def test_tool_output_links_call_id(rollout):
-    turns = parse_transcript(rollout)
-    assert turns[2] == {"role": "tool", "content": "file.txt", "tool_call_id": "c1"}
-    assert turns[4] == {"role": "tool", "content": "patched", "tool_call_id": "c2"}
+def test_tool_result_links_call_id(rollout):
+    grouped = _parse_grouped(rollout)
+    results = [b for b in grouped[0][1] if b["type"] == "tool_result"]
+    assert results[0] == {
+        "type": "tool_result", "content": "file.txt", "tool_call_id": "c1"
+    }
+    assert results[1] == {
+        "type": "tool_result", "content": "patched", "tool_call_id": "c2"
+    }
 
 
 def test_event_msg_lines_ignored(rollout):
-    turns = parse_transcript(rollout)
-    assert all(t.get("content") != "token_count" for t in turns)
+    grouped = _parse_grouped(rollout)
+    blob = json.dumps(grouped)
+    assert "token_count" not in blob
 
 
-def test_tool_call_without_preceding_message_opens_new_turn(tmp_path):
-    """A model that jumps straight to a tool gets a fresh assistant turn."""
-    lines = [
-        _message("user", "go"),
-        _call("exec_command", {"cmd": "pwd"}, "x1"),
-    ]
+def test_tool_call_before_first_user_attaches_to_leading_turn(tmp_path):
+    """A tool call with no preceding user message attaches to a leading turn
+    with empty user_content."""
     p = tmp_path / "r.jsonl"
-    p.write_text("\n".join(lines) + "\n")
-    turns = parse_transcript(p)
-    assert turns[1] == {
-        "role": "assistant", "content": "",
-        "tool_calls": [{"type": "exec_command", "input": {"cmd": "pwd"}, "id": "x1"}],
-    }
+    p.write_text(_call("exec_command", {"cmd": "pwd"}, "x1") + "\n")
+    grouped = _parse_grouped(p)
+    assert grouped[0][0] == ""
+    assert grouped[0][1] == [
+        {"type": "tool_use", "name": "exec_command", "input": {"cmd": "pwd"}, "id": "x1"}
+    ]
 
 
 def test_unparseable_arguments_preserved_raw(tmp_path):
     p = tmp_path / "r.jsonl"
-    p.write_text(_call("shell", "{not valid json", "y1") + "\n")
-    turns = parse_transcript(p)
-    assert turns[0]["tool_calls"][0]["input"] == {"raw": "{not valid json"}
+    p.write_text(
+        _message("user", "go") + "\n"
+        + _call("shell", "{not valid json", "y1") + "\n"
+    )
+    grouped = _parse_grouped(p)
+    tool_use = grouped[0][1][0]
+    assert tool_use["input"] == {"raw": "{not valid json"}
 
 
 def test_dict_output_flattened(tmp_path):
     p = tmp_path / "r.jsonl"
     p.write_text(
-        _call("exec_command", {"cmd": "ls"}, "z1") + "\n"
+        _message("user", "go") + "\n"
+        + _call("exec_command", {"cmd": "ls"}, "z1") + "\n"
         + _output("z1", {"output": "wrapped text", "metadata": {"exit": 0}}) + "\n"
     )
-    turns = parse_transcript(p)
-    tool_turn = next(t for t in turns if t["role"] == "tool")
-    assert tool_turn["content"] == "wrapped text"
+    grouped = _parse_grouped(p)
+    result = next(b for b in grouped[0][1] if b["type"] == "tool_result")
+    assert result["content"] == "wrapped text"
 
 
 def test_missing_file_returns_empty(tmp_path):
-    assert parse_transcript(tmp_path / "nope.jsonl") == []
+    assert _parse_grouped(tmp_path / "nope.jsonl") == []
 
 
 # ---------------------------------------------------------------------------
-# build_example
+# build_turns
 # ---------------------------------------------------------------------------
 
-def test_build_example_counts_and_metadata(rollout):
-    ex = build_example(rollout, session_id="abc", mind_id="mind-uuid")
-    assert ex is not None
-    assert ex.session_id == "abc"
-    assert ex.mind_id == "mind-uuid"
-    assert ex.harness == HARNESS_CODEX
-    assert ex.source_model == "gpt-5.4"
-    assert ex.harness_version == "0.135.0"
-    assert ex.system_prompt == "You are Codex, a coding agent."
-    assert ex.turn_count == 6
-    assert ex.tool_call_count == 3  # exec_command + apply_patch + mcp
-    assert ex.captured_at is not None
+def test_build_turns_metadata_and_indices(rollout):
+    turns = build_turns(rollout, session_id="abc", mind_id="mind-uuid")
+    assert len(turns) == 2
+    assert [t.turn_index for t in turns] == [0, 1]
+    first = turns[0]
+    assert first.session_id == "abc"
+    assert first.mind_id == "mind-uuid"
+    assert first.harness == HARNESS_CODEX
+    assert first.source_model == "gpt-5.4"
+    assert first.harness_version == "0.135.0"
+    assert first.system_prompt == "You are Codex, a coding agent."
+    assert first.has_reasoning is False  # Codex never carries reasoning
+    assert first.tool_call_count == 3  # exec_command + apply_patch + mcp
+    assert first.captured_at is not None
+    # system prompt denormalized onto every row
+    assert turns[1].system_prompt == "You are Codex, a coding agent."
 
 
-def test_build_example_empty_rollout_returns_none(tmp_path):
+def test_build_turns_always_no_reasoning(rollout):
+    turns = build_turns(rollout, session_id="abc")
+    assert all(t.has_reasoning is False for t in turns)
+
+
+def test_build_turns_empty_rollout_returns_empty(tmp_path):
     p = tmp_path / "empty.jsonl"
     p.write_text("")
-    assert build_example(p, session_id="x") is None
+    assert build_turns(p, session_id="x") == []
 
 
 # ---------------------------------------------------------------------------
@@ -204,25 +226,25 @@ def test_build_example_empty_rollout_returns_none(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_capture_session_upserts(rollout, tmp_path):
-    db = tmp_path / "data" / "training_examples.db"
+    db = tmp_path / "data" / "training_turns.db"
     assert capture_session(rollout, session_id="abc", mind_id="m", db_path=db) is True
-    assert count_examples(db, harness=HARNESS_CODEX) == 1
-    row = get_example(db, "abc")
-    assert row["harness"] == HARNESS_CODEX
-    assert row["tool_call_count"] == 3
-    assert len(row["turns"]) == 6
+    assert count_turns(db, harness=HARNESS_CODEX) == 2
+    rows = get_turns(db, "abc")
+    assert rows[0]["harness"] == HARNESS_CODEX
+    assert rows[0]["tool_call_count"] == 3
+    assert rows[0]["has_reasoning"] is False
 
 
 def test_capture_session_idempotent(rollout, tmp_path):
-    db = tmp_path / "training_examples.db"
+    db = tmp_path / "training_turns.db"
     capture_session(rollout, session_id="abc", db_path=db)
     capture_session(rollout, session_id="abc", db_path=db)
-    assert count_examples(db) == 1
+    assert count_turns(db) == 2
 
 
 def test_capture_session_noop_on_empty(tmp_path):
     p = tmp_path / "empty.jsonl"
     p.write_text("\n")
-    db = tmp_path / "training_examples.db"
+    db = tmp_path / "training_turns.db"
     assert capture_session(p, session_id="x", db_path=db) is False
     assert not db.exists()

--- a/tests/unit/test_training_migration_examples_to_turns.py
+++ b/tests/unit/test_training_migration_examples_to_turns.py
@@ -1,0 +1,182 @@
+"""Unit test for the training_examples → training_turns migration.
+
+Builds a synthetic old-schema DB, runs the file-to-file migration, and
+asserts the per-turn rows, curation-column carry-over, has_reasoning=0, that
+the destination file holds ``training_turns``, and that the superseded source
+file is removed. Also covers same-file (in-place) migration and idempotency.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_MIGRATION = (
+    _REPO_ROOT / "scripts" / "migrations"
+    / "2026-06-18-training-examples-to-turns.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("_mig_examples_to_turns", _MIGRATION)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_OLD_SCHEMA = """
+CREATE TABLE training_examples (
+    id                INTEGER PRIMARY KEY,
+    session_id        TEXT NOT NULL UNIQUE,
+    mind_id           TEXT,
+    harness           TEXT NOT NULL,
+    source_model      TEXT,
+    harness_version   TEXT,
+    captured_at       INTEGER,
+    system_prompt     TEXT,
+    turns             TEXT,
+    turn_count        INTEGER,
+    tool_call_count   INTEGER,
+    length_tokens     INTEGER,
+    quality_flag      TEXT NOT NULL DEFAULT 'pending',
+    judge_verdict     TEXT,
+    judge_confidence  REAL,
+    exclusion_reason  TEXT
+);
+"""
+
+
+def _old_turns():
+    return [
+        {"role": "user", "content": "fix the thing"},
+        {
+            "role": "assistant",
+            "content": "on it",
+            "tool_calls": [
+                {"type": "Bash", "input": {"command": "ls"}, "id": "t1"},
+            ],
+        },
+        {"role": "tool", "content": "file.txt", "tool_call_id": "t1"},
+        {"role": "user", "content": "now ship it"},
+        {"role": "assistant", "content": "done"},
+    ]
+
+
+def _write_old_db(db: Path) -> None:
+    conn = sqlite3.connect(str(db))
+    conn.executescript(_OLD_SCHEMA)
+    conn.execute(
+        "INSERT INTO training_examples ("
+        "session_id, mind_id, harness, source_model, harness_version, "
+        "captured_at, system_prompt, turns, turn_count, tool_call_count, "
+        "length_tokens, quality_flag, judge_verdict, judge_confidence, "
+        "exclusion_reason"
+        ") VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            "sess-1", "mind-uuid", "claude_code", "claude-opus-4-7", "2.0.0",
+            1781649576, "you are skippy", json.dumps(_old_turns()), 5, 1, 99,
+            "clean", "keep", 0.87, None,
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def src_db(tmp_path):
+    db = tmp_path / "training_examples.db"
+    _write_old_db(db)
+    return db
+
+
+def _read_turns(dest: Path) -> list[dict]:
+    conn = sqlite3.connect(str(dest))
+    conn.row_factory = sqlite3.Row
+    rows = [
+        dict(r)
+        for r in conn.execute("SELECT * FROM training_turns ORDER BY turn_index")
+    ]
+    conn.close()
+    return rows
+
+
+def test_migration_builds_per_turn_rows(src_db, tmp_path):
+    mig = _load_migration()
+    dest = tmp_path / "training_turns.db"
+    written = mig.migrate(src_db, dest)
+    assert written == 2  # two human turns
+
+    rows = _read_turns(dest)
+    assert [r["turn_index"] for r in rows] == [0, 1]
+
+    first = rows[0]
+    assert first["session_id"] == "sess-1"
+    assert first["user_content"] == "fix the thing"
+    assert first["has_reasoning"] == 0
+    assert first["tool_call_count"] == 1
+    blocks = json.loads(first["assistant_blocks"])
+    assert [b["type"] for b in blocks] == ["text", "tool_use", "tool_result"]
+    assert blocks[1]["name"] == "Bash"
+    assert blocks[2]["tool_call_id"] == "t1"
+
+    second = rows[1]
+    assert second["user_content"] == "now ship it"
+    assert json.loads(second["assistant_blocks"]) == [
+        {"type": "text", "text": "done"}
+    ]
+
+
+def test_migration_carries_curation_and_metadata(src_db, tmp_path):
+    mig = _load_migration()
+    dest = tmp_path / "training_turns.db"
+    mig.migrate(src_db, dest)
+    row = next(r for r in _read_turns(dest) if r["turn_index"] == 0)
+    assert row["mind_id"] == "mind-uuid"
+    assert row["source_model"] == "claude-opus-4-7"
+    assert row["harness_version"] == "2.0.0"
+    assert row["captured_at"] == 1781649576
+    assert row["system_prompt"] == "you are skippy"
+    assert row["quality_flag"] == "clean"
+    assert row["judge_verdict"] == "keep"
+    assert row["judge_confidence"] == 0.87
+
+
+def test_migration_removes_superseded_source(src_db, tmp_path):
+    mig = _load_migration()
+    dest = tmp_path / "training_turns.db"
+    mig.migrate(src_db, dest)
+    assert not src_db.exists()
+    assert dest.exists()
+
+
+def test_migration_same_file_drops_old_table(src_db):
+    mig = _load_migration()
+    # Source and destination are the same file: migrate in place.
+    mig.migrate(src_db, src_db)
+    conn = sqlite3.connect(str(src_db))
+    names = {
+        r[0]
+        for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    conn.close()
+    assert "training_examples" not in names
+    assert "training_turns" in names
+
+
+def test_migration_idempotent(src_db, tmp_path):
+    mig = _load_migration()
+    dest = tmp_path / "training_turns.db"
+    mig.migrate(src_db, dest)
+    # Second run: the source file was removed, so it must no-op without error.
+    assert mig.migrate(src_db, dest) == 0
+
+
+def test_migration_noop_on_missing_db(tmp_path):
+    mig = _load_migration()
+    assert mig.migrate(tmp_path / "nope.db", tmp_path / "out.db") == 0


### PR DESCRIPTION
## What

Redesigns the harness fine-tuning capture from **one row per session** to **one row per user-assistant turn**, so reasoning can be selected, stripped, or synthesized per turn without distorting the store.

## Why

To fine-tune both reasoning and non-reasoning models from one raw store, reasoning must be (a) selectable, (b) removable without leaving harmful empty placeholders, and (c) re-insertable in the right place for harnesses (Codex) that expose none. The session grain couldn't express where reasoning sat relative to the actions it produced, especially when a turn reasons, acts, observes results, then reasons again.

## Changes

- **`training_turns` table** keyed `(session_id, turn_index)`. Assistant response stored as an ordered block array (`thinking` / `text` / `tool_use` / `tool_result`) preserving interleaving. Per-row indexed `has_reasoning` boolean is the cheap filter that selects reasoning vs non-reasoning rows without scanning the JSON.
- **Claude consumer** keeps readable thinking in position, drops encrypted `redacted_thinking`, groups blocks by genuine human turn (tool results append to the open turn).
- **Codex consumer** same grouping; reasoning items dropped → Codex rows are `has_reasoning=0`, the targets for later synthetic reasoning. `capture_session` signatures unchanged, so the Stop hooks need no edits.
- **Migration** `scripts/migrations/2026-06-18-training-examples-to-turns.py`: file-to-file conversion of `training_examples.db` → `training_turns.db`, retiring the old file. Verified on the 202-session live copy → 427 turn rows, all 957 tool calls preserved.
- **Contract doc** `docs/training-capture/data-contract.md`: schema, block model, reconstruction, reasoning/non-reasoning export recipes, and the synthetic-reasoning insertion procedure, living next to the code.

## Tests

58 training-capture tests pass (storage, both parsers, migration); mypy and ruff clean on all changed modules. The repo's 10 pre-existing failures (`test_config_group_chat`, `test_nagatha_*`) are environmental — they need an untracked `config.yaml` / the four-mind Nagatha config — and touch nothing here.

## Deploy (manual, after merge)

1. Update the `hive_mind` working checkout to `master` (it's parked on `feature/kokoro-voice-engine`).
2. Run the migration once on the live DB: `python scripts/migrations/2026-06-18-training-examples-to-turns.py --src data/training_examples.db --dest data/training_turns.db`.