### PR TITLE
voice(kokoro): pin torch to CUDA 12 so whisper runs on the GPU

### DIFF
--- a/Dockerfile.voice.kokoro
+++ b/Dockerfile.voice.kokoro
@@ -35,6 +35,16 @@ import spacy; spacy.load('en_core_web_sm'); \
 import multipart; \
 print('Kokoro voice deps OK')"
 
+# CUDA-12 invariant -- ctranslate2 (faster-whisper's GPU backend) dlopens
+# libcublas.so.12. torch preloads its bundled CUDA libs at import, so a cu12
+# torch makes that library resolvable. If a future unpinned/bumped torch lands
+# on CUDA 13 (libcublas.so.13), this load fails and the BUILD fails here --
+# loudly, at build time -- instead of every voice note 500'ing at runtime.
+RUN /opt/venv/bin/python -c "\
+import torch, ctypes; \
+ctypes.CDLL('libcublas.so.12'); \
+print('CUDA 12 cublas loadable for whisper GPU backend')"
+
 RUN chown -R hivemind:hivemind /usr/src/app
 
 USER hivemind

--- a/requirements.voice.kokoro.txt
+++ b/requirements.voice.kokoro.txt
@@ -11,9 +11,14 @@ kokoro>=0.9.4
 soundfile
 
 # Torch stack -- Kokoro depends on torch; torchaudio encodes the WAV before ffmpeg.
-# Left unpinned so pip resolves a matching torch/torchaudio CUDA pair.
-torch
-torchaudio
+# PINNED to the CUDA 12 build. faster-whisper's backend (ctranslate2) is built
+# against CUDA 12 and dlopens libcublas.so.12. torch preloads its bundled CUDA
+# libs at import, so torch MUST be the cu12 build or whisper-on-GPU fails with
+# "Library libcublas.so.12 is not found". Leaving this unpinned resolved to
+# torch 2.12+cu130 (CUDA 13, libcublas.so.13) and broke STT on the GPU. This
+# matches the proven Chatterbox image (requirements.voice.txt).
+torch==2.6.0
+torchaudio==2.6.0
 
 # Audio numerics
 numpy


### PR DESCRIPTION
## Root cause
The Kokoro voice image left `torch`/`torchaudio` unpinned. The build resolved `torch 2.12+cu130` (CUDA 13, ships `libcublas.so.13`). But faster-whisper's GPU backend `ctranslate2` is built against CUDA 12 and dlopens `libcublas.so.12` — which a cu13 torch never preloads. Every `/stt` call died on the GPU:

```
RuntimeError: Library libcublas.so.12 is not found or cannot be loaded
```

The Chatterbox image works precisely because it pins `torch==2.6.0` (CUDA 12).

## Fix
Pin `torch==2.6.0` / `torchaudio==2.6.0` in `requirements.voice.kokoro.txt`, matching the proven Chatterbox stack. torch preloads its bundled cu12 cublas at import, ctranslate2 reuses it, and whisper runs on the GPU.

Add a build-time assertion in `Dockerfile.voice.kokoro` that `libcublas.so.12` is loadable, so a future CUDA-13 torch fails the **build** loudly rather than breaking STT at runtime.

## This is the real fix
This supersedes the runtime CPU-fallback band-aid (#156) as the actual cause. Whisper now runs on the GPU; the fallback remains only as a genuine last-resort seatbelt and no longer fires.

## Verified live
Rebuilt the image (both build gates pass: deps OK + cublas-12 loadable), recreated `hive-mind-voice-kokoro`, real `/stt` round-trip returns 200 with transcribed text in ~560ms on `device=cuda`. Container log shows no GPU error, no cuBLAS failure, no CPU fallback.