### PR TITLE
scheduler: explicit 600s TTS timeout to survive burst contention

### DIFF
--- a/bots/scheduler.py
+++ b/bots/scheduler.py
@@ -53,6 +53,12 @@ log = logging.getLogger("hive-mind-scheduler")
 
 SERVER_URL = os.environ.get("HIVE_MIND_SERVER_URL", f"http://localhost:{config.server_port}")
 VOICE_SERVER_URL = os.environ.get("VOICE_SERVER_URL", "http://localhost:8422")
+# The TTS server is GPU-bound and serialises requests. When several voice
+# jobs fire on the same cron minute (e.g. the 6:30am batch), a long
+# synthesis can queue ahead of a short one. aiohttp's silent 300s default
+# total timeout was tripping the queued job; give it an explicit, generous
+# ceiling instead.
+VOICE_TTS_TIMEOUT_SECONDS = float(os.environ.get("VOICE_TTS_TIMEOUT_SECONDS", "600"))
 MINDS_ROOT = Path(os.environ.get("MINDS_ROOT", "/usr/src/app/minds"))
 SCHEDULER_TASKS_YAML = Path(os.environ.get(
     "SCHEDULER_TASKS_YAML",
@@ -79,7 +85,12 @@ DEV_SURFACE_PROMPT = (
 
 
 async def _tts(http: aiohttp.ClientSession, text: str, voice_id: str) -> bytes:
-    async with http.post(f"{VOICE_SERVER_URL}/tts", json={"text": text, "voice_id": voice_id}) as resp:
+    timeout = aiohttp.ClientTimeout(total=VOICE_TTS_TIMEOUT_SECONDS)
+    async with http.post(
+        f"{VOICE_SERVER_URL}/tts",
+        json={"text": text, "voice_id": voice_id},
+        timeout=timeout,
+    ) as resp:
         if resp.status != 200:
             raise RuntimeError(f"TTS error {resp.status}: {await resp.text()}")
         return await resp.read()

--- a/tests/unit/test_scheduler_tts.py
+++ b/tests/unit/test_scheduler_tts.py
@@ -41,6 +41,26 @@ async def test_tts_sends_voice_id_in_payload():
 
 
 @pytest.mark.asyncio
+async def test_tts_sets_explicit_timeout():
+    """The TTS POST must carry an explicit generous timeout so a long
+    synthesis queued ahead of it on a busy GPU server can't trip aiohttp's
+    silent 300s default."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.read = AsyncMock(return_value=b"OGG")
+
+    http = MagicMock()
+    http.post = MagicMock(return_value=_AsyncCtx(resp))
+
+    await scheduler._tts(http, "hello", "ada-uuid-1234")
+
+    _, kwargs = http.post.call_args
+    timeout = kwargs["timeout"]
+    assert timeout.total == scheduler.VOICE_TTS_TIMEOUT_SECONDS
+    assert timeout.total >= 600
+
+
+@pytest.mark.asyncio
 async def test_try_send_voice_threads_voice_id_to_tts():
     with (
         patch.object(scheduler, "_tts", new=AsyncMock(return_value=b"OGG")) as tts_mock,


### PR DESCRIPTION
## What
NetSage flagged a single `Voice delivery failed for ada/deu28-blessings (text already sent)` at 2026-06-24T11:37Z.

## Root cause
At the 6:30am cron batch, `ada/6-30am` (a long morning-briefing synthesis) and `ada/deu28-blessings` fire in the same minute and hit the single GPU-bound TTS server. They serialise; `deu28-blessings` queued behind `6-30am` and the `_tts` POST — which carried no explicit timeout — tripped aiohttp's silent 300s default. `ada/6-30am` completed at 11:37:54, right after deu28 failed at 11:37:29, confirming the contention.

## Fix
Set an explicit, env-overridable `VOICE_TTS_TIMEOUT_SECONDS` (default 600s) on the TTS POST. The text path already delivers independently, so this only recovers the dropped voice note under burst load.

## Tests
Added `test_tts_sets_explicit_timeout`; existing TTS tests still pass (3 passed).

## Deploy
Already live — `hive-mind-scheduler` restarted and confirmed `VOICE_TTS_TIMEOUT_SECONDS = 600.0`.