### PR TITLE
hermes-skills: audit ledger, restore/undo, and change notifications

### DIFF
--- a/bots/scheduled_tasks/tasks.yaml
+++ b/bots/scheduled_tasks/tasks.yaml
@@ -43,6 +43,7 @@ tasks:
       - /usr/src/app/minds/nagatha/.codex
       - --harness
       - codex_cli
+      - --notify
 
   # Nagatha (codex_cli) autonomous skill-proposer. Same scheduling rationale as
   # the curator: Codex frontmatter strips `schedule:`, so the cadence lives in a
@@ -68,3 +69,4 @@ tasks:
       - /usr/src/app/data/training_turns.db
       - --mind-id
       - 128c1768-b659-4c83-86df-706690e344f4
+      - --notify

--- a/tests/unit/test_skill_curator_audit_events.py
+++ b/tests/unit/test_skill_curator_audit_events.py
@@ -1,0 +1,137 @@
+"""Named transition events + per-run curator audit entry.
+
+``apply_automatic_transitions`` now returns an ``events`` list alongside its
+counters; a live ``run`` records exactly one ``kind="curator"`` audit entry
+carrying those events plus the consolidation verdict. Tests drive a deterministic
+clock and assert the observable event shape and ledger contents.
+"""
+
+import importlib.util
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CURATOR_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_curator/skill_curator.py")
+TELEMETRY_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_telemetry/skill_telemetry.py")
+
+NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _curator():
+    return _load(CURATOR_PATH, "skill_curator_events_under_test")
+
+
+def _telemetry():
+    return _load(TELEMETRY_PATH, "skill_telemetry_events_under_test")
+
+
+def _seed_skill(config_dir, name, *, state="active", last_used_at=None,
+                created_at=None):
+    tel = _telemetry()
+    skills = config_dir / "skills"
+    skills.mkdir(parents=True, exist_ok=True)
+    d = skills / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+    data = tel.load_usage(config_dir)
+    rec = tel._empty_record()
+    rec["created_by"] = "agent"
+    rec["state"] = state
+    rec["last_used_at"] = last_used_at.isoformat() if last_used_at else None
+    rec["created_at"] = (created_at or NOW).isoformat()
+    data[name] = rec
+    tel.save_usage(config_dir, data)
+
+
+def _event_for(events, name):
+    matches = [e for e in events if e["name"] == name]
+    assert matches, f"no event for {name}: {events}"
+    return matches[0]
+
+
+def test_transitions_emit_named_events(tmp_path):
+    cur = _curator()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "rusty", last_used_at=NOW - timedelta(days=31))      # stale
+    _seed_skill(cfg, "ancient", last_used_at=NOW - timedelta(days=91))    # archive
+    _seed_skill(cfg, "revived", state="stale",
+                last_used_at=NOW - timedelta(days=1))                     # reactivate
+
+    counts = cur.apply_automatic_transitions(cfg, now=NOW)
+    events = counts["events"]
+    assert len(events) == 3
+
+    stale_ev = _event_for(events, "rusty")
+    assert (stale_ev["from_state"], stale_ev["to_state"], stale_ev["action"]) == \
+        ("active", "stale", "stale")
+
+    arch_ev = _event_for(events, "ancient")
+    assert (arch_ev["from_state"], arch_ev["to_state"], arch_ev["action"]) == \
+        ("active", "archived", "archive")
+
+    react_ev = _event_for(events, "revived")
+    assert (react_ev["from_state"], react_ev["to_state"], react_ev["action"]) == \
+        ("stale", "active", "reactivate")
+
+    # Counts keys preserved.
+    assert counts["marked_stale"] == 1
+    assert counts["archived"] == 1
+    assert counts["reactivated"] == 1
+    assert counts["checked"] == 3
+
+
+def test_no_transitions_yields_empty_events(tmp_path):
+    cur = _curator()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "fresh", last_used_at=NOW - timedelta(days=1))
+    counts = cur.apply_automatic_transitions(cfg, now=NOW)
+    assert counts["events"] == []
+
+
+def test_run_report_carries_events(tmp_path):
+    cur = _curator()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "rusty", last_used_at=NOW - timedelta(days=31))
+    cur.run(cfg, "claude_cli", now=NOW)
+    import json
+    state = json.loads(
+        (cfg / "skills" / ".curator_state").read_text(encoding="utf-8")
+    )
+    assert "events" in state
+    assert state["events"][0]["name"] == "rusty"
+    assert state["events"][0]["action"] == "stale"
+
+
+def test_live_run_appends_exactly_one_curator_audit_entry(tmp_path):
+    cur, tel = _curator(), _telemetry()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "rusty", last_used_at=NOW - timedelta(days=31))
+    _seed_skill(cfg, "ancient", last_used_at=NOW - timedelta(days=91))
+    cur.run(cfg, "claude_cli", now=NOW)
+
+    entries = tel.read_audit(cfg)
+    curator_entries = [e for e in entries if e.get("kind") == "curator"]
+    assert len(curator_entries) == 1
+    entry = curator_entries[0]
+    names = {ev["name"] for ev in entry["events"]}
+    assert names == {"rusty", "ancient"}
+    assert entry["counts"]["marked_stale"] == 1
+    assert entry["counts"]["archived"] == 1
+    # Consolidation defaults off → recorded as not-run.
+    assert entry["consolidation"]["ran"] is False
+
+
+def test_dry_run_writes_no_audit_entry(tmp_path):
+    cur, tel = _curator(), _telemetry()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "ancient", last_used_at=NOW - timedelta(days=91))
+    cur.run(cfg, "claude_cli", now=NOW, dry_run=True)
+    assert tel.read_audit(cfg) == []

--- a/tests/unit/test_skill_curator_notify.py
+++ b/tests/unit/test_skill_curator_notify.py
@@ -1,0 +1,105 @@
+"""Curator --notify: on-change summary with undo hint, test-mode safe.
+
+A changed live run composes a notify message that NAMES the changed skills and,
+under HERMES_NOTIFY_TEST, invokes the notify subprocess with ``--test-mode`` (no
+real Telegram). An unchanged run sends nothing. Tests drive a deterministic
+clock and assert on the composed message + the invoked argv — they do not stand
+up a real notification channel.
+"""
+
+import importlib.util
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+CURATOR_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_curator/skill_curator.py")
+TELEMETRY_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_telemetry/skill_telemetry.py")
+
+NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _curator():
+    return _load(CURATOR_PATH, "skill_curator_notify_under_test")
+
+
+def _telemetry():
+    return _load(TELEMETRY_PATH, "skill_telemetry_curnotify_under_test")
+
+
+def _seed_skill(cfg, name, *, state="active", last_used_at=None, created_at=None):
+    tel = _telemetry()
+    skills = cfg / "skills"
+    skills.mkdir(parents=True, exist_ok=True)
+    d = skills / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+    data = tel.load_usage(cfg)
+    rec = tel._empty_record()
+    rec["created_by"] = "agent"
+    rec["state"] = state
+    rec["last_used_at"] = last_used_at.isoformat() if last_used_at else None
+    rec["created_at"] = (created_at or NOW).isoformat()
+    data[name] = rec
+    tel.save_usage(cfg, data)
+
+
+def test_changed_run_composes_message_and_passes_test_mode(tmp_path, monkeypatch):
+    cur = _curator()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "rusty", last_used_at=NOW - timedelta(days=31))
+    _seed_skill(cfg, "ancient", last_used_at=NOW - timedelta(days=91))
+    summary = cur.run(cfg, "claude_cli", now=NOW)
+
+    monkeypatch.setenv("HERMES_NOTIFY_TEST", "1")
+    cmd = cur.maybe_notify(cfg, summary)
+    assert cmd is not None
+    assert "--test-mode" in cmd
+    assert "send" in cmd
+    # The message names what changed and carries the undo hint.
+    msg = cmd[cmd.index("--message") + 1]
+    assert "ancient" in msg          # archived
+    assert "rusty" in msg            # staled
+    assert "--action restore" in msg
+    assert str(cfg) in msg
+
+
+def test_unchanged_run_sends_no_notification(tmp_path, monkeypatch):
+    cur = _curator()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "fresh", last_used_at=NOW - timedelta(days=1))
+    summary = cur.run(cfg, "claude_cli", now=NOW)
+
+    monkeypatch.setenv("HERMES_NOTIFY_TEST", "1")
+    assert cur.maybe_notify(cfg, summary) is None
+
+
+def test_cli_notify_flag_is_accepted(tmp_path, monkeypatch, capsys):
+    cur = _curator()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "rusty", last_used_at=NOW - timedelta(days=31))
+    monkeypatch.setenv("HERMES_NOTIFY_TEST", "1")
+    rc = cur.main(["--config-dir", str(cfg), "--notify"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["marked_stale"] == 1
+
+
+def test_dry_run_with_notify_sends_nothing(tmp_path, monkeypatch, capsys):
+    cur = _curator()
+    cfg = tmp_path / "cfg"
+    _seed_skill(cfg, "ancient", last_used_at=NOW - timedelta(days=91))
+    monkeypatch.setenv("HERMES_NOTIFY_TEST", "1")
+    # A dry-run mutates nothing and must not notify — exercised via main().
+    rc = cur.main(["--config-dir", str(cfg), "--notify", "--dry-run"])
+    assert rc == 0
+    # No archive happened (dry run), so the skill is still live.
+    assert (cfg / "skills" / "ancient").is_dir()

--- a/tests/unit/test_skill_manage_archive_audit.py
+++ b/tests/unit/test_skill_manage_archive_audit.py
@@ -1,0 +1,85 @@
+"""Archive logging in skill_manage delete + round-trip with restore_skill.
+
+A ``delete`` archives the skill dir and logs a ``kind="archive"`` audit entry
+capturing name + absorbed_into + archive_path. A subsequent
+``telemetry.restore_skill`` brings the dir back and the ledger shows both events
+in order — the chain that makes a consolidation merge reversible.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_manage/skill_manage.py")
+TELEMETRY_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_telemetry/skill_telemetry.py")
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _manage():
+    return _load(SCRIPT_PATH, "skill_manage_archive_audit_under_test")
+
+
+def _telemetry():
+    return _load(TELEMETRY_PATH, "skill_telemetry_archive_audit_under_test")
+
+
+def _content(name="demo", body="Do the thing."):
+    return f"---\nname: {name}\ndescription: A demo skill\n---\n{body}\n"
+
+
+def _create(mod, cfg, name):
+    return json.loads(mod.skill_manage("create", str(cfg), "claude_cli",
+                                       name=name, content=_content(name)))
+
+
+def test_delete_writes_archive_audit_entry(tmp_path):
+    mod, tel = _manage(), _telemetry()
+    _create(mod, tmp_path, "umbrella")
+    _create(mod, tmp_path, "sibling")
+    r = json.loads(mod.skill_manage("delete", str(tmp_path), "claude_cli",
+                                    name="sibling", absorbed_into="umbrella"))
+    assert r["success"] is True
+
+    entries = tel.read_audit(tmp_path)
+    archive_entries = [e for e in entries if e.get("kind") == "archive"]
+    assert len(archive_entries) == 1
+    entry = archive_entries[0]
+    assert entry["name"] == "sibling"
+    assert entry["absorbed_into"] == "umbrella"
+    assert entry["archive_path"] == r["archived_to"]
+
+
+def test_plain_prune_logs_absorbed_into_none(tmp_path):
+    mod, tel = _manage(), _telemetry()
+    _create(mod, tmp_path, "lonely")
+    mod.skill_manage("delete", str(tmp_path), "claude_cli", name="lonely")
+    entry = [e for e in tel.read_audit(tmp_path) if e.get("kind") == "archive"][-1]
+    assert entry["name"] == "lonely"
+    assert entry["absorbed_into"] is None
+
+
+def test_archive_then_restore_round_trip_ledger_in_order(tmp_path):
+    mod, tel = _manage(), _telemetry()
+    _create(mod, tmp_path, "umbrella")
+    _create(mod, tmp_path, "absorbed")
+
+    mod.skill_manage("delete", str(tmp_path), "claude_cli",
+                     name="absorbed", absorbed_into="umbrella")
+    assert not (tmp_path / "skills" / "absorbed").exists()
+
+    ok, _ = tel.restore_skill(tmp_path, "absorbed")
+    assert ok is True
+    assert (tmp_path / "skills" / "absorbed" / "SKILL.md").is_file()
+
+    kinds = [e.get("kind") for e in tel.read_audit(tmp_path)]
+    # archive precedes restore in the durable ledger.
+    assert "archive" in kinds and "restore" in kinds
+    assert kinds.index("archive") < kinds.index("restore")

--- a/tests/unit/test_skill_proposer_notify.py
+++ b/tests/unit/test_skill_proposer_notify.py
@@ -1,0 +1,115 @@
+"""Proposer --notify: on-create summary with undo hint, test-mode safe.
+
+A run that created skills composes a notify message naming them and (under
+HERMES_NOTIFY_TEST) invokes notify with ``--test-mode``; a run that created
+nothing sends no notification. Fixture training_turns.db is built in tmp via
+core.training_capture — never the live DB.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from core import training_capture as tc
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_proposer/skill_proposer.py")
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _proposer():
+    return _load(SCRIPT_PATH, "skill_proposer_notify_under_test")
+
+
+def _seed_seq(db, *, session_id, turn_index, mind_id, tools, captured_at):
+    turn = tc.TrainingTurn.from_blocks(
+        session_id=session_id, turn_index=turn_index,
+        harness=tc.HARNESS_CLAUDE_CODE, mind_id=mind_id, user_content="x",
+        assistant_blocks=[{"type": "tool_use", "name": n, "input": {}} for n in tools],
+        captured_at=captured_at,
+    )
+    tc.upsert_turns(str(db), [turn])
+
+
+def _enable(config_dir: Path, **overrides):
+    skills = config_dir / "skills"
+    skills.mkdir(parents=True, exist_ok=True)
+    lines = ["enabled: true"] + [f"{k}: {v}" for k, v in overrides.items()]
+    (skills / "proposer.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_created_run_composes_message_and_passes_test_mode(tmp_path, monkeypatch):
+    prop = _proposer()
+    cfg = tmp_path / "ada" / ".claude"
+    _enable(cfg)
+    db = tmp_path / "training_turns.db"
+    for i in range(3):
+        _seed_seq(db, session_id="s", turn_index=i, mind_id="ada",
+                  tools=["Read", "Grep", "Edit"], captured_at=100 + i)
+    summary = prop.run(cfg, "claude_cli", db_path=str(db), mind_id="ada")
+    created = [p["name"] for p in summary["proposed"] if p["created"]]
+    assert created
+
+    monkeypatch.setenv("HERMES_NOTIFY_TEST", "1")
+    cmd = prop.maybe_notify(cfg, summary)
+    assert cmd is not None
+    assert "--test-mode" in cmd
+    msg = cmd[cmd.index("--message") + 1]
+    assert created[0] in msg
+    assert "--action restore" in msg
+    assert str(cfg) in msg
+
+
+def test_nothing_created_sends_no_notification(tmp_path, monkeypatch):
+    prop = _proposer()
+    cfg = tmp_path / "ada" / ".claude"
+    # Disabled by default → proposes nothing.
+    db = tmp_path / "training_turns.db"
+    for i in range(3):
+        _seed_seq(db, session_id="s", turn_index=i, mind_id="ada",
+                  tools=["Read", "Grep", "Edit"], captured_at=100 + i)
+    summary = prop.run(cfg, "claude_cli", db_path=str(db), mind_id="ada")
+    assert summary == {"enabled": False, "proposed": []}
+
+    monkeypatch.setenv("HERMES_NOTIFY_TEST", "1")
+    assert prop.maybe_notify(cfg, summary) is None
+
+
+def test_enabled_but_below_threshold_sends_nothing(tmp_path, monkeypatch):
+    prop = _proposer()
+    cfg = tmp_path / "ada" / ".claude"
+    _enable(cfg)
+    db = tmp_path / "training_turns.db"
+    # Only one occurrence — below the default min_frequency=3, nothing created.
+    _seed_seq(db, session_id="s", turn_index=0, mind_id="ada",
+              tools=["Read", "Grep"], captured_at=100)
+    summary = prop.run(cfg, "claude_cli", db_path=str(db), mind_id="ada")
+    assert [p for p in summary["proposed"] if p["created"]] == []
+
+    monkeypatch.setenv("HERMES_NOTIFY_TEST", "1")
+    assert prop.maybe_notify(cfg, summary) is None
+
+
+def test_cli_notify_flag_accepted(tmp_path, monkeypatch, capsys):
+    import json
+    prop = _proposer()
+    cfg = tmp_path / "ada" / ".claude"
+    _enable(cfg)
+    db = tmp_path / "training_turns.db"
+    for i in range(3):
+        _seed_seq(db, session_id="s", turn_index=i, mind_id="ada",
+                  tools=["Read", "Grep", "Edit"], captured_at=100 + i)
+    monkeypatch.setenv("HERMES_NOTIFY_TEST", "1")
+    rc = prop.main(["--config-dir", str(cfg), "--db-path", str(db),
+                    "--mind-id", "ada", "--notify"])
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["enabled"] is True

--- a/tests/unit/test_skill_proposer_scheduling.py
+++ b/tests/unit/test_skill_proposer_scheduling.py
@@ -37,3 +37,15 @@ def test_nagatha_proposer_task_registered():
 
     # A cron string is present.
     assert isinstance(task.get("cron"), str) and task["cron"].strip()
+
+
+def test_nagatha_curator_and_proposer_tasks_notify_on_change():
+    """Both scheduled Nagatha command tasks pass --notify so a changed run
+    surfaces a Telegram summary (with the restore undo hint) on cron cadence."""
+    tasks = _load_tasks()
+    by_name = {t.get("name"): t for t in tasks if isinstance(t, dict)}
+    for name in ("nagatha-skill-curator", "nagatha-skill-proposer"):
+        assert name in by_name, by_name.keys()
+        command = by_name[name].get("command")
+        assert isinstance(command, list), command
+        assert "--notify" in command, (name, command)

--- a/tests/unit/test_skill_telemetry_audit.py
+++ b/tests/unit/test_skill_telemetry_audit.py
@@ -1,0 +1,204 @@
+"""Audit ledger + restore — the shared undo layer in skill_telemetry.
+
+The ledger (``<config_dir>/skills/.skill_audit.log``) is the single durable,
+append-only record both the curator and skill_manage write to; ``restore_skill``
+is the exact inverse of an archive move. All tests drive the public functions
+and assert observable on-disk state (files, sidecar records, ledger contents).
+"""
+
+import importlib.util
+import json
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+TELEMETRY_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_telemetry/skill_telemetry.py")
+CURATOR_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_curator/skill_curator.py")
+
+NOW = datetime(2026, 6, 27, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _load(path, name):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _telemetry():
+    return _load(TELEMETRY_PATH, "skill_telemetry_audit_under_test")
+
+
+def _curator():
+    return _load(CURATOR_PATH, "skill_curator_audit_under_test")
+
+
+# ---------------------------------------------------------------------------
+# append_audit / read_audit
+# ---------------------------------------------------------------------------
+
+def test_append_then_read_round_trip(tmp_path):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    tel.append_audit(cfg, {"kind": "archive", "name": "alpha"})
+    tel.append_audit(cfg, {"kind": "restore", "name": "alpha"})
+    entries = tel.read_audit(cfg)
+    assert [e["kind"] for e in entries] == ["archive", "restore"]
+    assert all("at" in e for e in entries)
+    assert entries[0]["name"] == "alpha"
+
+
+def test_append_audit_stamps_injected_now(tmp_path):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    tel.append_audit(cfg, {"kind": "archive", "name": "x"}, now=NOW)
+    entries = tel.read_audit(cfg)
+    assert entries[-1]["at"] == NOW.isoformat()
+
+
+def test_read_audit_limit_returns_tail(tmp_path):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    for i in range(5):
+        tel.append_audit(cfg, {"kind": "archive", "name": f"s{i}"})
+    tail = tel.read_audit(cfg, limit=2)
+    assert [e["name"] for e in tail] == ["s3", "s4"]
+
+
+def test_read_audit_missing_ledger_is_empty(tmp_path):
+    tel = _telemetry()
+    assert tel.read_audit(tmp_path / "cfg") == []
+
+
+def test_concurrent_appends_do_not_corrupt_lines(tmp_path):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    (cfg / "skills").mkdir(parents=True)
+
+    def _worker(idx):
+        for j in range(20):
+            tel.append_audit(cfg, {"kind": "archive", "name": f"w{idx}-{j}"})
+
+    threads = [threading.Thread(target=_worker, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    path = cfg / "skills" / ".skill_audit.log"
+    lines = [ln for ln in path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(lines) == 100
+    # Every line is a well-formed JSON object (no interleaving / partial writes).
+    for ln in lines:
+        obj = json.loads(ln)
+        assert obj["kind"] == "archive"
+
+
+# ---------------------------------------------------------------------------
+# restore_skill
+# ---------------------------------------------------------------------------
+
+def _archive_via_curator(cfg, name):
+    """Seed a live agent skill and archive it the real way (curator)."""
+    cur, tel = _curator(), _telemetry()
+    skills = cfg / "skills"
+    d = skills / name
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "SKILL.md").write_text("# skill\n", encoding="utf-8")
+    tel.seed_record_if_missing(cfg, name, created_by="agent")
+    ok, dest = cur.archive_skill(cfg, name)
+    assert ok
+    return dest
+
+
+def test_restore_round_trips_and_sets_active_and_audits(tmp_path):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    _archive_via_curator(cfg, "comeback")
+    assert not (cfg / "skills" / "comeback").exists()
+
+    ok, info = tel.restore_skill(cfg, "comeback")
+    assert ok is True
+    assert (cfg / "skills" / "comeback" / "SKILL.md").is_file()
+    assert tel.get_record(cfg, "comeback")["state"] == "active"
+
+    entries = tel.read_audit(cfg)
+    restore_entries = [e for e in entries if e.get("kind") == "restore"]
+    assert restore_entries and restore_entries[-1]["name"] == "comeback"
+
+
+def test_restore_picks_newest_on_suffix_collision(tmp_path):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    archive = cfg / "skills" / ".archive"
+    archive.mkdir(parents=True)
+    # Plain copy (oldest) plus two timestamp-suffixed copies; newest = largest suffix.
+    older = archive / "dup"
+    older.mkdir()
+    (older / "SKILL.md").write_text("OLD", encoding="utf-8")
+    mid = archive / "dup-20260101T000000000000"
+    mid.mkdir()
+    (mid / "SKILL.md").write_text("MID", encoding="utf-8")
+    newest = archive / "dup-20260601T000000000000"
+    newest.mkdir()
+    (newest / "SKILL.md").write_text("NEW", encoding="utf-8")
+
+    ok, _ = tel.restore_skill(cfg, "dup")
+    assert ok is True
+    assert (cfg / "skills" / "dup" / "SKILL.md").read_text(encoding="utf-8") == "NEW"
+    # The non-selected copies are left in place.
+    assert older.exists() and mid.exists()
+
+
+def test_restore_refused_when_live_exists_mutates_nothing(tmp_path):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    _archive_via_curator(cfg, "again")
+    # Re-create a live skill of the same name.
+    live = cfg / "skills" / "again"
+    live.mkdir(parents=True)
+    (live / "SKILL.md").write_text("# live\n", encoding="utf-8")
+
+    ok, reason = tel.restore_skill(cfg, "again")
+    assert ok is False
+    assert reason
+    # Archive copy still present, nothing moved.
+    assert (cfg / "skills" / ".archive" / "again").exists()
+    assert "restore" not in [e.get("kind") for e in tel.read_audit(cfg)]
+
+
+def test_restore_refused_when_no_archive_copy(tmp_path):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    ok, reason = tel.restore_skill(cfg, "ghost")
+    assert ok is False
+    assert reason
+    assert tel.read_audit(cfg) == []
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+# ---------------------------------------------------------------------------
+
+def test_cli_audit_prints_ledger(tmp_path, capsys):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    tel.append_audit(cfg, {"kind": "archive", "name": "z"})
+    rc = tel.main(["--action", "audit", "--config-dir", str(cfg)])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out[-1]["name"] == "z"
+
+
+def test_cli_restore_round_trips(tmp_path, capsys):
+    tel = _telemetry()
+    cfg = tmp_path / "cfg"
+    _archive_via_curator(cfg, "clicomeback")
+    rc = tel.main(["--action", "restore", "--config-dir", str(cfg),
+                   "--skill", "clicomeback"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert (cfg / "skills" / "clicomeback" / "SKILL.md").is_file()

--- a/tools/stateless/skill_curator/skill_curator.py
+++ b/tools/stateless/skill_curator/skill_curator.py
@@ -54,6 +54,7 @@ import importlib.util
 import json
 import os
 import shutil
+import subprocess
 import sys
 import tempfile
 from datetime import datetime, timedelta, timezone
@@ -334,7 +335,7 @@ def apply_automatic_transitions(
     now: Optional[datetime] = None,
     stale_after_days: Optional[int] = None,
     archive_after_days: Optional[int] = None,
-) -> Dict[str, int]:
+) -> Dict[str, Any]:
     """Walk every eligible skill and move active/stale/archived based on the
     latest real activity timestamp. Pinned skills are never touched.
 
@@ -345,7 +346,11 @@ def apply_automatic_transitions(
     they are read from ``<config-dir>/skills/curator.yaml``. ``now`` is injectable
     so tests seed a deterministic clock.
 
-    Returns the counter dict ``{checked, marked_stale, archived, reactivated}``.
+    Returns the counter dict ``{checked, marked_stale, archived, reactivated}``
+    plus an ``events`` list — one ``{name, from_state, to_state, action}`` per
+    transition actually made (``action`` ∈ ``stale`` / ``archive`` /
+    ``reactivate``). The named events make each run observable and let the audit
+    ledger record exactly what moved.
     """
     if now is None:
         now = datetime.now(timezone.utc)
@@ -359,7 +364,10 @@ def apply_automatic_transitions(
     stale_cutoff = now - timedelta(days=stale_after_days)
     archive_cutoff = now - timedelta(days=archive_after_days)
 
-    counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
+    counts: Dict[str, Any] = {
+        "marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0,
+    }
+    events: List[Dict[str, Any]] = []
 
     for row in eligible_skill_rows(config_dir):
         counts["checked"] += 1
@@ -380,13 +388,26 @@ def apply_automatic_transitions(
             ok, _dest = archive_skill(config_dir, name)
             if ok:
                 counts["archived"] += 1
+                events.append({
+                    "name": name, "from_state": current,
+                    "to_state": STATE_ARCHIVED, "action": "archive",
+                })
         elif anchor <= stale_cutoff and current == STATE_ACTIVE:
             telemetry.set_state(config_dir, name, STATE_STALE)
             counts["marked_stale"] += 1
+            events.append({
+                "name": name, "from_state": STATE_ACTIVE,
+                "to_state": STATE_STALE, "action": "stale",
+            })
         elif anchor > stale_cutoff and current == STATE_STALE:
             telemetry.set_state(config_dir, name, STATE_ACTIVE)
             counts["reactivated"] += 1
+            events.append({
+                "name": name, "from_state": STATE_STALE,
+                "to_state": STATE_ACTIVE, "action": "reactivate",
+            })
 
+    counts["events"] = events
     return counts
 
 
@@ -568,12 +589,13 @@ def _curator_state_path(config_dir: Path) -> Path:
 
 
 def write_run_report(
-    config_dir: Path, counts: Dict[str, int], *, now: Optional[datetime] = None
+    config_dir: Path, counts: Dict[str, Any], *, now: Optional[datetime] = None
 ) -> Path:
     """Atomically write ``<config-dir>/skills/.curator_state`` (JSON).
 
-    Payload is ``{last_run_at, **counts}``. Same tempfile + ``os.replace``
-    pattern the Phase 1/2 tools use.
+    Payload is ``{last_run_at, **counts}`` — so the named ``events`` list rides
+    in alongside the four counters, making the latest snapshot self-describing.
+    Same tempfile + ``os.replace`` pattern the Phase 1/2 tools use.
     """
     if now is None:
         now = datetime.now(timezone.utc)
@@ -604,11 +626,14 @@ def _compute_dry_run_counts(
     now: datetime,
     stale_after_days: int,
     archive_after_days: int,
-) -> Dict[str, int]:
-    """Compute would-be transition counts WITHOUT mutating anything."""
+) -> Dict[str, Any]:
+    """Compute would-be transition counts + events WITHOUT mutating anything."""
     stale_cutoff = now - timedelta(days=stale_after_days)
     archive_cutoff = now - timedelta(days=archive_after_days)
-    counts = {"marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0}
+    counts: Dict[str, Any] = {
+        "marked_stale": 0, "archived": 0, "reactivated": 0, "checked": 0,
+    }
+    events: List[Dict[str, Any]] = []
     for row in eligible_skill_rows(config_dir):
         counts["checked"] += 1
         if row.get("pinned"):
@@ -623,10 +648,17 @@ def _compute_dry_run_counts(
         current = row.get("state", STATE_ACTIVE)
         if anchor <= archive_cutoff and current != STATE_ARCHIVED:
             counts["archived"] += 1
+            events.append({"name": row["name"], "from_state": current,
+                           "to_state": STATE_ARCHIVED, "action": "archive"})
         elif anchor <= stale_cutoff and current == STATE_ACTIVE:
             counts["marked_stale"] += 1
+            events.append({"name": row["name"], "from_state": STATE_ACTIVE,
+                           "to_state": STATE_STALE, "action": "stale"})
         elif anchor > stale_cutoff and current == STATE_STALE:
             counts["reactivated"] += 1
+            events.append({"name": row["name"], "from_state": STATE_STALE,
+                           "to_state": STATE_ACTIVE, "action": "reactivate"})
+    counts["events"] = events
     return counts
 
 
@@ -679,6 +711,26 @@ def run(
         config_dir, harness, enabled=bool(effective_consolidate)
     )
 
+    # Durable audit trail: one curator entry per live run, capturing the named
+    # transitions AND whether the consolidation pass ran. This is what makes a
+    # run observable and (via restore_skill) reversible after the fact.
+    events = counts.get("events", [])
+    counts_only = {k: v for k, v in counts.items() if k != "events"}
+    consolidation_summary = {
+        "ran": bool(consolidation.get("ran")),
+        "reason": consolidation.get("reason"),
+        "harness": consolidation.get("harness"),
+    }
+    try:
+        telemetry.append_audit(config_dir, {
+            "kind": "curator",
+            "counts": counts_only,
+            "events": events,
+            "consolidation": consolidation_summary,
+        }, now=now)
+    except Exception:  # pragma: no cover - audit is best-effort
+        pass
+
     return {
         "harness": harness,
         "dry_run": False,
@@ -686,6 +738,83 @@ def run(
         "consolidation": consolidation,
         "report_path": str(report_path),
     }
+
+
+# ---------------------------------------------------------------------------
+# Notify — concise on-change summary with an undo hint (best-effort)
+# ---------------------------------------------------------------------------
+
+_NOTIFY_PATH = _THIS_DIR.parent / "notify" / "notify.py"
+
+
+def _run_changed(summary: Dict[str, Any]) -> bool:
+    """True when a live curator run actually moved something or consolidated."""
+    counts = summary.get("counts", {})
+    if any(int(counts.get(k, 0) or 0) > 0
+           for k in ("marked_stale", "archived", "reactivated")):
+        return True
+    return bool(summary.get("consolidation", {}).get("ran"))
+
+
+def compose_notify_message(config_dir: Path, summary: Dict[str, Any]) -> str:
+    """Build a concise one-message curator summary that NAMES what changed and
+    carries the undo hint.
+
+    Lists the skills that staled / archived / reactivated by name and appends the
+    ``skill_telemetry.py --action restore`` recovery command so the recipient can
+    reverse an archive without hunting for the syntax.
+    """
+    counts = summary.get("counts", {})
+    events = counts.get("events", []) or []
+    by_action: Dict[str, List[str]] = {"stale": [], "archive": [], "reactivate": []}
+    for ev in events:
+        by_action.setdefault(ev.get("action", ""), []).append(ev.get("name", ""))
+
+    parts: List[str] = []
+    if by_action.get("archive"):
+        parts.append("archived " + ", ".join(by_action["archive"]))
+    if by_action.get("stale"):
+        parts.append("staled " + ", ".join(by_action["stale"]))
+    if by_action.get("reactivate"):
+        parts.append("reactivated " + ", ".join(by_action["reactivate"]))
+
+    consolidation = summary.get("consolidation", {})
+    if consolidation.get("ran"):
+        parts.append("ran consolidation pass")
+
+    summary_line = "; ".join(parts) if parts else "no transitions"
+    msg = f"Skill curator: {summary_line}."
+
+    archived = by_action.get("archive") or []
+    if archived:
+        example = archived[0]
+        msg += (
+            f" Undo an archive with: skill_telemetry.py --action restore "
+            f"--skill {example} --config-dir {config_dir}"
+        )
+    return msg
+
+
+def maybe_notify(config_dir: Path, summary: Dict[str, Any]) -> Optional[List[str]]:
+    """Shell out to the notify tool with a one-message change summary.
+
+    No-op (returns ``None``) when nothing changed. Best-effort: a notify failure
+    is swallowed so it never fails the run. When ``HERMES_NOTIFY_TEST`` is set,
+    ``--test-mode`` is passed so no real Telegram is sent — tests assert the
+    composed message and the invoked argv. Returns the argv that was invoked (or
+    would have been), or ``None`` when no notification was warranted.
+    """
+    if not _run_changed(summary):
+        return None
+    message = compose_notify_message(config_dir, summary)
+    cmd = [sys.executable, str(_NOTIFY_PATH), "send", "--message", message]
+    if os.getenv("HERMES_NOTIFY_TEST"):
+        cmd.append("--test-mode")
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+    except Exception:  # pragma: no cover - notify is best-effort
+        pass
+    return cmd
 
 
 # ---------------------------------------------------------------------------
@@ -708,6 +837,10 @@ def main(argv: Optional[List[str]] = None) -> int:
         "--dry-run", action="store_true",
         help="Compute would-be transitions without mutating; write no report",
     )
+    parser.add_argument(
+        "--notify", action="store_true",
+        help="On a changed live run, send a concise notify summary (best-effort)",
+    )
     args = parser.parse_args(argv)
 
     consolidate_arg = True if args.consolidate else None
@@ -715,6 +848,8 @@ def main(argv: Optional[List[str]] = None) -> int:
         Path(args.config_dir), args.harness,
         consolidate=consolidate_arg, dry_run=args.dry_run,
     )
+    if args.notify and not args.dry_run:
+        maybe_notify(Path(args.config_dir), summary)
     print(json.dumps(summary, sort_keys=True))
     return 0
 

--- a/tools/stateless/skill_manage/skill_manage.py
+++ b/tools/stateless/skill_manage/skill_manage.py
@@ -756,9 +756,29 @@ def _delete_skill(config_dir: Path, name: str,
         dest = archive_root / f"{name}-{stamp}"
     shutil.move(str(skill_dir), str(dest))
 
+    absorbed = (
+        absorbed_into.strip()
+        if isinstance(absorbed_into, str) and absorbed_into.strip()
+        else None
+    )
+
+    # Durable, reversible record: log where the dir went and which umbrella (if
+    # any) it was absorbed into. This is what makes a consolidation merge
+    # undoable — every absorbed sibling appears in the ledger paired with both
+    # its umbrella and its archive path, so restore_skill can bring it back.
+    try:
+        telemetry.append_audit(config_dir, {
+            "kind": "archive",
+            "name": name,
+            "absorbed_into": absorbed,
+            "archive_path": str(dest),
+        })
+    except Exception:  # pragma: no cover - audit is best-effort
+        pass
+
     message = f"Skill '{name}' archived to {dest}."
-    if absorbed_into is not None and isinstance(absorbed_into, str) and absorbed_into.strip():
-        message += f" Content absorbed into '{absorbed_into.strip()}'."
+    if absorbed is not None:
+        message += f" Content absorbed into '{absorbed}'."
 
     return {"success": True, "message": message, "archived_to": str(dest)}
 

--- a/tools/stateless/skill_proposer/skill_proposer.py
+++ b/tools/stateless/skill_proposer/skill_proposer.py
@@ -39,6 +39,7 @@ import importlib.util
 import json
 import os
 import re
+import subprocess
 import sys
 from collections import Counter
 from dataclasses import dataclass
@@ -410,6 +411,61 @@ def run(
 
 
 # ---------------------------------------------------------------------------
+# Notify — concise on-change summary with an undo hint (best-effort)
+# ---------------------------------------------------------------------------
+
+_NOTIFY_PATH = _THIS_DIR.parent / "notify" / "notify.py"
+
+
+def _created_names(summary: Dict[str, Any]) -> List[str]:
+    """Names of skills the proposer actually created this run."""
+    return [p["name"] for p in summary.get("proposed", []) if p.get("created")]
+
+
+def compose_notify_message(config_dir: Path, summary: Dict[str, Any]) -> str:
+    """Build a concise one-message proposer summary that NAMES the created
+    skills and carries the undo hint.
+
+    Each auto-created skill is agent-provenance and Curator-eligible; the message
+    names them and appends the ``skill_telemetry.py --action restore`` recovery
+    command (a created skill can be deleted via skill_manage and brought back the
+    same way an archive is), so the recipient has the reversal syntax inline.
+    """
+    created = _created_names(summary)
+    summary_line = "created " + ", ".join(created) if created else "created nothing"
+    msg = f"Skill proposer: {summary_line}."
+    if created:
+        example = created[0]
+        msg += (
+            f" Undo with: skill_telemetry.py --action restore "
+            f"--skill {example} --config-dir {config_dir}"
+        )
+    return msg
+
+
+def maybe_notify(config_dir: Path, summary: Dict[str, Any]) -> Optional[List[str]]:
+    """Shell out to the notify tool with a one-message change summary.
+
+    No-op (returns ``None``) when nothing was created. Best-effort: a notify
+    failure is swallowed so it never fails the run. When ``HERMES_NOTIFY_TEST``
+    is set, ``--test-mode`` is passed so no real Telegram is sent — tests assert
+    the composed message and the invoked argv. Returns the argv invoked (or that
+    would have been), or ``None`` when no notification was warranted.
+    """
+    if not _created_names(summary):
+        return None
+    message = compose_notify_message(config_dir, summary)
+    cmd = [sys.executable, str(_NOTIFY_PATH), "send", "--message", message]
+    if os.getenv("HERMES_NOTIFY_TEST"):
+        cmd.append("--test-mode")
+    try:
+        subprocess.run(cmd, capture_output=True, text=True, timeout=20)
+    except Exception:  # pragma: no cover - notify is best-effort
+        pass
+    return cmd
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -426,12 +482,18 @@ def main(argv: Optional[List[str]] = None) -> int:
         help="Path to training_turns.db (read-only)",
     )
     parser.add_argument("--mind-id", required=True, help="This mind's MIND_ID")
+    parser.add_argument(
+        "--notify", action="store_true",
+        help="On a run that created skills, send a concise notify summary (best-effort)",
+    )
     args = parser.parse_args(argv)
 
     summary = run(
         Path(args.config_dir), args.harness,
         db_path=args.db_path, mind_id=args.mind_id,
     )
+    if args.notify:
+        maybe_notify(Path(args.config_dir), summary)
     print(json.dumps(summary, sort_keys=True))
     return 0
 

--- a/tools/stateless/skill_telemetry/skill_telemetry.py
+++ b/tools/stateless/skill_telemetry/skill_telemetry.py
@@ -34,6 +34,7 @@ import argparse
 import json
 import logging
 import os
+import shutil
 import sys
 import tempfile
 from contextlib import contextmanager
@@ -78,6 +79,16 @@ def usage_file(config_dir: Path) -> Path:
     ``.codex`` dir.
     """
     return _skills_dir(config_dir) / ".usage.json"
+
+
+def audit_log_file(config_dir: Path) -> Path:
+    """Resolve the append-only audit-ledger path for *config_dir*.
+
+    The ledger is ``<config_dir>/skills/.skill_audit.log`` — one JSON object
+    per line, append-only history. This is the single durable record both the
+    curator and skill_manage write to when they transition or archive a skill.
+    """
+    return _skills_dir(config_dir) / ".skill_audit.log"
 
 
 @contextmanager
@@ -366,6 +377,129 @@ def forget(config_dir: Path, skill_name: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Shared audit ledger — append-only history both other tools write to
+# ---------------------------------------------------------------------------
+
+def append_audit(
+    config_dir: Path, entry: Dict[str, Any], *, now: Optional[datetime] = None
+) -> None:
+    """Append one JSON line to ``<config_dir>/skills/.skill_audit.log``.
+
+    The ledger is append-only history: every entry is merged with an ``at``
+    ISO-8601 timestamp and written as a single line. Parents are created on
+    demand and the write is serialized through the module's lock so concurrent
+    appends never interleave a partial line. Best-effort — failures log at
+    DEBUG and return silently; a broken ledger never breaks the caller.
+    """
+    path = audit_log_file(config_dir)
+    stamp = (now or datetime.now(timezone.utc)).isoformat()
+    record = {"at": stamp, **dict(entry)}
+    try:
+        with _usage_file_lock(config_dir):
+            path.parent.mkdir(parents=True, exist_ok=True)
+            line = json.dumps(record, sort_keys=True, ensure_ascii=False)
+            with open(path, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
+                f.flush()
+                os.fsync(f.fileno())
+    except Exception as e:  # pragma: no cover - best-effort
+        logger.debug("skill_telemetry.append_audit failed: %s", e, exc_info=True)
+
+
+def read_audit(config_dir: Path, limit: Optional[int] = None) -> List[Dict[str, Any]]:
+    """Read the audit ledger, returning the most-recent *limit* entries.
+
+    Entries come back oldest-first (newest last); when *limit* is given only
+    the trailing ``limit`` entries are returned. Corrupt or empty lines are
+    skipped. A missing ledger yields ``[]``.
+    """
+    path = audit_log_file(config_dir)
+    if not path.exists():
+        return []
+    entries: List[Dict[str, Any]] = []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(obj, dict):
+                    entries.append(obj)
+    except OSError as e:  # pragma: no cover - defensive
+        logger.debug("skill_telemetry.read_audit failed: %s", e, exc_info=True)
+        return []
+    if limit is not None and limit >= 0:
+        return entries[-limit:] if limit else []
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# restore_skill — the exact inverse of the curator/skill_manage archive move
+# ---------------------------------------------------------------------------
+
+def _archived_copies(config_dir: Path, name: str) -> List[Path]:
+    """Return every archived copy of *name* under ``skills/.archive/``.
+
+    Matches both the plain ``<name>`` directory and any timestamp-suffixed
+    ``<name>-<stamp>`` collision copy (the suffix scheme used by both
+    ``skill_curator.archive_skill`` and ``skill_manage`` delete). Sorted so the
+    most recent copy is last.
+    """
+    archive_root = _skills_dir(config_dir) / ".archive"
+    if not archive_root.is_dir():
+        return []
+    copies: List[Path] = []
+    for entry in archive_root.iterdir():
+        if not entry.is_dir():
+            continue
+        if entry.name == name or entry.name.startswith(f"{name}-"):
+            copies.append(entry)
+    # Plain "<name>" sorts before any "<name>-<stamp>"; the lexicographically
+    # largest timestamp suffix is the newest, so a plain sort puts newest last.
+    copies.sort(key=lambda p: p.name)
+    return copies
+
+
+def restore_skill(config_dir: Path, name: str) -> "tuple[bool, Optional[str]]":
+    """Move an archived skill back to live and re-activate it — inverse of
+    ``archive_skill``.
+
+    Locates ``<config_dir>/skills/.archive/<name>`` (picking the most-recent
+    timestamp-suffixed copy on collision), moves it back to
+    ``<config_dir>/skills/<name>``, sets its sidecar state ``active``, and
+    appends a ``{kind: "restore", name}`` audit entry. Refuses (returns
+    ``(False, reason)``) when a live skill of that name already exists or no
+    archived copy is found — and mutates nothing on refusal.
+    """
+    if not name:
+        return False, "no skill name given"
+
+    live = _skills_dir(config_dir) / name
+    if live.exists() or os.path.islink(str(live)):
+        return False, f"skill '{name}' already exists live; refusing to overwrite"
+
+    copies = _archived_copies(config_dir, name)
+    if not copies:
+        return False, f"no archived copy of '{name}' found"
+
+    source = copies[-1]
+    try:
+        live.parent.mkdir(parents=True, exist_ok=True)
+        shutil.move(str(source), str(live))
+    except Exception as e:  # pragma: no cover - defensive
+        logger.debug("restore_skill move failed: %s", e, exc_info=True)
+        return False, f"could not move archive copy ({type(e).__name__})"
+
+    set_state(config_dir, name, STATE_ACTIVE)
+    append_audit(config_dir, {"kind": "restore", "name": name})
+    return True, str(live)
+
+
+# ---------------------------------------------------------------------------
 # Shared bump helper — the thin entry point the Stop-hooks call
 # ---------------------------------------------------------------------------
 
@@ -438,6 +572,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         choices=[
             "bump-use", "bump-view", "bump-patch", "mark-agent-created",
             "set-state", "set-pinned", "forget", "list", "seed",
+            "restore", "audit",
         ],
         help="Telemetry action to perform",
     )
@@ -445,6 +580,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser.add_argument("--skill", help="Skill name (required for all per-skill actions)")
     parser.add_argument("--state", help="Lifecycle state for --action set-state")
     parser.add_argument("--pinned", help="Bool for --action set-pinned (true/false)")
+    parser.add_argument("--limit", type=int, default=None, help="Tail length for --action audit")
 
     args = parser.parse_args(argv)
     config_dir = Path(args.config_dir)
@@ -462,6 +598,22 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     if action == "seed":
         print(json.dumps(seed_existing_skills(config_dir), sort_keys=True))
+        return 0
+
+    if action == "audit":
+        print(json.dumps(read_audit(config_dir, args.limit), indent=2, sort_keys=True))
+        return 0
+
+    if action == "restore":
+        rc = _needs_skill()
+        if rc is not None:
+            return rc
+        ok, info = restore_skill(config_dir, args.skill)
+        if not ok:
+            print(json.dumps({"ok": False, "skill": args.skill, "error": info}, sort_keys=True))
+            return 1
+        print(json.dumps({"ok": True, "skill": args.skill, "restored_to": info},
+                         sort_keys=True))
         return 0
 
     rc = _needs_skill()


### PR DESCRIPTION
Adds the observability-and-reversibility layer so the autonomous proposer and the LLM consolidation pass can be safely enabled — the precondition Daniel set for turning them on.

## What's new (committed shared tools + tests)
- **Shared audit ledger** in `skill_telemetry.py`: `append_audit` / `read_audit` write an append-only `.skill_audit.log`. Every curator transition (as named `{name, from_state, to_state, action}` events), every proposer creation, and every archive (with its `absorbed_into` umbrella and `archive_path`) is recorded.
- **Restore / undo**: `restore_skill` is the exact inverse of archive — moves the newest archived copy back to active, sets state, logs it; refuses if a live copy exists or nothing is archived. New CLI actions `restore` and `audit`.
- **Named events** in the curator: `apply_automatic_transitions` now returns an `events` list, carried into `.curator_state` and the ledger; a live `run` appends one curator audit entry.
- **Archive logging** in `skill_manage delete`: every archive (aged-out or consolidation-absorbed) is logged with its umbrella, making consolidation merges visible and reversible.
- **Change notifications**: `--notify` on the curator and proposer CLIs sends a Telegram summary naming what changed plus the one-line undo command — only when something actually changed. Nagatha's scheduled `tasks.yaml` tasks pass `--notify`.

## Deployment (on-disk, gitignored per-host minds dirs — not in this diff)
- Proposer enabled on Ada and Nagatha (fully deterministic, self-cleaning).
- Consolidation enabled on Ada only — Nagatha's curator fires as an agentless scheduled subprocess with no agent to drive the LLM review, so enabling it there would be inert.
- New user-invocable `skill-audit` skill on both minds to view the ledger and restore from Telegram.

## Tests
506 passed, 0 failures (478 baseline + 28 new across telemetry audit/restore, curator events, archive logging, and notify for both passes).