### PR TITLE
Phase 5: richer-signal clustering for the skill proposer

### DIFF
--- a/core/training_capture_claude.py
+++ b/core/training_capture_claude.py
@@ -181,6 +181,7 @@ def _parse_grouped(transcript_path: str | Path) -> list[tuple[str, list[dict]]]:
                         "type": "tool_result",
                         "content": _tool_result_text(c.get("content")),
                         "tool_call_id": c.get("tool_use_id", ""),
+                        "is_error": bool(c.get("is_error")),
                     })
                 elif ctype == "text" and c.get("text"):
                     acc.start_turn(c["text"])

--- a/core/training_capture_codex.py
+++ b/core/training_capture_codex.py
@@ -120,6 +120,24 @@ def _output_text(output) -> str:
     return str(output)
 
 
+def _output_is_error(output) -> bool:
+    """Best-effort error verdict for a ``function_call_output``.
+
+    Codex wraps the tool result as a dict that may carry ``metadata.exit_code``
+    or a ``success`` flag. A non-zero exit or ``success: false`` is an error;
+    anything else (including a bare string) is treated as success so the flag
+    only tightens success-gating when the signal is actually present."""
+    if isinstance(output, dict):
+        meta = output.get("metadata")
+        if isinstance(meta, dict):
+            ec = meta.get("exit_code")
+            if isinstance(ec, int):
+                return ec != 0
+        if output.get("success") is False:
+            return True
+    return False
+
+
 def _parse_arguments(arguments) -> dict:
     """Decode a ``function_call`` ``arguments`` value into an input dict.
 
@@ -222,6 +240,7 @@ def _parse_grouped(transcript_path: str | Path) -> list[tuple[str, list[dict]]]:
                 "type": "tool_result",
                 "content": _output_text(payload.get("output")),
                 "tool_call_id": payload.get("call_id", ""),
+                "is_error": _output_is_error(payload.get("output")),
             })
             continue
 

--- a/tests/unit/test_skill_proposer_richer_signal.py
+++ b/tests/unit/test_skill_proposer_richer_signal.py
@@ -1,0 +1,207 @@
+"""Phase 5 — richer-signal clustering for harness-native minds.
+
+Covers the five improvements over bare-name clustering:
+  1. semantic action-token extraction (name + input), incl. http method/path
+     granularity and inline-env resolution / unresolvable-$VAR drop;
+  2. run-collapse of consecutive identical tokens;
+  3. order-canonical cluster key (reversed-order turns merge);
+  4. parameter extraction into a templated ``## Procedure`` body;
+  5. success gating (errored turns excluded from cluster counts).
+
+Fixture training_turns.db built via core.training_capture (never the live DB).
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+from core import training_capture as tc
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = str(_PROJECT_ROOT / "tools/stateless/skill_proposer/skill_proposer.py")
+
+
+def _load():
+    name = "skill_proposer_richer_under_test"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT_PATH)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _seed_blocks(db, *, session_id, turn_index, mind_id, blocks, captured_at):
+    turn = tc.TrainingTurn.from_blocks(
+        session_id=session_id,
+        turn_index=turn_index,
+        harness=tc.HARNESS_CLAUDE_CODE,
+        mind_id=mind_id,
+        user_content="x",
+        assistant_blocks=blocks,
+        captured_at=captured_at,
+    )
+    tc.upsert_turns(str(db), [turn])
+
+
+def _bash(cmd):
+    return {"type": "tool_use", "name": "Bash", "input": {"command": cmd}}
+
+
+# ---------------------------------------------------------------------------
+# 1 — semantic action-token extraction
+# ---------------------------------------------------------------------------
+
+def test_token_stateless_tool_script():
+    mod = _load()
+    blk = _bash("python3 tools/stateless/reminders/reminders.py due")
+    assert mod._extract_action_token(blk) == "tool:reminders"
+
+
+def test_token_curl_method_and_two_path_segments():
+    mod = _load()
+    get = _bash("curl -s http://127.0.0.1:8425/memory/retrieve")
+    post = _bash("curl -s -X POST http://127.0.0.1:8425/memory/store -d '{}'")
+    post_d = _bash("curl -s http://127.0.0.1:8425/memory/store --data '{}'")
+    assert mod._extract_action_token(get) == "http:GET:memory/retrieve"
+    assert mod._extract_action_token(post) == "http:POST:memory/store"
+    assert mod._extract_action_token(post_d) == "http:POST:memory/store"
+    # Distinct lucent ops do NOT collapse to one token.
+    assert mod._extract_action_token(get) != mod._extract_action_token(post)
+
+
+def test_token_read_skill_md_and_extension():
+    mod = _load()
+    sk = {"type": "tool_use", "name": "Read",
+          "input": {"file_path": "/x/.claude/skills/planka/SKILL.md"}}
+    py = {"type": "tool_use", "name": "Edit",
+          "input": {"file_path": "/x/tools/foo.py"}}
+    assert mod._extract_action_token(sk) == "skill:planka"
+    assert mod._extract_action_token(py) == "edit:py"
+
+
+def test_token_mcp_kept_verbatim_and_skill_agent():
+    mod = _load()
+    mcp = {"type": "tool_use", "name": "mcp__hive-mind-tools__graph_query", "input": {}}
+    skill = {"type": "tool_use", "name": "Skill", "input": {"skill": "hivemind:planka"}}
+    agent = {"type": "tool_use", "name": "Agent", "input": {"subagent_type": "Explore"}}
+    assert mod._extract_action_token(mcp) == "mcp__hive-mind-tools__graph_query"
+    assert mod._extract_action_token(skill) == "skill:hivemind:planka"
+    assert mod._extract_action_token(agent) == "agent:Explore"
+
+
+def test_token_inline_env_resolved():
+    mod = _load()
+    blk = _bash("TOOL=reminders python3 $TOOL.py due")
+    assert mod._extract_action_token(blk) == "tool:reminders"
+
+
+def test_token_unresolvable_var_dropped():
+    mod = _load()
+    blk = _bash("$TOOL due")  # exe itself is an unresolved variable
+    assert mod._extract_action_token(blk) is None
+
+
+# ---------------------------------------------------------------------------
+# 2 — run-collapse
+# ---------------------------------------------------------------------------
+
+def test_run_collapse_folds_consecutive_duplicates():
+    mod = _load()
+    assert mod._collapse_runs(("sh:grep",) * 10) == ("sh:grep",)
+    assert mod._collapse_runs(("a", "a", "b", "b", "a")) == ("a", "b", "a")
+
+
+# ---------------------------------------------------------------------------
+# 3 — order-canonical cluster key
+# ---------------------------------------------------------------------------
+
+def test_reversed_order_turns_cluster_together():
+    mod = _load()
+    seqs = (
+        [("sh:docker", "read:txt")] * 2
+        + [("read:txt", "sh:docker")] * 2
+    )
+    clusters = mod.cluster_sequences(seqs, min_frequency=3, min_sequence_length=2)
+    assert len(clusters) == 1
+    assert clusters[0].count == 4
+
+
+# ---------------------------------------------------------------------------
+# 4 — parameter extraction
+# ---------------------------------------------------------------------------
+
+def test_template_from_details_varies_to_placeholder():
+    mod = _load()
+    tmpl = mod._template_from_details(
+        ["reminders.py due", "reminders.py add", "reminders.py list"]
+    )
+    assert tmpl == "reminders.py {{arg}}"
+
+
+def test_template_from_details_identical_is_literal():
+    mod = _load()
+    assert mod._template_from_details(["docker ps", "docker ps"]) == "docker ps"
+
+
+def test_extract_procedure_emits_templated_body():
+    mod = _load()
+    members = [
+        mod.TurnRecord(("tool:reminders",), ("reminders.py due",), True),
+        mod.TurnRecord(("tool:reminders",), ("reminders.py add",), True),
+        mod.TurnRecord(("tool:reminders",), ("reminders.py list",), True),
+    ]
+    lines = mod._extract_procedure(("tool:reminders",), members)
+    assert lines == ("`reminders.py {{arg}}`",)
+
+
+# ---------------------------------------------------------------------------
+# 5 — success gating
+# ---------------------------------------------------------------------------
+
+def test_turn_succeeded_reads_terminal_error():
+    mod = _load()
+    ok = [_bash("ls"), {"type": "tool_result", "is_error": False}]
+    bad = [_bash("ls"), {"type": "tool_result", "is_error": True}]
+    legacy = [_bash("ls")]  # no tool_result → treated as success
+    assert mod._turn_succeeded(ok) is True
+    assert mod._turn_succeeded(bad) is False
+    assert mod._turn_succeeded(legacy) is True
+
+
+def test_failed_turns_excluded_from_records(tmp_path):
+    mod = _load()
+    db = tmp_path / "training_turns.db"
+    ok_blocks = [_bash("docker ps"), {"type": "tool_result", "is_error": False}]
+    bad_blocks = [_bash("docker ps"), {"type": "tool_result", "is_error": True}]
+    _seed_blocks(db, session_id="s", turn_index=0, mind_id="skip",
+                 blocks=ok_blocks, captured_at=100)
+    _seed_blocks(db, session_id="s", turn_index=1, mind_id="skip",
+                 blocks=bad_blocks, captured_at=101)
+    records = mod.read_recent_turn_records(str(db), "skip", lookback_turns=500)
+    succeeded = [r for r in records if r.succeeded]
+    assert len(records) == 2
+    assert len(succeeded) == 1
+
+
+# ---------------------------------------------------------------------------
+# headline — a real mixed-tool workflow clusters into one named proposal,
+# where the bare-name version produced only ``auto-bash``.
+# ---------------------------------------------------------------------------
+
+def test_mixed_tool_workflow_clusters_into_named_proposal(tmp_path):
+    mod = _load()
+    db = tmp_path / "training_turns.db"
+    for i in range(3):
+        blocks = [
+            _bash("curl -s http://127.0.0.1:8425/memory/retrieve"),
+            _bash("python3 tools/stateless/notify/notify.py send --message hi"),
+        ]
+        _seed_blocks(db, session_id="s", turn_index=i, mind_id="skip",
+                     blocks=blocks, captured_at=100 + i)
+    seqs = mod.read_recent_sequences(str(db), "skip", lookback_turns=500)
+    clusters = mod.cluster_sequences(seqs, min_frequency=3, min_sequence_length=2)
+    assert len(clusters) == 1
+    name = clusters[0].proposed_name
+    assert name != "auto-bash"
+    assert "memory" in name and "notify" in name

--- a/tests/unit/test_training_capture_claude.py
+++ b/tests/unit/test_training_capture_claude.py
@@ -69,10 +69,10 @@ def transcript(tmp_path):
             {"type": "tool_use", "id": "t4", "name": "Task",
              "input": {"subagent_type": "Explore", "prompt": "look around"}},
         ]),
-        # tool_result content as a block array (not a bare string)
+        # tool_result content as a block array (not a bare string); errored.
         _user([
             {"type": "tool_result", "tool_use_id": "t2",
-             "content": [{"type": "text", "text": "card list"}]},
+             "content": [{"type": "text", "text": "card list"}], "is_error": True},
         ]),
         # sidechain (sub-agent) events must be skipped entirely
         _assistant([{"type": "text", "text": "subagent internal chatter"}], sidechain=True),
@@ -148,10 +148,12 @@ def test_tool_result_links_id_and_flattens_blocks(transcript):
     blocks = grouped[0][1]
     results = [b for b in blocks if b["type"] == "tool_result"]
     assert results[0] == {
-        "type": "tool_result", "content": "file.txt", "tool_call_id": "t1"
+        "type": "tool_result", "content": "file.txt", "tool_call_id": "t1",
+        "is_error": False,
     }
     assert results[1] == {
-        "type": "tool_result", "content": "card list", "tool_call_id": "t2"
+        "type": "tool_result", "content": "card list", "tool_call_id": "t2",
+        "is_error": True,
     }
 
 

--- a/tests/unit/test_training_capture_codex.py
+++ b/tests/unit/test_training_capture_codex.py
@@ -136,10 +136,12 @@ def test_tool_result_links_call_id(rollout):
     grouped = _parse_grouped(rollout)
     results = [b for b in grouped[0][1] if b["type"] == "tool_result"]
     assert results[0] == {
-        "type": "tool_result", "content": "file.txt", "tool_call_id": "c1"
+        "type": "tool_result", "content": "file.txt", "tool_call_id": "c1",
+        "is_error": False,
     }
     assert results[1] == {
-        "type": "tool_result", "content": "patched", "tool_call_id": "c2"
+        "type": "tool_result", "content": "patched", "tool_call_id": "c2",
+        "is_error": False,
     }
 
 
@@ -182,6 +184,21 @@ def test_dict_output_flattened(tmp_path):
     grouped = _parse_grouped(p)
     result = next(b for b in grouped[0][1] if b["type"] == "tool_result")
     assert result["content"] == "wrapped text"
+
+
+def test_output_is_error_from_nonzero_exit(tmp_path):
+    p = tmp_path / "r.jsonl"
+    p.write_text(
+        _message("user", "go") + "\n"
+        + _call("exec_command", {"cmd": "false"}, "e1") + "\n"
+        + _output("e1", {"output": "boom", "metadata": {"exit_code": 1}}) + "\n"
+        + _call("exec_command", {"cmd": "true"}, "e2") + "\n"
+        + _output("e2", {"output": "ok", "metadata": {"exit_code": 0}}) + "\n"
+    )
+    grouped = _parse_grouped(p)
+    results = [b for b in grouped[0][1] if b["type"] == "tool_result"]
+    assert results[0]["is_error"] is True
+    assert results[1]["is_error"] is False
 
 
 def test_missing_file_returns_empty(tmp_path):

--- a/tools/stateless/skill_proposer/skill_proposer.py
+++ b/tools/stateless/skill_proposer/skill_proposer.py
@@ -44,8 +44,8 @@ import os
 import re
 import subprocess
 import sys
-from collections import Counter
-from dataclasses import dataclass
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -99,6 +99,9 @@ _NOISE_TOOL_WORDS = {"todowrite", "todoread"}
 MAX_NAME_LENGTH = 64
 VALID_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9._-]*$")
 
+# Placeholder emitted for the varying argument slot in a templated procedure step.
+_PLACEHOLDER = "{{arg}}"
+
 
 @dataclass
 class SequenceCluster:
@@ -106,33 +109,209 @@ class SequenceCluster:
     count: int
     example_session_id: str
     proposed_name: str
+    # Optional templated ``## Procedure`` lines (one per signature token),
+    # filled by ``run`` from the cluster's member turns. Empty → generic steps.
+    procedure_lines: Tuple[str, ...] = ()
+
+
+@dataclass
+class TurnRecord:
+    """One captured turn reduced to its semantic action signal.
+
+    ``tokens`` is the per-turn ordered tuple of semantic action tokens (see
+    ``_extract_action``); ``details`` is the parallel tuple of the concrete
+    invocation string each token was derived from (used for parameter
+    extraction); ``succeeded`` is False only when the turn's final tool_result
+    carried ``is_error`` (success gating — see ``_turn_succeeded``).
+    """
+
+    tokens: Tuple[str, ...]
+    details: Tuple[str, ...]
+    succeeded: bool
+
+
+# ---------------------------------------------------------------------------
+# Step 3a — semantic action-token extraction (name + input → action)
+#
+# The bare ``tool_use`` name is signal-free for harness-native minds whose work
+# runs through generic ``Bash``/``Read``/``Edit``. We derive a semantic token
+# from each block's name AND input so a crypto check and a docker restart no
+# longer both read as "Bash". Deterministic, no model.
+# ---------------------------------------------------------------------------
+
+_CD_PREFIX_RE = re.compile(r"^\s*cd\s+\S+\s*&&\s*")
+_LEADING_ASSIGN_RE = re.compile(r"^\s*(?:[A-Za-z_]\w*=[^\s;|&]+\s+)+")
+_SOURCE_PREFIX_RE = re.compile(r"^\s*(?:\.|source)\s+\S+\s*(?:;|&&)?\s*")
+_ENV_ASSIGN_RE = re.compile(r"(?:^|[;&|]|\s)([A-Za-z_]\w*)=([^\s;|&]+)")
+_VAR_RE = re.compile(r"\$\{(\w+)\}|\$(\w+)")
+_TOOLSCRIPT_RE = re.compile(r"tools/stateless/(\w+)/\1\.py\b|(?:^|/|\s)(\w+)\.py\b")
+_SKILL_MD_RE = re.compile(r"skills/([^/]+)/SKILL\.md$")
+
+
+def _resolve_command(command: str) -> str:
+    """Strip ``cd … &&`` prefixes, leading env assignments and ``.``/``source``
+    lines, then substitute reused inline ``$VAR`` assignments. Returns the
+    salient command with indirection removed (a ``$VAR`` with no in-command
+    assignment is left intact so the caller can drop it)."""
+    cmd = command.strip()
+    env = {k: v for k, v in _ENV_ASSIGN_RE.findall(cmd)}
+    while True:
+        m = _CD_PREFIX_RE.match(cmd)
+        if not m:
+            break
+        cmd = cmd[m.end():]
+    cmd = _LEADING_ASSIGN_RE.sub("", cmd)
+    cmd = _SOURCE_PREFIX_RE.sub("", cmd)
+
+    def _sub(m: "re.Match") -> str:
+        var = m.group(1) or m.group(2)
+        return env.get(var, m.group(0))
+
+    return _VAR_RE.sub(_sub, cmd).strip()
+
+
+def _curl_parse(cmd: str) -> Tuple[str, str]:
+    """``curl`` → ``http:<METHOD>:<first-two-path-segments>`` so distinct lucent
+    ops (``memory/store`` vs ``memory/retrieve``) stay apart."""
+    method = "GET"
+    if re.search(r"-X\s*PUT", cmd):
+        method = "PUT"
+    elif re.search(r"-X\s*DELETE", cmd):
+        method = "DELETE"
+    elif re.search(r"-X\s*POST", cmd) or re.search(r"(?:^|\s)(?:-d|--data\b|--data-\w+)", cmd):
+        method = "POST"
+    m = re.search(r"https?://[^\s\"']+", cmd)
+    if not m:
+        return "sh:curl", cmd
+    pm = re.search(r"https?://[^/\s]+/([^\s\"'?]*)", m.group(0))
+    path = pm.group(1) if pm else ""
+    segs = [s for s in path.split("/") if s][:2]
+    return "http:" + method + ":" + "/".join(segs), cmd
+
+
+def _parse_bash(command: str) -> Tuple[Optional[str], str]:
+    """Return ``(token, detail)`` for a Bash command, or ``(None, "")`` to drop
+    a block whose token would carry an unresolved ``$VAR`` (no signal)."""
+    if not command or not command.strip():
+        return "Bash", ""
+    cmd = _resolve_command(command)
+    if not cmd:
+        return "Bash", ""
+    if re.match(r"^(?:sudo\s+)?curl\b", cmd):
+        return _curl_parse(cmd)
+    m = _TOOLSCRIPT_RE.search(cmd)
+    if m:
+        tool = m.group(1) or m.group(2)
+        if tool and "$" not in tool:
+            return f"tool:{tool}", cmd
+    parts = cmd.split()
+    first = parts[0]
+    if first == "sudo" and len(parts) > 1:
+        first = parts[1]
+    exe = os.path.basename(first)
+    if not exe or "$" in exe:
+        return None, ""
+    return f"sh:{exe}", cmd
+
+
+def _extract_action(block: Any) -> Optional[Tuple[str, str]]:
+    """Map one ``tool_use`` block to ``(token, detail)``, or ``None`` to drop.
+
+    ``Bash`` → ``tool:``/``http:``/``sh:`` (see ``_parse_bash``); ``Read``/
+    ``Edit``/``Write`` → ``skill:<name>`` for a SKILL.md else ``<verb>:<ext>``;
+    ``Skill`` → ``skill:<skill>``; ``Agent`` → ``agent:<subagent_type>``;
+    ``mcp__*`` verbatim; anything else → the bare name (unchanged fallback)."""
+    if not isinstance(block, dict):
+        return None
+    name = block.get("name", "")
+    inp = block.get("input")
+    if not isinstance(inp, dict):
+        inp = {}
+    if name == "Bash":
+        tok, det = _parse_bash(inp.get("command", "") or "")
+        return None if tok is None else (tok, det)
+    if name in ("Read", "Edit", "Write"):
+        fp = inp.get("file_path", "") or ""
+        if fp:
+            mm = _SKILL_MD_RE.search(fp)
+            if mm:
+                return f"skill:{mm.group(1)}", fp
+            ext = Path(fp).suffix.lstrip(".").lower()
+            if ext:
+                return f"{name.lower()}:{ext}", fp
+        return name, fp
+    if name == "Skill":
+        s = inp.get("skill") or ""
+        return (f"skill:{s}", s) if s else (name, "")
+    if name == "Agent":
+        t = inp.get("subagent_type") or ""
+        return (f"agent:{t}", t) if t else (name, "")
+    if name.startswith("mcp__"):
+        return name, ""
+    if name:
+        return name, ""
+    return None
+
+
+def _extract_action_token(block: Any) -> Optional[str]:
+    """The semantic token for one ``tool_use`` block (``None`` to drop)."""
+    a = _extract_action(block)
+    return a[0] if a else None
+
+
+def _collapse_runs(seq: Tuple[str, ...]) -> Tuple[str, ...]:
+    """Collapse consecutive identical tokens — a workflow's signal is its shape,
+    not how many greps it took. Kills the ``Bash×N`` noise at the source."""
+    out: List[str] = []
+    for t in seq:
+        if not out or out[-1] != t:
+            out.append(t)
+    return tuple(out)
+
+
+def _collapse_pairs(
+    tokens: Tuple[str, ...], details: Tuple[str, ...]
+) -> List[Tuple[str, str]]:
+    """Run-collapse ``(token, detail)`` pairs, keeping the first detail of a run."""
+    out: List[Tuple[str, str]] = []
+    for tok, det in zip(tokens, details):
+        if out and out[-1][0] == tok:
+            continue
+        out.append((tok, det))
+    return out
+
+
+def _turn_succeeded(blocks: List[Any]) -> bool:
+    """Success gating: a turn counts only if its final ``tool_result`` did not
+    error. Rows captured before ``is_error`` existed have no flag → treated as
+    successful, so gating only tightens as new turns are captured."""
+    last: Optional[bool] = None
+    for b in blocks:
+        if isinstance(b, dict) and b.get("type") == "tool_result":
+            last = bool(b.get("is_error"))
+    return last is not True
 
 
 # ---------------------------------------------------------------------------
 # Step 3 — DB reader + clustering
 # ---------------------------------------------------------------------------
 
-def read_recent_sequences(
+def read_recent_turn_records(
     db_path: Any,
     mind_id: str,
     *,
     harness: Optional[str] = None,
     lookback_turns: int = 500,
-) -> List[Tuple[str, ...]]:
-    """Read recent ``training_turns`` for *mind_id* and return per-turn ordered
-    tuples of ``tool_use`` block names.
+) -> List[TurnRecord]:
+    """Read recent ``training_turns`` for *mind_id* into ``TurnRecord``s.
 
-    Rows are ordered ``captured_at DESC, id DESC`` and limited to
-    ``lookback_turns`` (most-recent first). Optionally filtered by ``harness``.
-    Turns with no tool_use blocks are skipped. Uses
-    ``core.training_capture.connect`` for schema fidelity — never assumes column
-    positions.
-    """
+    Each record carries the per-turn semantic action tokens (name + input),
+    the parallel concrete-invocation details, and the success verdict. Rows are
+    ordered ``captured_at DESC, id DESC`` and limited to ``lookback_turns``;
+    optionally filtered by ``harness``. Turns with no tool_use blocks are
+    skipped. Uses ``core.training_capture.connect`` for schema fidelity."""
     tc = _load_training_capture()
-    sql = (
-        "SELECT assistant_blocks FROM training_turns "
-        "WHERE mind_id = ?"
-    )
+    sql = "SELECT assistant_blocks FROM training_turns WHERE mind_id = ?"
     params: List[Any] = [mind_id]
     if harness is not None:
         sql += " AND harness = ?"
@@ -140,7 +319,7 @@ def read_recent_sequences(
     sql += " ORDER BY captured_at DESC, id DESC LIMIT ?"
     params.append(int(lookback_turns))
 
-    sequences: List[Tuple[str, ...]] = []
+    records: List[TurnRecord] = []
     with tc.connect(db_path) as conn:
         rows = conn.execute(sql, params).fetchall()
     for row in rows:
@@ -153,14 +332,42 @@ def read_recent_sequences(
             continue
         if not isinstance(blocks, list):
             continue
-        names = tuple(
-            b.get("name", "")
-            for b in blocks
-            if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name")
+        toks: List[str] = []
+        dets: List[str] = []
+        for b in blocks:
+            if isinstance(b, dict) and b.get("type") == "tool_use" and b.get("name"):
+                a = _extract_action(b)
+                if a is None:
+                    continue
+                toks.append(a[0])
+                dets.append(a[1])
+        if toks:
+            records.append(
+                TurnRecord(
+                    tokens=tuple(toks),
+                    details=tuple(dets),
+                    succeeded=_turn_succeeded(blocks),
+                )
+            )
+    return records
+
+
+def read_recent_sequences(
+    db_path: Any,
+    mind_id: str,
+    *,
+    harness: Optional[str] = None,
+    lookback_turns: int = 500,
+) -> List[Tuple[str, ...]]:
+    """Per-turn ordered tuples of semantic action tokens (thin shim over
+    ``read_recent_turn_records`` — run-collapse and success-gating are applied
+    downstream in clustering / ``run``)."""
+    return [
+        r.tokens
+        for r in read_recent_turn_records(
+            db_path, mind_id, harness=harness, lookback_turns=lookback_turns
         )
-        if names:
-            sequences.append(names)
-    return sequences
+    ]
 
 
 def _derive_proposed_name(signature: Tuple[str, ...]) -> str:
@@ -197,20 +404,30 @@ def cluster_sequences(
     min_frequency: int = 3,
     min_sequence_length: int = 2,
 ) -> List[SequenceCluster]:
-    """Count identical ordered tool tuples and return over-threshold clusters.
+    """Run-collapse, group by **sorted token multiset**, return over-threshold
+    clusters.
 
-    Only sequences of length >= ``min_sequence_length`` are counted; only those
+    Each sequence is first run-collapsed (consecutive duplicates folded). Only
+    collapsed sequences of length >= ``min_sequence_length`` are counted. They
+    are grouped by their **sorted** token multiset so the same set of actions in
+    a different order (``docker→cat`` vs ``cat→docker``) lands in one cluster
+    instead of two under-threshold ones; the most frequent observed ordering is
+    kept as the cluster ``signature`` for naming and the drafted body. Only keys
     recurring >= ``min_frequency`` times become clusters. Sorted by count desc
-    then signature for deterministic ordering. Each cluster gets a deterministic
-    kebab ``proposed_name``.
+    then signature for deterministic ordering.
     """
-    counts: Counter = Counter(
-        seq for seq in sequences if len(seq) >= int(min_sequence_length)
-    )
+    collapsed = [_collapse_runs(seq) for seq in sequences]
+    collapsed = [seq for seq in collapsed if len(seq) >= int(min_sequence_length)]
+    by_key: Dict[Tuple[str, ...], List[Tuple[str, ...]]] = defaultdict(list)
+    for seq in collapsed:
+        by_key[tuple(sorted(seq))].append(seq)
+
     clusters: List[SequenceCluster] = []
-    for signature, count in counts.items():
+    for members in by_key.values():
+        count = len(members)
         if count < int(min_frequency):
             continue
+        signature = Counter(members).most_common(1)[0][0]
         clusters.append(
             SequenceCluster(
                 signature=signature,
@@ -221,6 +438,50 @@ def cluster_sequences(
         )
     clusters.sort(key=lambda c: (-c.count, c.signature))
     return clusters
+
+
+# ---------------------------------------------------------------------------
+# Parameter extraction — turn a confirmed cluster's member turns into a runnable
+# templated body (the varying argument becomes a placeholder) instead of a stub.
+# ---------------------------------------------------------------------------
+
+def _template_from_details(details: List[str]) -> Optional[str]:
+    """One template line for an action token across its member invocations.
+
+    All-identical invocations → that literal. Varying invocations → the common
+    prefix + ``{{arg}}`` + common suffix (e.g. ``reminders.py due|add|list`` →
+    ``reminders.py {{arg}}``). No usable detail → ``None``."""
+    vals = [d for d in details if d]
+    distinct = list(dict.fromkeys(vals))
+    if not distinct:
+        return None
+    if len(distinct) == 1:
+        return distinct[0]
+    prefix = os.path.commonprefix(distinct)
+    suffix = os.path.commonprefix([s[::-1] for s in distinct])[::-1]
+    if len(prefix) + len(suffix) >= min(len(s) for s in distinct):
+        suffix = ""  # affixes overlap; keep prefix only
+    return f"{prefix}{_PLACEHOLDER}{suffix}".strip()
+
+
+def _extract_procedure(
+    signature: Tuple[str, ...], members: List[TurnRecord]
+) -> Tuple[str, ...]:
+    """Render one ``## Procedure`` line per signature token from member turns,
+    diffing concrete invocations into a templated (placeholdered) command."""
+    pool: Dict[str, List[str]] = defaultdict(list)
+    for rec in members:
+        for tok, det in _collapse_pairs(rec.tokens, rec.details):
+            pool[tok].append(det)
+    lines: List[str] = []
+    for tok in signature:
+        tmpl = _template_from_details(pool.get(tok, []))
+        if tmpl:
+            tmpl = tmpl.replace("`", "'").replace("\n", " ").strip()
+            lines.append(f"`{tmpl}`")
+        else:
+            lines.append(f"Invoke `{tok}`.")
+    return tuple(lines)
 
 
 # ---------------------------------------------------------------------------
@@ -332,10 +593,15 @@ def draft_skill_md(cluster: SequenceCluster, *, harness: str) -> str:
         f"observed across {cluster.count} turns."
     )
 
-    steps = "\n".join(
-        f"{i}. Invoke `{tool}` as the next step of the sequence."
-        for i, tool in enumerate(tools, start=1)
-    )
+    if cluster.procedure_lines:
+        steps = "\n".join(
+            f"{i}. {line}" for i, line in enumerate(cluster.procedure_lines, start=1)
+        )
+    else:
+        steps = "\n".join(
+            f"{i}. Invoke `{tool}` as the next step of the sequence."
+            for i, tool in enumerate(tools, start=1)
+        )
 
     body = (
         f"# {title}\n\n"
@@ -377,14 +643,21 @@ def run(
     if not conf["enabled"]:
         return {"enabled": False, "proposed": []}
 
-    sequences = read_recent_sequences(
+    records = read_recent_turn_records(
         db_path, mind_id, harness=None, lookback_turns=conf["lookback_turns"]
     )
+    # Success gating: only turns that ended without a terminal error count.
+    succeeded = [r for r in records if r.succeeded]
     clusters = cluster_sequences(
-        sequences,
+        [r.tokens for r in succeeded],
         min_frequency=conf["min_frequency"],
         min_sequence_length=conf["min_sequence_length"],
     )
+    # Map each cluster's canonical key back to its member turns for parameter
+    # extraction (the key is the sorted, run-collapsed token multiset).
+    key_to_records: Dict[Tuple[str, ...], List[TurnRecord]] = defaultdict(list)
+    for r in succeeded:
+        key_to_records[tuple(sorted(_collapse_runs(r.tokens)))].append(r)
 
     sm = _load_skill_manage()
     proposed: List[Dict[str, Any]] = []
@@ -395,6 +668,10 @@ def run(
         # Re-read existing names each iteration so a just-created skill counts.
         if is_covered(cluster, existing_skill_names(config_dir)):
             continue
+        cluster.procedure_lines = _extract_procedure(
+            cluster.signature,
+            key_to_records.get(tuple(sorted(cluster.signature)), []),
+        )
         content = draft_skill_md(cluster, harness=harness)
         out = sm.skill_manage(
             "create", config_dir, harness,


### PR DESCRIPTION
Clusters on a semantic action token (name + input) instead of the bare tool-use wrapper name, so harness-native minds get real workflow signal instead of `auto-bash` noise.

## Changes
- **Semantic token extraction** — `Bash` → `tool:`/`http:<METHOD>:<seg1>/<seg2>`/`sh:`; `Read`/`Edit`/`Write` → `skill:<name>` or `<verb>:<ext>`; `Skill`/`Agent`/`mcp__*` kept semantic. Inline env (`TOOL=x … $TOOL`) resolved; a block whose executable stays an unresolved `$VAR` is dropped.
- **Run-collapse** of consecutive identical tokens.
- **Order-canonical cluster key** (sorted token multiset) so reversed-order variants merge; dominant ordering kept for naming and body.
- **Parameter extraction** — a confirmed cluster's member turns are diffed into a templated `## Procedure` body with `{{arg}}` placeholders, not a stub.
- **Success gating** — turns whose terminal `tool_result` errored are excluded; capture layer now records `is_error` (Claude + Codex), backward-compatible.

## Validation
Read-only dry-run on live turns: Ada's noise resolves into her real workflows (check-reminders ×744, btc-buy-alerter ×186, 1pm newsletter, blessings→TTS); Skippy's 13 junk `auto-bash` clusters collapse to 5 honest ones. Full suite 519 green.

Design doc: Phase 5 of `hermes-skills-implementation.md`.