### PR TITLE
netsage: gate Suricata noise on the Loki stream source label

### DIFF
--- a/bots/scheduled_tasks/scripts/netsage_run.py
+++ b/bots/scheduled_tasks/scripts/netsage_run.py
@@ -48,7 +48,7 @@ BENIGN_SUBSTRINGS = (
 )
 
 
-def pull_loki_lines() -> list[tuple[str, str, str]]:
+def pull_loki_lines() -> list[tuple[str, str, str, str]]:
     end_ns = time.time_ns()
     start_ns = end_ns - 15 * 60 * 1_000_000_000
     query = urllib.parse.urlencode({
@@ -64,7 +64,7 @@ def pull_loki_lines() -> list[tuple[str, str, str]]:
     except Exception as exc:
         print(f"Loki query failed: {exc}")
         return []
-    lines: list[tuple[str, str, str]] = []
+    lines: list[tuple[str, str, str, str]] = []
     for stream in data.get("data", {}).get("result", []):
         meta = stream.get("stream", {})
         svc = (
@@ -76,9 +76,13 @@ def pull_loki_lines() -> list[tuple[str, str, str]]:
         )
         if isinstance(svc, str):
             svc = svc.lstrip("/")
+        # Vector tags every Loki stream with its origin in the `source` label
+        # (docker / journald / auth / suricata / zeek / clamav). The anomaly
+        # picker gates on this, so carry it through rather than discard it.
+        src = meta.get("source") or ""
         for entry in stream.get("values", []):
             ts, msg = entry[0], entry[1]
-            lines.append((svc, ts, msg))
+            lines.append((src, svc, ts, msg))
     return lines
 
 
@@ -168,18 +172,20 @@ def _suricata_alert(record: dict | None) -> str | None:
 
 def pick_anomalies(lines):
     out = []
-    for svc, ts, msg in lines:
+    for src, svc, ts, msg in lines:
         record = _decode_envelope(msg)
         suricata_line = _suricata_alert(record)
         if suricata_line is not None:
             host = record.get("host") if record else None
             out.append((f"suricata@{host or svc}", ts, suricata_line))
             continue
-        if record and record.get("source_app") == "suricata":
+        if src == "suricata":
             # Any other Suricata event (stats, flow, dns, tls…) only ever
-            # surfaces via the alert path above. Skip it before the generic
-            # text filter, whose crisis words (e.g. "error") match substrings
-            # in Suricata's own internal stats counter names.
+            # surfaces via the alert path above. Gate on the Loki stream's
+            # `source` label, not a body field: eve.json lines carry no source
+            # marker of their own, and their stats counters embed crisis words
+            # ("errors", "invalid") that would otherwise trip the generic text
+            # filter below and page Daniel with routine telemetry.
             continue
         priority = _journal_priority(record)
         if priority is not None and priority > MAX_JOURNAL_PRIORITY:

--- a/tests/unit/test_netsage_run.py
+++ b/tests/unit/test_netsage_run.py
@@ -4,6 +4,11 @@ Focus is the anomaly picker, specifically that Suricata IDS alerts — which
 express badness through a numeric severity field rather than the English
 crisis words the generic regex hunts for — are surfaced, while informational
 Suricata noise and non-alert Suricata events (flow/dns/tls) are dropped.
+
+The picker identifies Suricata lines by the Loki stream's `source` label
+(supplied by Vector), which is the first element of each input tuple
+(source, service, ts, message). Real eve.json bodies carry no source marker
+of their own, so gating on a body field silently leaked stats telemetry.
 """
 
 from __future__ import annotations
@@ -29,11 +34,15 @@ netsage = _load_module()
 def _suricata_eve(event_type="alert", severity=1, signature="ET ATTACK Something",
                   category="A Network Trojan was Detected", src="10.0.0.5",
                   dst="10.0.0.1", host="NetSage"):
-    """Build the JSON envelope Vector ships to Loki for a Suricata eve line."""
+    """Build the JSON body Vector ships to Loki for a Suricata eve line.
+
+    Real eve.json lines carry no source marker of their own — the "suricata"
+    tag lives on the Loki stream's `source` label, supplied separately to
+    pick_anomalies as the first tuple element.
+    """
     record = {
         "event_type": event_type,
         "host": host,
-        "source_app": "suricata",
         "src_ip": src,
         "dest_ip": dst,
         "in_iface": "enp2s0",
@@ -94,7 +103,7 @@ def test_non_suricata_record_returns_none():
 # ---------------------------------------------------------------------------
 
 def test_pick_anomalies_surfaces_suricata_alert():
-    lines = [("unknown_service", "1", _suricata_eve(severity=1, signature="ET ATTACK X"))]
+    lines = [("suricata", "unknown_service", "1", _suricata_eve(severity=1, signature="ET ATTACK X"))]
     out = netsage.pick_anomalies(lines)
     assert len(out) == 1
     label, _ts, msg = out[0]
@@ -104,28 +113,29 @@ def test_pick_anomalies_surfaces_suricata_alert():
 
 def test_pick_anomalies_drops_suricata_noise():
     lines = [
-        ("unknown_service", "1", _suricata_eve(severity=3, signature="SURICATA Ethertype unknown")),
-        ("unknown_service", "2", _suricata_eve(event_type="dns")),
-        ("unknown_service", "3", _suricata_eve(event_type="flow")),
+        ("suricata", "unknown_service", "1", _suricata_eve(severity=3, signature="SURICATA Ethertype unknown")),
+        ("suricata", "unknown_service", "2", _suricata_eve(event_type="dns")),
+        ("suricata", "unknown_service", "3", _suricata_eve(event_type="flow")),
     ]
     assert netsage.pick_anomalies(lines) == []
 
 
-def test_pick_anomalies_drops_suricata_stats_with_error_counter():
-    # Suricata stats payloads carry counter names containing "error"; they
-    # must never reach the generic English-word filter.
+def test_pick_anomalies_drops_real_suricata_stats():
+    # Regression: real eve.json stats lines carry NO source marker in the body
+    # and their counter names embed crisis words ("error", "invalid"). The only
+    # Suricata tell is the Loki stream's source="suricata" label. Gating on a
+    # body field (the old bug) let these page Daniel every scheduler fire.
     stats = json.dumps({
+        "timestamp": "2026-06-28T19:17:39.500920-0500",
         "event_type": "stats",
-        "source_app": "suricata",
-        "host": "NetSage",
         "stats": {"app_layer": {"error": {"http": {"alloc": 0}}}, "capture": {"errors": 0}},
     })
-    assert "error" in stats
-    assert netsage.pick_anomalies([("unknown_service", "1", stats)]) == []
+    assert netsage.ANOMALY_REGEX.search(stats), "fixture must contain a crisis word to be a real regression"
+    assert netsage.pick_anomalies([("suricata", "unknown_service", "1", stats)]) == []
 
 
 def test_pick_anomalies_still_catches_plain_text_errors():
-    lines = [("ollama.service", "1", "CRITICAL: model failed to load")]
+    lines = [("journald", "ollama.service", "1", "CRITICAL: model failed to load")]
     out = netsage.pick_anomalies(lines)
     assert len(out) == 1
     assert "CRITICAL" in out[0][2]
@@ -133,10 +143,10 @@ def test_pick_anomalies_still_catches_plain_text_errors():
 
 def test_pick_anomalies_mixed_stream():
     lines = [
-        ("unknown_service", "1", _suricata_eve(severity=1, signature="ET ATTACK X")),
-        ("unknown_service", "2", _suricata_eve(severity=3, signature="Ethertype unknown")),
-        ("skippy.service", "3", "Traceback (most recent call last):"),
-        ("unknown_service", "4", _suricata_eve(event_type="tls")),
+        ("suricata", "unknown_service", "1", _suricata_eve(severity=1, signature="ET ATTACK X")),
+        ("suricata", "unknown_service", "2", _suricata_eve(severity=3, signature="Ethertype unknown")),
+        ("journald", "skippy.service", "3", "Traceback (most recent call last):"),
+        ("suricata", "unknown_service", "4", _suricata_eve(event_type="tls")),
     ]
     out = netsage.pick_anomalies(lines)
     assert len(out) == 2


### PR DESCRIPTION
## What

Hex's NetSage triage pass was paging on routine Suricata telemetry — or would have, once its Loki route was fixed.

`pick_anomalies` dropped non-alert Suricata events by checking `record['source_app'] == 'suricata'` **in the message body**. Real eve.json lines carry no such field. Vector tags the origin on the Loki stream's `source` label, which `pull_loki_lines` discarded. So the guard never fired, and Suricata `stats` payloads (counter names embed `error`, `invalid`) fell through to the generic crisis-word text filter.

## Fix

- Carry the stream `source` label through `pull_loki_lines` (now a 4-tuple `(source, service, ts, msg)`).
- Gate the Suricata-noise skip on `source == 'suricata'`.
- Rewrite the unit fixtures to model real data — no body source marker, source supplied as the stream label. The old fixtures injected a fictional `source_app` field, which is why they were green while production leaked.

## Test

`tests/unit/test_netsage_run.py` — 11 passed. Added a regression (`test_pick_anomalies_drops_real_suricata_stats`) that asserts the fixture contains a crisis word, proving the gate, not the text filter, is what drops it.

Verified live on Hex: real-mode run reports clean instead of 8 phantom stats anomalies.