### PR TITLE
netsage: unwrap nested eve.json + split Loki query to beat the sev-3 flood

### DIFF
--- a/bots/scheduled_tasks/scripts/netsage_run.py
+++ b/bots/scheduled_tasks/scripts/netsage_run.py
@@ -47,15 +47,32 @@ BENIGN_SUBSTRINGS = (
     "cron fired",
 )
 
+LOKI_WINDOW_NS = 15 * 60 * 1_000_000_000
+LOKI_LIMIT = 2000
 
-def pull_loki_lines() -> list[tuple[str, str, str, str]]:
+# The feed is pulled with two queries, not one. Suricata floods Loki with
+# sev-3 eve noise (Ethertype unknown, our own Telegram traffic, CLOSE_WAIT) at
+# thousands of lines per 15-minute window — far over LOKI_LIMIT. A single
+# `{service_name=~".+"}` pull therefore returns almost nothing but that noise,
+# burying both the rare real Suricata alerts and genuine errors from every
+# other service. So:
+#   1. the generic query EXCLUDES Suricata, keeping the budget for everyone else;
+#   2. Suricata is pulled on its own, pre-filtered to forward-worthy severities
+#      at the Loki layer. Vector nests the eve.json as a JSON string inside the
+#      envelope's `message` field, so severity appears in the escaped form
+#      `\"severity\":N`; the regex below matches the two escape chars with `..`.
+GENERIC_QUERY = '{service_name=~".+", source!="suricata"}'
+SURICATA_ALERT_QUERY = r'{source="suricata", event_type="alert"} |~ `severity..:[12]`'
+
+
+def _query_loki(logql: str) -> list[tuple[str, str, str, str]]:
     end_ns = time.time_ns()
-    start_ns = end_ns - 15 * 60 * 1_000_000_000
+    start_ns = end_ns - LOKI_WINDOW_NS
     query = urllib.parse.urlencode({
-        "query": '{service_name=~".+"}',
+        "query": logql,
         "start": start_ns,
         "end": end_ns,
-        "limit": 2000,
+        "limit": LOKI_LIMIT,
         "direction": "backward",
     })
     try:
@@ -86,8 +103,14 @@ def pull_loki_lines() -> list[tuple[str, str, str, str]]:
     return lines
 
 
-def _decode_envelope(msg: str) -> dict | None:
+def pull_loki_lines() -> list[tuple[str, str, str, str]]:
+    return _query_loki(GENERIC_QUERY) + _query_loki(SURICATA_ALERT_QUERY)
+
+
+def _decode_envelope(msg: str | None) -> dict | None:
     """Return the parsed dict if msg is a JSON log envelope, else None."""
+    if not isinstance(msg, str):
+        return None
     stripped = msg.lstrip()
     if not stripped.startswith("{"):
         return None
@@ -138,11 +161,27 @@ def _service_label(record: dict | None, raw_svc: str) -> str:
     return raw_svc
 
 
+def _eve_record(envelope: dict | None) -> dict | None:
+    """Unwrap the real Suricata eve.json record from a Loki envelope.
+
+    Vector tails eve.json (each line already JSON) and ships it as a *string*
+    in the envelope's ``message`` field — it does NOT flatten the eve fields to
+    the top level. So the event_type, alert{} sub-object, and src_ip/dest_ip
+    that matter all live inside ``envelope["message"]``, not on ``envelope``
+    itself. Parse that nested string; fall back to the envelope only if there
+    is no message to unwrap (so a future flattened shape still works).
+    """
+    if not envelope:
+        return None
+    inner = _decode_envelope(envelope.get("message"))
+    return inner if inner is not None else envelope
+
+
 def _suricata_alert(record: dict | None) -> str | None:
     """Return a readable one-liner for a worth-forwarding Suricata alert.
 
-    Vector merges the parsed eve.json line into the record, so an alert event
-    carries a top-level event_type=="alert" and an alert sub-object with
+    ``record`` is the unwrapped eve.json record (see :func:`_eve_record`): an
+    alert event carries event_type=="alert" and an alert sub-object with
     severity/signature/category. Returns None for non-alert Suricata events
     (flow, dns, tls, stats…) and for alerts at or below the noise ceiling.
     """
@@ -174,18 +213,20 @@ def pick_anomalies(lines):
     out = []
     for src, svc, ts, msg in lines:
         record = _decode_envelope(msg)
-        suricata_line = _suricata_alert(record)
-        if suricata_line is not None:
-            host = record.get("host") if record else None
-            out.append((f"suricata@{host or svc}", ts, suricata_line))
-            continue
         if src == "suricata":
-            # Any other Suricata event (stats, flow, dns, tls…) only ever
-            # surfaces via the alert path above. Gate on the Loki stream's
-            # `source` label, not a body field: eve.json lines carry no source
-            # marker of their own, and their stats counters embed crisis words
-            # ("errors", "invalid") that would otherwise trip the generic text
-            # filter below and page Daniel with routine telemetry.
+            # Suricata is gated entirely on the Loki stream's `source` label,
+            # never the generic text filter: its eve.json carries no source
+            # marker of its own, and its stats counters embed crisis words
+            # ("errors", "invalid") that would otherwise page on routine
+            # telemetry. The real eve record is nested as a JSON string in
+            # record["message"] — unwrap it before reading event_type/alert.
+            eve = _eve_record(record)
+            suricata_line = _suricata_alert(eve)
+            if suricata_line is not None:
+                host = (record.get("host") if record else None) or svc
+                out.append((f"suricata@{host}", ts, suricata_line))
+            # Everything else Suricata (stats/flow/dns/tls, sub-ceiling
+            # alerts) is intentionally dropped here, never text-filtered.
             continue
         priority = _journal_priority(record)
         if priority is not None and priority > MAX_JOURNAL_PRIORITY:

--- a/tests/unit/test_netsage_run.py
+++ b/tests/unit/test_netsage_run.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import urllib.parse
 from pathlib import Path
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -31,30 +32,46 @@ def _load_module():
 netsage = _load_module()
 
 
-def _suricata_eve(event_type="alert", severity=1, signature="ET ATTACK Something",
-                  category="A Network Trojan was Detected", src="10.0.0.5",
-                  dst="10.0.0.1", host="NetSage"):
-    """Build the JSON body Vector ships to Loki for a Suricata eve line.
-
-    Real eve.json lines carry no source marker of their own — the "suricata"
-    tag lives on the Loki stream's `source` label, supplied separately to
-    pick_anomalies as the first tuple element.
-    """
+def _eve_record(event_type="alert", severity=1, signature="ET ATTACK Something",
+                category="A Network Trojan was Detected", src="10.0.0.5",
+                dst="10.0.0.1"):
+    """The real Suricata eve.json record — what lives INSIDE the envelope's
+    nested `message` string, where event_type, alert{}, and src/dest_ip sit."""
     record = {
+        "timestamp": "2026-06-28T19:45:05.562147-0500",
         "event_type": event_type,
-        "host": host,
+        "in_iface": "enp9s0",
+        "pkt_src": "wire/pcap",
         "src_ip": src,
         "dest_ip": dst,
-        "in_iface": "enp2s0",
     }
     if event_type == "alert":
         record["alert"] = {
+            "action": "allowed",
             "severity": severity,
             "signature": signature,
             "category": category,
-            "action": "allowed",
         }
-    return json.dumps(record)
+    return record
+
+
+def _suricata_eve(host="sentinel", **kw):
+    """The full Loki value Vector ships for a Suricata eve line.
+
+    Vector tails eve.json and ships each line as a JSON *string* in the
+    envelope's `message` field — it does NOT flatten eve fields to the top
+    level. event_type and host ride as envelope fields/labels; the alert object
+    only exists inside the nested string. This is the byte shape Loki returns.
+    """
+    inner = _eve_record(**kw)
+    envelope = {
+        "event_type": inner["event_type"],
+        "file": "/var/log/suricata/eve.json",
+        "host": host,
+        "message": json.dumps(inner),
+        "source_type": "file",
+    }
+    return json.dumps(envelope)
 
 
 # ---------------------------------------------------------------------------
@@ -62,7 +79,7 @@ def _suricata_eve(event_type="alert", severity=1, signature="ET ATTACK Something
 # ---------------------------------------------------------------------------
 
 def test_high_severity_alert_is_surfaced():
-    record = json.loads(_suricata_eve(severity=1, signature="ET ATTACK X"))
+    record = _eve_record(severity=1, signature="ET ATTACK X")
     line = netsage._suricata_alert(record)
     assert line is not None
     assert "severity 1" in line
@@ -71,22 +88,22 @@ def test_high_severity_alert_is_surfaced():
 
 
 def test_ceiling_severity_alert_is_surfaced():
-    record = json.loads(_suricata_eve(severity=netsage.SURICATA_SEVERITY_CEILING))
+    record = _eve_record(severity=netsage.SURICATA_SEVERITY_CEILING)
     assert netsage._suricata_alert(record) is not None
 
 
 def test_informational_severity_alert_is_dropped():
-    record = json.loads(_suricata_eve(severity=3, signature="SURICATA Ethertype unknown"))
+    record = _eve_record(severity=3, signature="SURICATA Ethertype unknown")
     assert netsage._suricata_alert(record) is None
 
 
 def test_non_alert_suricata_event_is_dropped():
-    record = json.loads(_suricata_eve(event_type="flow"))
+    record = _eve_record(event_type="flow")
     assert netsage._suricata_alert(record) is None
 
 
 def test_alert_without_severity_still_surfaces():
-    record = json.loads(_suricata_eve())
+    record = _eve_record()
     del record["alert"]["severity"]
     line = netsage._suricata_alert(record)
     assert line is not None
@@ -99,16 +116,40 @@ def test_non_suricata_record_returns_none():
 
 
 # ---------------------------------------------------------------------------
+# _eve_record — the envelope-unwrap step that the false-clean bug skipped
+# ---------------------------------------------------------------------------
+
+def test_eve_record_unwraps_nested_message():
+    envelope = json.loads(_suricata_eve(severity=1, signature="ET ATTACK X"))
+    # The alert object is NOT on the envelope — only inside the nested string.
+    assert "alert" not in envelope
+    eve = netsage._eve_record(envelope)
+    assert eve["event_type"] == "alert"
+    assert eve["alert"]["severity"] == 1
+    assert eve["alert"]["signature"] == "ET ATTACK X"
+
+
+def test_eve_record_falls_back_to_envelope_without_message():
+    flat = {"event_type": "alert", "alert": {"severity": 1, "signature": "X"}}
+    assert netsage._eve_record(flat) is flat
+    assert netsage._eve_record(None) is None
+
+
+# ---------------------------------------------------------------------------
 # pick_anomalies integration
 # ---------------------------------------------------------------------------
 
 def test_pick_anomalies_surfaces_suricata_alert():
+    # Regression for the false clean: the eve alert lives in the nested message
+    # string, not at the envelope top level. pick_anomalies must unwrap it or
+    # every real severity 1/2 alert is silently dropped.
     lines = [("suricata", "unknown_service", "1", _suricata_eve(severity=1, signature="ET ATTACK X"))]
     out = netsage.pick_anomalies(lines)
     assert len(out) == 1
     label, _ts, msg = out[0]
-    assert label == "suricata@NetSage"
+    assert label == "suricata@sentinel"
     assert "ET ATTACK X" in msg
+    assert "10.0.0.5 to 10.0.0.1" in msg
 
 
 def test_pick_anomalies_drops_suricata_noise():
@@ -121,14 +162,21 @@ def test_pick_anomalies_drops_suricata_noise():
 
 
 def test_pick_anomalies_drops_real_suricata_stats():
-    # Regression: real eve.json stats lines carry NO source marker in the body
-    # and their counter names embed crisis words ("error", "invalid"). The only
-    # Suricata tell is the Loki stream's source="suricata" label. Gating on a
-    # body field (the old bug) let these page Daniel every scheduler fire.
-    stats = json.dumps({
+    # Regression: real eve.json stats lines embed crisis words ("error",
+    # "invalid") in their counter names, nested in the envelope's message
+    # string. The only Suricata tell is the Loki stream's source="suricata"
+    # label; gating on a body field (the old bug) paged on every fire.
+    inner = json.dumps({
         "timestamp": "2026-06-28T19:17:39.500920-0500",
         "event_type": "stats",
         "stats": {"app_layer": {"error": {"http": {"alloc": 0}}}, "capture": {"errors": 0}},
+    })
+    stats = json.dumps({
+        "event_type": "stats",
+        "file": "/var/log/suricata/eve.json",
+        "host": "sentinel",
+        "message": inner,
+        "source_type": "file",
     })
     assert netsage.ANOMALY_REGEX.search(stats), "fixture must contain a crisis word to be a real regression"
     assert netsage.pick_anomalies([("suricata", "unknown_service", "1", stats)]) == []
@@ -151,4 +199,68 @@ def test_pick_anomalies_mixed_stream():
     out = netsage.pick_anomalies(lines)
     assert len(out) == 2
     labels = {label for label, _, _ in out}
-    assert labels == {"suricata@NetSage", "skippy.service"}
+    assert labels == {"suricata@sentinel", "skippy.service"}
+
+
+# ---------------------------------------------------------------------------
+# pull_loki_lines — two-query split that keeps Suricata's sev-3 flood from
+# blowing the line budget and burying real alerts / other services' errors
+# ---------------------------------------------------------------------------
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return json.dumps(self._payload).encode()
+
+
+def test_pull_loki_lines_runs_two_filtered_queries_and_merges(monkeypatch):
+    captured = []
+
+    def fake_urlopen(url, timeout=0):
+        decoded = urllib.parse.unquote(url)
+        captured.append(decoded)
+        if 'source!="suricata"' in decoded:
+            payload = {"data": {"result": [
+                {"stream": {"source": "journald", "service_name": "ollama.service"},
+                 "values": [["1", "CRITICAL: model failed to load"]]}
+            ]}}
+        else:
+            payload = {"data": {"result": [
+                {"stream": {"source": "suricata", "service_name": "unknown_service",
+                            "event_type": "alert"},
+                 "values": [["2", _suricata_eve(severity=1, signature="ET ATTACK X")]]}
+            ]}}
+        return _FakeResp(payload)
+
+    monkeypatch.setattr(netsage.urllib.request, "urlopen", fake_urlopen)
+
+    lines = netsage.pull_loki_lines()
+
+    # Exactly two queries: generic (suricata excluded) and suricata-alert.
+    assert len(captured) == 2
+    assert any('source!="suricata"' in q for q in captured)
+    suricata_q = next(q for q in captured if 'event_type="alert"' in q)
+    assert "severity" in suricata_q, "suricata query must pre-filter severity at the Loki layer"
+
+    # Lines from both queries merge, tagged by their stream source.
+    assert {ln[0] for ln in lines} == {"journald", "suricata"}
+
+    # End to end: both a non-suricata error and a nested suricata alert surface.
+    labels = {label for label, _, _ in netsage.pick_anomalies(lines)}
+    assert labels == {"ollama.service", "suricata@sentinel"}
+
+
+def test_query_loki_returns_empty_on_failure(monkeypatch):
+    def boom(url, timeout=0):
+        raise OSError("loki unreachable")
+
+    monkeypatch.setattr(netsage.urllib.request, "urlopen", boom)
+    assert netsage._query_loki(netsage.GENERIC_QUERY) == []


### PR DESCRIPTION
Follow-up to #165. Hex's deeper sweep found that pass still reported a **false clean** for Suricata. Two defects:

## 1. Nested alert object
Vector tails eve.json and ships each line as a JSON **string** inside the envelope's `message` field — it does *not* flatten eve fields to the top level. `_suricata_alert` read `event_type`/`alert`/`severity` from the envelope top level, where they don't exist, so **every real severity 1/2 alert returned None and was dropped**. Added `_eve_record` to unwrap the nested message (with a fallback to the envelope if a future shape flattens it).

## 2. Query cap
Suricata floods Loki with ~6k sev-3 records per 15-min window, far over the 2000-line `limit`. A single `{service_name=~".+"}` pull returned almost nothing but that noise, burying both the rare real alerts **and** genuine errors from every other service. Split into two queries:
- generic feed now **excludes** `source="suricata"`, preserving the budget for everyone else;
- Suricata pulled separately, **pre-filtered to severity 1/2 at the Loki layer** (matching the escaped `\"severity\":N` form Vector produces).

## Tests
`tests/unit/test_netsage_run.py` — 15 passed. Fixtures now model the real two-layer Loki envelope byte-for-byte (the prior fixtures' flat shape is exactly why the bug was invisible), plus a mocked-`urlopen` test that locks the two-query split and severity pre-filter.

## Verified live on Hex
15-min pass now surfaces real sev-2 alerts (ET CINS poor-reputation, ET DROP Spamhaus inbound to 192.168.4.64) where it previously returned clean.

## Known residue (not in this PR)
ET INFO sev-2 (e.g. `.world` TLD DNS) also forwards; it's absorbed by Skippy's triage layer rather than paging Daniel, but signature-level tuning is a follow-up policy call.