### PR TITLE
netsage: route Sentinel alerts through Hex's triage, not raw to Skippy

### DIFF
--- a/bots/scheduled_tasks/scripts/netsage_run.py
+++ b/bots/scheduled_tasks/scripts/netsage_run.py
@@ -3,9 +3,11 @@
 
 Runs once per scheduler fire. Pulls the last 15 minutes of logs from
 Loki, picks out anomalous lines, and on a real finding dispatches a
-detailed report to Skippy via the broker as a self-message. Bilby is
-no longer involved. Skippy's event-triage pipeline owns classification,
-rule application, and notifying Daniel when something warrants his hands.
+detailed report to Hex via the broker as a self-message. Hex's
+sentinel-triage pipeline owns classification, rule application, and
+deciding whether anything warrants paging Daniel — most routine fires
+are silenced by an approved rule without anyone being notified. Only
+findings that survive triage escalate to Daniel, with Skippy as backup.
 Prints a one-line status to stdout for the scheduler to echo back.
 """
 
@@ -22,7 +24,7 @@ import urllib.request
 import uuid
 
 LOKI_URL = "http://sentinel-loki:3100/loki/api/v1/query_range"
-SKIPPY_MIND_ID = "14cb820b-4a42-4f04-a593-54f532fd1d2f"
+HEX_MIND_ID = "1d284b0a-0a45-40db-82a4-c4a984d0ee49"
 
 ANOMALY_PATTERNS = ("error", "critical", "panic", "traceback", "denied", "fatal")
 ANOMALY_REGEX = re.compile(
@@ -242,21 +244,21 @@ def pick_anomalies(lines):
     return out
 
 
-def broker_skippy(detail: str) -> None:
+def broker_hex(detail: str) -> None:
     broker_url = os.environ.get("HIVEMIND_BROKER_URL")
     broker_token = os.environ.get("HIVEMIND_BROKER_TOKEN")
     if not (broker_url and broker_token):
-        print("Broker env missing; skipping Skippy dispatch")
+        print("Broker env missing; skipping Hex dispatch")
         return
     body = {
         "message_id": str(uuid.uuid4()),
         "conversation_id": str(uuid.uuid4()),
-        "from": SKIPPY_MIND_ID,
-        "to": SKIPPY_MIND_ID,
+        "from": HEX_MIND_ID,
+        "to": HEX_MIND_ID,
         "content": detail,
         "rolling_summary": "",
         "metadata": {
-            "request_type": "netsage_alert",
+            "request_type": "sentinel_alert",
             "triggered_by": "scheduler",
             "expects_reply": False,
         },
@@ -334,13 +336,13 @@ def main(argv: list[str] | None = None) -> None:
 
     sample = _build_sample(anomalies)
     detail = (
-        f"NetSage alert at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}. "
+        f"Sentinel alert at {time.strftime('%Y-%m-%dT%H:%M:%SZ', time.gmtime())}. "
         f"{count} anomalous log line(s) across {len(services)} service(s). "
         f"First line: {first_line}\n\n"
         f"Sample lines:\n{sample}"
     )
-    broker_skippy(detail)
-    print(f"OK: dispatched {count} anomalies to Skippy")
+    broker_hex(detail)
+    print(f"OK: dispatched {count} anomalies to Hex")
 
 
 if __name__ == "__main__":

--- a/bots/scheduled_tasks/tasks.yaml
+++ b/bots/scheduled_tasks/tasks.yaml
@@ -16,12 +16,8 @@
 # to be user-invocable in chat. User-invocable skills still live under
 # the mind's .claude/skills/ or .codex/skills/ tree.
 
-tasks:
-  - name: netsage-alert
-    cron: "*/15 * * * *"
-    timezone: America/Chicago
-    voice: false
-    notify: false
-    command:
-      - /opt/venv/bin/python3
-      - /usr/src/app/bots/scheduled_tasks/scripts/netsage_run.py
+# NetSage/Sentinel triage no longer runs here. This central scheduler can't
+# resolve sentinel-loki, so the pass failed every fire. It now runs on the
+# Sentinel host via a 15-min cron that exec's netsage_run.py inside the
+# hive-mind-hex container, where Loki is reachable and Hex owns triage.
+tasks: []

--- a/tests/unit/test_netsage_run.py
+++ b/tests/unit/test_netsage_run.py
@@ -264,3 +264,43 @@ def test_query_loki_returns_empty_on_failure(monkeypatch):
 
     monkeypatch.setattr(netsage.urllib.request, "urlopen", boom)
     assert netsage._query_loki(netsage.GENERIC_QUERY) == []
+
+
+# ---------------------------------------------------------------------------
+# broker_hex — the dispatch target. Triage belongs to Hex now: the report is
+# a self-message to Hex's mind id so his sentinel-triage fires, NOT a page to
+# Skippy. A regression here is the bug Daniel hit — raw alerts forwarded to
+# Skippy while Hex stayed silent.
+# ---------------------------------------------------------------------------
+
+def test_broker_hex_dispatches_to_hex_as_self_message(monkeypatch):
+    monkeypatch.setenv("HIVEMIND_BROKER_URL", "http://broker.local")
+    monkeypatch.setenv("HIVEMIND_BROKER_TOKEN", "tok")
+    captured = {}
+
+    def fake_urlopen(req, timeout=0):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode())
+        captured["auth"] = req.headers.get("Authorization")
+        return _FakeResp({})
+
+    monkeypatch.setattr(netsage.urllib.request, "urlopen", fake_urlopen)
+    netsage.broker_hex("Sentinel alert: ET ATTACK X from 10.0.0.5 to 10.0.0.1")
+
+    assert captured["url"] == "http://broker.local/broker/messages"
+    assert captured["auth"] == "Bearer tok"
+    assert captured["body"]["from"] == netsage.HEX_MIND_ID
+    assert captured["body"]["to"] == netsage.HEX_MIND_ID
+    assert captured["body"]["metadata"]["triggered_by"] == "scheduler"
+    assert captured["body"]["metadata"]["expects_reply"] is False
+
+
+def test_broker_hex_skips_without_broker_env(monkeypatch, capsys):
+    monkeypatch.delenv("HIVEMIND_BROKER_URL", raising=False)
+    monkeypatch.delenv("HIVEMIND_BROKER_TOKEN", raising=False)
+    sent = []
+    monkeypatch.setattr(netsage.urllib.request, "urlopen",
+                        lambda *a, **k: sent.append(1))
+    netsage.broker_hex("anything")
+    assert sent == []
+    assert "skipping Hex dispatch" in capsys.readouterr().out


### PR DESCRIPTION
Skippy was getting raw NetSage alerts while Hex stayed silent. Root cause: `netsage_run.py` dispatched every Loki anomaly straight to Skippy as a self-message and never invoked Hex's `sentinel-triage` loop.

## Changes
- Repoint dispatch to Hex's mind id (`broker_skippy` -> `broker_hex`) so `sentinel-triage` fires; Hex owns classification, rule-silencing, and the escalation decision (page Daniel + Skippy only on a real finding).
- Relabel the alert header `NetSage` -> `Sentinel`.
- Drop the dead `netsage-alert` entry from the central scheduler's `tasks.yaml` — that scheduler can't resolve `sentinel-loki` and failed every fire. The pass runs on the Sentinel host via cron exec'ing the script inside `hive-mind-hex`.

## Tests
- New `broker_hex` coverage: self-message targets Hex, skips without broker env.
- Full unit suite: 495 passed.