### PR TITLE
fix: register proposer fallback modules before exec

### DIFF
--- a/tests/unit/test_skill_proposer_cluster.py
+++ b/tests/unit/test_skill_proposer_cluster.py
@@ -7,6 +7,7 @@ counts/filters identical sequences deterministically.
 """
 
 import importlib.util
+import builtins
 import sys
 from pathlib import Path
 
@@ -55,6 +56,22 @@ def test_read_recent_sequences_extracts_tool_names(tmp_path):
     seqs = mod.read_recent_sequences(str(db), "ada", lookback_turns=500)
     assert ("Read", "Grep", "Edit") in seqs
     assert ("Bash",) in seqs
+
+
+def test_load_training_capture_fallback_registers_module(monkeypatch):
+    mod = _load()
+    real_import = builtins.__import__
+
+    def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "core":
+            raise ModuleNotFoundError("forced fallback")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("core.training_capture", None)
+    loaded = mod._load_training_capture()
+    assert loaded.TrainingTurn.__module__ == "core.training_capture"
+    assert sys.modules["core.training_capture"] is loaded
 
 
 def test_read_filters_by_mind_id(tmp_path):

--- a/tools/stateless/skill_proposer/skill_proposer.py
+++ b/tools/stateless/skill_proposer/skill_proposer.py
@@ -64,6 +64,7 @@ def _load_skill_manage():
     if spec is None or spec.loader is None:  # pragma: no cover - import guard
         raise ImportError(f"cannot load skill_manage module from {_SKILL_MANAGE_PATH}")
     mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(spec.name, mod)
     spec.loader.exec_module(mod)
     return mod
 
@@ -85,6 +86,7 @@ def _load_training_capture():
         if spec is None or spec.loader is None:
             raise ImportError(f"cannot load training_capture from {path}")
         mod = importlib.util.module_from_spec(spec)
+        sys.modules.setdefault(spec.name, mod)
         spec.loader.exec_module(mod)
         return mod
 


### PR DESCRIPTION
## Summary
- register file-backed modules in sys.modules before exec in the skill proposer fallback loaders
- add a regression test for the standalone training capture fallback path
- rerun proposer tests and the live scheduled proposer pass

## Testing
- /opt/venv/bin/pytest -q /usr/src/app/tests/unit/test_skill_proposer_cluster.py /usr/src/app/tests/unit/test_skill_proposer_run.py
- /opt/venv/bin/pytest -q /usr/src/app/tests/integration/test_learn_and_proposer_endtoend.py
- /opt/venv/bin/python3 /usr/src/app/tools/stateless/skill_proposer/skill_proposer.py --config-dir /usr/src/app/minds/nagatha/.codex --harness codex_cli --db-path /usr/src/app/data/training_turns.db --mind-id 128c1768-b659-4c83-86df-706690e344f4 --notify