### PR TITLE
fix: add repo root to sys.path in _load_training_capture for standalone CLI

### DIFF
--- a/tools/stateless/skill_proposer/skill_proposer.py
+++ b/tools/stateless/skill_proposer/skill_proposer.py
@@ -72,21 +72,26 @@ def _load_skill_manage():
 def _load_training_capture():
     """Import ``core.training_capture`` — the authoritative DB layer.
 
-    Tries a normal package import first (works under pytest with the repo root
-    on the path); falls back to loading by file path so the standalone CLI runs
-    without the package installed.
+    Ensures the repo root is on sys.path so the normal package import works
+    whether running under pytest or as a standalone CLI script. Falls back to
+    loading by file path (bypassing builtins.__import__) when tests mock the
+    import machinery.
     """
+    repo_root = _THIS_DIR.parents[2]
+    repo_root_str = str(repo_root)
+    if repo_root_str not in sys.path:
+        sys.path.insert(0, repo_root_str)
+
     try:
         from core import training_capture as tc  # type: ignore
         return tc
-    except Exception:  # pragma: no cover - CLI fallback
-        repo_root = _THIS_DIR.parents[2]
+    except Exception:
         path = repo_root / "core" / "training_capture.py"
         spec = importlib.util.spec_from_file_location("core.training_capture", str(path))
         if spec is None or spec.loader is None:
             raise ImportError(f"cannot load training_capture from {path}")
         mod = importlib.util.module_from_spec(spec)
-        sys.modules.setdefault(spec.name, mod)
+        sys.modules["core.training_capture"] = mod
         spec.loader.exec_module(mod)
         return mod
 


### PR DESCRIPTION
## Summary
- Adds the repo root (`/usr/src/app`) to `sys.path` before attempting `from core import training_capture` so the standalone CLI invocation works without requiring the package to be installed.
- Retains the `importlib` file-path fallback for test scenarios that mock `builtins.__import__`.
- Switches `setdefault` to direct assignment in the fallback to avoid a no-op when a stale `None` sentinel exists in `sys.modules`.

## Test plan
- [ ] 33 skill proposer unit tests pass (`tests/unit/test_skill_proposer_*.py`)
- [ ] Standalone CLI invocation succeeds: `python3 tools/stateless/skill_proposer/skill_proposer.py --config-dir ... --harness claude_cli --db-path ... --mind-id ...`