### PR TITLE
Proactive Telegram delivery for containerized minds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,6 +156,8 @@ docs/financial/
 # Host-local mind tests: these import gitignored minds/* code, so they would
 # break any fresh clone or CI. They live with their host-local mind, not here.
 tests/unit/test_bilby_empty_turn_diagnostic.py
+tests/unit/test_proactive_idle_drain.py
+tests/unit/test_ada_backend_proactive_wiring.py
 
 # Our minds are our own
 minds/*

--- a/bots/telegram_bot.py
+++ b/bots/telegram_bot.py
@@ -42,6 +42,16 @@ TELEGRAM_MSG_LIMIT = 4096
 SERVER_URL = os.environ.get("HIVE_MIND_SERVER_URL", f"http://localhost:{config.server_port}")
 VOICE_SERVER_URL = os.environ.get("VOICE_SERVER_URL", "http://localhost:8422")
 
+# Direct private channel to this bot's own mind backend for proactive
+# (unsolicited) delivery. The backend buffers assistant turns produced while no
+# request is in flight and exposes them at GET {MIND_BACKEND_URL}/proactive
+# (bearer-protected with COMMS_BEARER_TOKEN). This bot polls that endpoint and
+# posts each item to Telegram. Empty MIND_BACKEND_URL disables the poller.
+MIND_BACKEND_URL = os.environ.get("MIND_BACKEND_URL", "")
+COMMS_BEARER_TOKEN = os.environ.get("COMMS_BEARER_TOKEN", "")
+# How often to poll the backend for buffered proactive items.
+PROACTIVE_POLL_INTERVAL = float(os.environ.get("PROACTIVE_POLL_INTERVAL", "5.0"))
+
 # Surface-specific system prompt appended when spawning Telegram sessions.
 # Telegram renders plain text only; voice output is spoken aloud.
 # Instruct Claude to respond conversationally — no code blocks, no markdown,
@@ -753,9 +763,54 @@ def _get_bot_token() -> str:
     return token
 
 
+async def _proactive_poller(app) -> None:
+    """Poll this bot's own mind backend for unsolicited turns and deliver them.
+
+    Runs for the lifetime of the bot. Every ``PROACTIVE_POLL_INTERVAL`` seconds
+    it GETs ``{MIND_BACKEND_URL}/proactive`` (bearer-protected). The endpoint
+    drains the backend's buffer and returns ``[{"chat_id", "text"}, ...]``. Each
+    item is an assistant turn produced without an inbound user message
+    (background agent completion, scheduled wakeup, rotation notice); it is
+    posted to Telegram split over the 4096-char limit. Backend errors and empty
+    responses never kill the loop.
+    """
+    if not MIND_BACKEND_URL:
+        log.info("MIND_BACKEND_URL unset — proactive poller disabled")
+        return
+
+    url = f"{MIND_BACKEND_URL.rstrip('/')}/proactive"
+    headers = {"Authorization": f"Bearer {COMMS_BEARER_TOKEN}"} if COMMS_BEARER_TOKEN else {}
+    log.info("Proactive poller started (backend=%s, interval=%ss)", url, PROACTIVE_POLL_INTERVAL)
+
+    while True:
+        try:
+            await asyncio.sleep(PROACTIVE_POLL_INTERVAL)
+            assert http is not None
+            async with http.get(
+                url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)
+            ) as resp:
+                if resp.status != 200:
+                    log.warning("proactive poll got HTTP %s from %s", resp.status, url)
+                    continue
+                items = await resp.json()
+            for item in items or []:
+                chat_id = item.get("chat_id")
+                text = item.get("text")
+                if not chat_id or not text:
+                    continue
+                for chunk in _chunk_message(text):
+                    await app.bot.send_message(chat_id=chat_id, text=chunk)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("proactive poll cycle failed")
+
+
 async def _on_startup(app) -> None:
     global http, gateway
     http = aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=0, sock_read=0))
+    # Background poller for proactive (unsolicited) turns from the mind backend.
+    app.bot_data["_proactive_task"] = asyncio.ensure_future(_proactive_poller(app))
     # Namespace the session client_type so two telegram bots with the same
     # authorized user don't share a session (private DM chat_id == user_id).
     # MIND_ID takes priority; fall back to TELEGRAM_BOT_TOKEN_KEYRING_KEY (already
@@ -774,6 +829,13 @@ async def _on_startup(app) -> None:
 
 
 async def _on_shutdown(app) -> None:
+    task = app.bot_data.get("_proactive_task") if hasattr(app, "bot_data") else None
+    if task is not None and not task.done():
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
     if http:
         await http.close()
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -151,6 +151,10 @@ services:
       - KEY_RING=/usr/src/app/data/keyring
       - MIND_ID=example
       - TELEGRAM_BOT_TOKEN_KEYRING_KEY=EXAMPLE_TELEGRAM_BOT_TOKEN
+      # Direct channel to this mind's backend for proactive (unsolicited)
+      # delivery. Point at the backend service on the hivemind network, e.g.
+      # http://<mind>:8420. Requires COMMS_BEARER_TOKEN in this env to auth.
+      # - MIND_BACKEND_URL=http://example:8420
     command: ["/opt/venv/bin/python3", "-m", "bots.telegram_bot"]
 
   bilby-bot:
@@ -180,6 +184,10 @@ services:
       - KEY_RING=/usr/src/app/data/keyring
       - MIND_ID=bilby
       - TELEGRAM_BOT_TOKEN_KEYRING_KEY=BILBY_TELEGRAM_BOT_TOKEN
+      # Direct channel to this mind's backend for proactive (unsolicited)
+      # delivery. Point at the backend service on the hivemind network, e.g.
+      # http://<mind>:8420. Requires COMMS_BEARER_TOKEN in this env to auth.
+      # - MIND_BACKEND_URL=http://bilby:8420
     command: ["/opt/venv/bin/python3", "-m", "bots.telegram_bot"]
 
   # ─────────────────────────────────────────────────────────────

--- a/tests/unit/test_telegram_proactive_poller.py
+++ b/tests/unit/test_telegram_proactive_poller.py
@@ -1,0 +1,133 @@
+"""Unit tests for the Telegram proactive-delivery poller.
+
+The poller GETs the mind backend's ``/proactive`` endpoint on an interval and
+posts each ``{chat_id, text}`` item to Telegram, splitting over the 4096-char
+limit. Backend errors and empty responses must never kill the loop.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from bots import telegram_bot
+
+
+class _FakeResp:
+    def __init__(self, status=200, payload=None, raise_exc=None):
+        self.status = status
+        self._payload = payload if payload is not None else []
+        self._raise = raise_exc
+
+    async def json(self):
+        return self._payload
+
+    async def __aenter__(self):
+        if self._raise is not None:
+            raise self._raise
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _FakeHttp:
+    """Serves a queued sequence of responses to successive .get() calls."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    def get(self, url, headers=None, timeout=None):
+        if self._responses:
+            return self._responses.pop(0)
+        # After the scripted responses, hand back an empty 200 forever.
+        return _FakeResp(status=200, payload=[])
+
+
+async def _run_poller_briefly(app, monkeypatch, responses, ticks=0.2):
+    monkeypatch.setattr(telegram_bot, "http", _FakeHttp(responses))
+    monkeypatch.setattr(telegram_bot, "MIND_BACKEND_URL", "http://ada:8420")
+    monkeypatch.setattr(telegram_bot, "COMMS_BEARER_TOKEN", "tok")
+    monkeypatch.setattr(telegram_bot, "PROACTIVE_POLL_INTERVAL", 0.01)
+    task = asyncio.create_task(telegram_bot._proactive_poller(app))
+    await asyncio.sleep(ticks)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+
+async def test_poller_posts_item_to_correct_chat(monkeypatch):
+    app = MagicMock()
+    app.bot.send_message = AsyncMock()
+    responses = [_FakeResp(200, [{"chat_id": 4242, "text": "unsolicited turn"}])]
+
+    await _run_poller_briefly(app, monkeypatch, responses)
+
+    app.bot.send_message.assert_any_await(chat_id=4242, text="unsolicited turn")
+
+
+async def test_poller_splits_long_messages(monkeypatch):
+    app = MagicMock()
+    app.bot.send_message = AsyncMock()
+    long_text = "x" * (telegram_bot.TELEGRAM_MSG_LIMIT + 100)
+    responses = [_FakeResp(200, [{"chat_id": 7, "text": long_text}])]
+
+    await _run_poller_briefly(app, monkeypatch, responses)
+
+    # At least the two chunks for the long message were sent.
+    calls = app.bot.send_message.await_args_list
+    chunks = [c.kwargs["text"] for c in calls if c.kwargs["chat_id"] == 7]
+    assert "".join(chunks[:2]) == long_text
+    for c in calls:
+        assert len(c.kwargs["text"]) <= telegram_bot.TELEGRAM_MSG_LIMIT
+
+
+async def test_poller_survives_backend_http_error(monkeypatch):
+    app = MagicMock()
+    app.bot.send_message = AsyncMock()
+    responses = [
+        _FakeResp(status=500, payload=[]),  # backend error, skipped
+        _FakeResp(status=200, payload=[{"chat_id": 3, "text": "recovered"}]),
+    ]
+
+    await _run_poller_briefly(app, monkeypatch, responses, ticks=0.3)
+
+    app.bot.send_message.assert_any_await(chat_id=3, text="recovered")
+
+
+async def test_poller_survives_get_exception(monkeypatch):
+    app = MagicMock()
+    app.bot.send_message = AsyncMock()
+    responses = [
+        _FakeResp(raise_exc=RuntimeError("boom")),  # connection blows up
+        _FakeResp(status=200, payload=[{"chat_id": 5, "text": "after boom"}]),
+    ]
+
+    await _run_poller_briefly(app, monkeypatch, responses, ticks=0.3)
+
+    app.bot.send_message.assert_any_await(chat_id=5, text="after boom")
+
+
+async def test_poller_disabled_without_backend_url(monkeypatch):
+    app = MagicMock()
+    app.bot.send_message = AsyncMock()
+    monkeypatch.setattr(telegram_bot, "MIND_BACKEND_URL", "")
+    # Should return immediately without touching http or the bot.
+    await asyncio.wait_for(telegram_bot._proactive_poller(app), timeout=1.0)
+    app.bot.send_message.assert_not_awaited()
+
+
+async def test_poller_skips_items_missing_fields(monkeypatch):
+    app = MagicMock()
+    app.bot.send_message = AsyncMock()
+    responses = [_FakeResp(200, [{"chat_id": None, "text": "no chat"}, {"chat_id": 8}])]
+
+    await _run_poller_briefly(app, monkeypatch, responses)
+
+    # Neither malformed item should have been sent.
+    for c in app.bot.send_message.await_args_list:
+        assert c.kwargs["chat_id"] not in (None, 8) or c.kwargs.get("text")
+    # Concretely: no send with chat_id 8 (missing text) and none with None.
+    sent_chats = [c.kwargs["chat_id"] for c in app.bot.send_message.await_args_list]
+    assert 8 not in sent_chats
+    assert None not in sent_chats


### PR DESCRIPTION
## Summary

Ports the single-process operator-mind proactive-delivery fix (already shipped in Skippy and Mordecai) to the **containerized** minds, adapted for the fact that each mind's backend and its Telegram bot run in **separate containers**.

In the operator minds an in-process `asyncio.Queue` bridges the mind backend and the bot. Here they are different containers, so unsolicited assistant output (background-agent completions, scheduled wakeups, rotation notices) currently buffers in the CLI subprocess stdout and is **lost**. This adds a direct private channel:

- **Backend** buffers unsolicited assistant `text` blocks (idle-drain, guarded so it never reads stdout while a solicited request holds the per-session `stdout_lock`) and exposes them at bearer-protected `GET /proactive`.
- **Bot** polls its own backend's `/proactive` on an interval and posts each `{chat_id, text}` item to Telegram, chunked to 4096.

## What's in this PR (tracked tree)

- `bots/telegram_bot.py` — `_proactive_poller` background task (started in `_on_startup`, cancelled in `_on_shutdown`), reads `MIND_BACKEND_URL` + `COMMS_BEARER_TOKEN`.
- `docker-compose.example.yml` — documents the `MIND_BACKEND_URL` wiring for bot services.
- `tests/unit/test_telegram_proactive_poller.py` — poller posts each item, chunks >4096, survives HTTP errors / connection exceptions, disabled without `MIND_BACKEND_URL`.

## Host-local (not in this tree — `minds/*` and `docker-compose.yml` are gitignored, edit-is-deploy)

- `minds/proactive.py` — shared `idle_drain` + `make_proactive_router` (`GET /proactive`).
- `minds/ada/implementation.py`, `minds/bob/implementation.py` — the two **claude_cli** minds: wire `chat_id`/`stdout_lock`/`in_flight`, start the drain at session create, wrap the solicited reader in the lock, cancel the drain in kill.
- `minds/bilby/implementation.py`, `minds/nagatha/implementation.py` — **codex_cli** minds: mount `/proactive` (returns `[]`) for uniform polling; no idle-drain because Codex spawns a fresh per-turn subprocess with stdin closed (same reason Hex is excluded).
- `docker-compose.yml` — `MIND_BACKEND_URL=http://<mind>:8420` on each bot service.
- Their tests (`test_proactive_idle_drain.py`, `test_ada_backend_proactive_wiring.py`) are gitignored — they import `minds/*` code a fresh clone lacks (same convention as `test_bilby_empty_turn_diagnostic.py`).

## Tests

Full local suite: **548 passed, 0 failures** (526 baseline + 22 new). Tracked/CI tree: **528 passed**. ruff clean on all changed files; mypy adds no new errors.

## Deploy (human, not done here)

Rebuild/restart the mind backend containers (ada, bob, bilby, nagatha) and their bot containers (telegram-bot, bob-bot, bilby-bot, nagatha-bot) to pick up the host-local backend + compose changes.